### PR TITLE
ci: enhance staging workflow with E2E change detection

### DIFF
--- a/.github/workflows/ci-staging.yml
+++ b/.github/workflows/ci-staging.yml
@@ -15,18 +15,49 @@ on:
       - '.github/**'
       - '!.github/workflows/**'
 
+  merge_group:
+    branches: [main]
+
+  workflow_dispatch:
+
 permissions:
   contents: read
+  pull-requests: write
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect E2E-Relevant Changes
+    runs-on: ubuntu-latest
+    outputs:
+      e2e: ${{ steps.filter.outputs.e2e }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            e2e:
+              - 'src/**'
+              - 'public/**'
+              - 'tests/e2e/**'
+              - 'vitest.config.ts'
+              - 'tsconfig.json'
+              - 'next.config.ts'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'drizzle.config.ts'
   e2e-tests:
     name: E2E / Smoke Tests
+    if: (github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch') && (needs.changes.outputs.e2e == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs: [build-staging, changes]
     strategy:
       fail-fast: false
       matrix:
@@ -177,6 +208,7 @@ jobs:
   all-checks-staging:
     name: All Checks Passed (staging)
     needs: [e2e-tests, build-staging]
+    if: always() && (github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - name: Check all jobs


### PR DESCRIPTION
This commit improves the CI staging workflow by adding a new job to detect changes relevant to end-to-end (E2E) tests. This enhancement allows the workflow to conditionally run E2E tests based on whether relevant files have been modified, optimizing the testing process and reducing unnecessary test executions.

Changes:
- Added a new job `changes` to detect E2E-relevant changes
- Configured the `e2e-tests` job to run conditionally based on the output of the `changes` job
- Updated permissions to include pull-requests write access
- Introduced a merge group for the main branch

New files:
- none

Tests cover:
- CI workflow validates the detection of E2E-relevant changes
- E2E tests execution based on detected changes