### PR TITLE
ci: simplify CI staging workflow by removing push trigger

### DIFF
--- a/.github/workflows/ci-staging.yml
+++ b/.github/workflows/ci-staging.yml
@@ -1,13 +1,6 @@
 name: CI - Staging (staging env)
 
 on:
-  push:
-    branches: [main]
-    paths-ignore:
-      - '**.md'
-      - '.github/**'
-      - '!.github/workflows/**'
-
   pull_request:
     branches: [main]
     paths-ignore:


### PR DESCRIPTION
This commit modifies the CI staging workflow to remove the push trigger for the main branch. This change aims to streamline the workflow by focusing on pull requests only, reducing unnecessary runs and improving efficiency.

Changes:
- Removed the push trigger from `ci-staging.yml`
- Kept the pull request trigger for the main branch

New files:
- none

Tests cover:
- CI workflow validation for the updated trigger conditions