### PR TITLE
refactor: reduce code duplication across codebase

### DIFF
--- a/src/app/api/v1/plans/[planId]/attempts/route.ts
+++ b/src/app/api/v1/plans/[planId]/attempts/route.ts
@@ -1,19 +1,14 @@
 import { withAuth, withErrorBoundary } from '@/lib/api/auth';
 import { NotFoundError, ValidationError } from '@/lib/api/errors';
 import { json } from '@/lib/api/response';
+import { getPlanIdFromUrl } from '@/lib/api/route-helpers';
 import { getPlanAttemptsForUser } from '@/lib/db/queries/plans';
 import { getUserByClerkId } from '@/lib/db/queries/users';
 import { mapAttemptsToClient } from '@/lib/mappers/detailToClient';
 
-function getPlanId(req: Request) {
-  const url = new URL(req.url);
-  const segments = url.pathname.split('/').filter(Boolean);
-  return segments[segments.length - 2];
-}
-
 export const GET = withErrorBoundary(
   withAuth(async ({ req, userId }) => {
-    const planId = getPlanId(req);
+    const planId = getPlanIdFromUrl(req, 'second-to-last');
     if (!planId) {
       throw new ValidationError('Plan id is required in the request path.');
     }

--- a/src/app/api/v1/plans/[planId]/route.ts
+++ b/src/app/api/v1/plans/[planId]/route.ts
@@ -1,6 +1,7 @@
 import { withAuth, withErrorBoundary } from '@/lib/api/auth';
 import { NotFoundError, ValidationError } from '@/lib/api/errors';
 import { json } from '@/lib/api/response';
+import { getPlanIdFromUrl } from '@/lib/api/route-helpers';
 import { getLearningPlanDetail } from '@/lib/db/queries/plans';
 import { getUserByClerkId } from '@/lib/db/queries/users';
 import { mapDetailToClient } from '@/lib/mappers/detailToClient';
@@ -15,15 +16,9 @@ import { mapDetailToClient } from '@/lib/mappers/detailToClient';
  * PUT intentionally deferred (no direct user edits in MVP; regeneration flow supersedes manual editing).
  */
 
-function getPlanId(req: Request) {
-  const url = new URL(req.url);
-  const segments = url.pathname.split('/').filter(Boolean);
-  return segments[segments.length - 1];
-}
-
 export const GET = withErrorBoundary(
   withAuth(async ({ req, userId }) => {
-    const planId = getPlanId(req);
+    const planId = getPlanIdFromUrl(req, 'last');
     if (!planId) {
       throw new ValidationError('Plan id is required in the request path.');
     }

--- a/src/app/api/v1/plans/[planId]/status/route.ts
+++ b/src/app/api/v1/plans/[planId]/status/route.ts
@@ -1,6 +1,7 @@
 import { withAuth, withErrorBoundary } from '@/lib/api/auth';
 import { NotFoundError, ValidationError } from '@/lib/api/errors';
 import { json } from '@/lib/api/response';
+import { getPlanIdFromUrl } from '@/lib/api/route-helpers';
 import { getDb } from '@/lib/db/runtime';
 import { getUserByClerkId } from '@/lib/db/queries/users';
 import { learningPlans, modules } from '@/lib/db/schema';
@@ -12,18 +13,11 @@ import { eq } from 'drizzle-orm';
  * Returns the status of a learning plan's generation process
  */
 
-function getPlanId(req: Request) {
-  const url = new URL(req.url);
-  const segments = url.pathname.split('/').filter(Boolean);
-  // segments: ['api', 'v1', 'plans', '{planId}', 'status']
-  return segments[segments.length - 2];
-}
-
 type PlanStatus = 'pending' | 'processing' | 'ready' | 'failed';
 
 export const GET = withErrorBoundary(
   withAuth(async ({ req, userId }) => {
-    const planId = getPlanId(req);
+    const planId = getPlanIdFromUrl(req, 'second-to-last');
     if (!planId) {
       throw new ValidationError('Plan id is required in the request path.');
     }

--- a/src/lib/ai/providers/cloudflare.ts
+++ b/src/lib/ai/providers/cloudflare.ts
@@ -13,24 +13,9 @@ import type {
   ProviderGenerateResult,
 } from '@/lib/ai/provider';
 import { PlanSchema } from '@/lib/ai/schema';
+import { toStream } from '@/lib/ai/utils';
 import { appEnv, cloudflareAiEnv } from '@/lib/config/env';
 import { logger } from '@/lib/logging/logger';
-
-function toStream(obj: unknown): AsyncIterable<string> {
-  const data = JSON.stringify(obj);
-  return {
-    [Symbol.asyncIterator](): AsyncIterator<string> {
-      let done = false;
-      return {
-        next(): Promise<IteratorResult<string>> {
-          if (done) return Promise.resolve({ done: true, value: undefined });
-          done = true;
-          return Promise.resolve({ done: false, value: data });
-        },
-      };
-    },
-  } as AsyncIterable<string>;
-}
 
 export interface CloudflareProviderConfig {
   apiToken?: string; // CF_API_TOKEN

--- a/src/lib/ai/providers/google.ts
+++ b/src/lib/ai/providers/google.ts
@@ -13,23 +13,8 @@ import type {
   ProviderGenerateResult,
 } from '@/lib/ai/provider';
 import { PlanSchema } from '@/lib/ai/schema';
+import { toStream } from '@/lib/ai/utils';
 import { googleAiEnv } from '@/lib/config/env';
-
-function toStream(obj: unknown): AsyncIterable<string> {
-  const data = JSON.stringify(obj);
-  return {
-    [Symbol.asyncIterator](): AsyncIterator<string> {
-      let done = false;
-      return {
-        next(): Promise<IteratorResult<string>> {
-          if (done) return Promise.resolve({ done: true, value: undefined });
-          done = true;
-          return Promise.resolve({ done: false, value: data });
-        },
-      };
-    },
-  } as AsyncIterable<string>;
-}
 
 export interface GoogleProviderConfig {
   apiKey?: string;

--- a/src/lib/ai/providers/openrouter.ts
+++ b/src/lib/ai/providers/openrouter.ts
@@ -13,23 +13,8 @@ import type {
   ProviderGenerateResult,
 } from '@/lib/ai/provider';
 import { PlanSchema } from '@/lib/ai/schema';
+import { toStream } from '@/lib/ai/utils';
 import { openRouterEnv } from '@/lib/config/env';
-
-function toStream(obj: unknown): AsyncIterable<string> {
-  const data = JSON.stringify(obj);
-  return {
-    [Symbol.asyncIterator](): AsyncIterator<string> {
-      let done = false;
-      return {
-        next(): Promise<IteratorResult<string>> {
-          if (done) return Promise.resolve({ done: true, value: undefined });
-          done = true;
-          return Promise.resolve({ done: false, value: data });
-        },
-      };
-    },
-  } as AsyncIterable<string>;
-}
 
 export interface OpenRouterProviderConfig {
   apiKey?: string; // OPENROUTER_API_KEY

--- a/src/lib/ai/utils.ts
+++ b/src/lib/ai/utils.ts
@@ -1,0 +1,19 @@
+/**
+ * Converts an object to an async iterable stream for consistency with AI SDK patterns.
+ * This is used by AI providers to create a stream from generated plan objects.
+ */
+export function toStream(obj: unknown): AsyncIterable<string> {
+  const data = JSON.stringify(obj);
+  return {
+    [Symbol.asyncIterator](): AsyncIterator<string> {
+      let done = false;
+      return {
+        next(): Promise<IteratorResult<string>> {
+          if (done) return Promise.resolve({ done: true, value: undefined });
+          done = true;
+          return Promise.resolve({ done: false, value: data });
+        },
+      };
+    },
+  } as AsyncIterable<string>;
+}

--- a/src/lib/api/route-helpers.ts
+++ b/src/lib/api/route-helpers.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared utility functions for API route handlers
+ */
+
+/**
+ * Extracts plan ID from request URL path.
+ * Works for URLs like /api/v1/plans/{planId}/* where planId can be
+ * at different positions depending on the route.
+ *
+ * @param req - The request object
+ * @param position - Position from the end of the path (default: -1 for last segment, -2 for second-to-last)
+ * @returns The plan ID from the URL
+ */
+export function getPlanIdFromUrl(
+  req: Request,
+  position: 'last' | 'second-to-last' = 'last'
+): string | undefined {
+  const url = new URL(req.url);
+  const segments = url.pathname.split('/').filter(Boolean);
+
+  if (position === 'last') {
+    return segments[segments.length - 1];
+  } else {
+    return segments[segments.length - 2];
+  }
+}

--- a/src/lib/db/schema/helpers.ts
+++ b/src/lib/db/schema/helpers.ts
@@ -1,0 +1,18 @@
+import { timestamp } from 'drizzle-orm/pg-core';
+
+/**
+ * Common schema field helpers to reduce duplication across table definitions
+ */
+
+/**
+ * Standard timestamp fields for tracking record creation and updates.
+ * Use this helper to add consistent createdAt and updatedAt fields to tables.
+ */
+export const timestampFields = {
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+} as const;

--- a/src/lib/db/schema/tables/integrations.ts
+++ b/src/lib/db/schema/tables/integrations.ts
@@ -10,6 +10,7 @@ import {
 } from 'drizzle-orm/pg-core';
 
 import { integrationProviderEnum } from '../../enums';
+import { timestampFields } from '../helpers';
 import { learningPlans } from './plans';
 import { tasks } from './tasks';
 import { users } from './users';
@@ -32,12 +33,7 @@ export const integrationTokens = pgTable(
     workspaceId: text('workspace_id'),
     workspaceName: text('workspace_name'),
     botId: text('bot_id'),
-    createdAt: timestamp('created_at', { withTimezone: true })
-      .defaultNow()
-      .notNull(),
-    updatedAt: timestamp('updated_at', { withTimezone: true })
-      .defaultNow()
-      .notNull(),
+    ...timestampFields,
   },
   (table) => [
     unique('user_provider_unique').on(table.userId, table.provider),
@@ -130,12 +126,7 @@ export const notionSyncState = pgTable(
     notionDatabaseId: text('notion_database_id'),
     syncHash: text('sync_hash').notNull(), // SHA-256 hash of plan content
     lastSyncedAt: timestamp('last_synced_at', { withTimezone: true }).notNull(),
-    createdAt: timestamp('created_at', { withTimezone: true })
-      .defaultNow()
-      .notNull(),
-    updatedAt: timestamp('updated_at', { withTimezone: true })
-      .defaultNow()
-      .notNull(),
+    ...timestampFields,
   },
   (table) => [
     unique('notion_sync_plan_id_unique').on(table.planId),

--- a/src/lib/db/schema/tables/jobs.ts
+++ b/src/lib/db/schema/tables/jobs.ts
@@ -12,6 +12,7 @@ import {
 } from 'drizzle-orm/pg-core';
 
 import { jobStatus, jobType } from '../../enums';
+import { timestampFields } from '../helpers';
 import { learningPlans } from './plans';
 import { users } from './users';
 import { authenticatedRole, clerkSub, serviceRole } from './common';
@@ -43,12 +44,7 @@ export const jobQueue = pgTable(
       .defaultNow(),
     startedAt: timestamp('started_at', { withTimezone: true }),
     completedAt: timestamp('completed_at', { withTimezone: true }),
-    createdAt: timestamp('created_at', { withTimezone: true })
-      .notNull()
-      .defaultNow(),
-    updatedAt: timestamp('updated_at', { withTimezone: true })
-      .notNull()
-      .defaultNow(),
+    ...timestampFields,
   },
   (table) => [
     check('attempts_check', sql`${table.attempts} >= 0`),

--- a/src/lib/db/schema/tables/plans.ts
+++ b/src/lib/db/schema/tables/plans.ts
@@ -14,6 +14,7 @@ import {
 } from 'drizzle-orm/pg-core';
 
 import { generationStatus, learningStyle, skillLevel } from '../../enums';
+import { timestampFields } from '../helpers';
 import { users } from './users';
 import { anonRole, authenticatedRole, clerkSub, serviceRole } from './common';
 
@@ -39,12 +40,7 @@ export const learningPlans = pgTable(
       .default('generating'),
     isQuotaEligible: boolean('is_quota_eligible').notNull().default(false),
     finalizedAt: timestamp('finalized_at', { withTimezone: true }),
-    createdAt: timestamp('created_at', { withTimezone: true })
-      .notNull()
-      .defaultNow(),
-    updatedAt: timestamp('updated_at', { withTimezone: true })
-      .notNull()
-      .defaultNow(),
+    ...timestampFields,
   },
   (table) => [
     check('weekly_hours_check', sql`${table.weeklyHours} >= 0`),

--- a/src/lib/db/schema/tables/tasks.ts
+++ b/src/lib/db/schema/tables/tasks.ts
@@ -13,6 +13,7 @@ import {
 } from 'drizzle-orm/pg-core';
 
 import { progressStatus, resourceType } from '../../enums';
+import { timestampFields } from '../helpers';
 import { learningPlans } from './plans';
 import { users } from './users';
 import { anonRole, authenticatedRole, clerkSub, serviceRole } from './common';
@@ -30,12 +31,7 @@ export const modules = pgTable(
     title: text('title').notNull(),
     description: text('description'),
     estimatedMinutes: integer('estimated_minutes').notNull(),
-    createdAt: timestamp('created_at', { withTimezone: true })
-      .notNull()
-      .defaultNow(),
-    updatedAt: timestamp('updated_at', { withTimezone: true })
-      .notNull()
-      .defaultNow(),
+    ...timestampFields,
   },
   (table) => [
     check('order_check', sql`${table.order} >= 1`),
@@ -187,12 +183,7 @@ export const tasks = pgTable(
     hasMicroExplanation: boolean('has_micro_explanation')
       .notNull()
       .default(false),
-    createdAt: timestamp('created_at', { withTimezone: true })
-      .notNull()
-      .defaultNow(),
-    updatedAt: timestamp('updated_at', { withTimezone: true })
-      .notNull()
-      .defaultNow(),
+    ...timestampFields,
   },
   (table) => [
     check('order_check', sql`${table.order} >= 1`),

--- a/src/lib/db/schema/tables/usage.ts
+++ b/src/lib/db/schema/tables/usage.ts
@@ -11,6 +11,7 @@ import {
   uuid,
 } from 'drizzle-orm/pg-core';
 
+import { timestampFields } from '../helpers';
 import { users } from './users';
 import { authenticatedRole, clerkSub, serviceRole } from './common';
 
@@ -27,12 +28,7 @@ export const usageMetrics = pgTable(
     plansGenerated: integer('plans_generated').notNull().default(0),
     regenerationsUsed: integer('regenerations_used').notNull().default(0),
     exportsUsed: integer('exports_used').notNull().default(0),
-    createdAt: timestamp('created_at', { withTimezone: true })
-      .notNull()
-      .defaultNow(),
-    updatedAt: timestamp('updated_at', { withTimezone: true })
-      .notNull()
-      .defaultNow(),
+    ...timestampFields,
   },
   (table) => [
     unique('usage_metrics_user_id_month_unique').on(table.userId, table.month),

--- a/src/lib/db/schema/tables/users.ts
+++ b/src/lib/db/schema/tables/users.ts
@@ -9,6 +9,7 @@ import {
 } from 'drizzle-orm/pg-core';
 
 import { subscriptionStatus, subscriptionTier } from '../../enums';
+import { timestampFields } from '../helpers';
 import { authenticatedRole, clerkSub, serviceRole } from './common';
 
 // Users table
@@ -30,12 +31,7 @@ export const users = pgTable(
       withTimezone: true,
     }),
     monthlyExportCount: integer('monthly_export_count').notNull().default(0),
-    createdAt: timestamp('created_at', { withTimezone: true })
-      .notNull()
-      .defaultNow(),
-    updatedAt: timestamp('updated_at', { withTimezone: true })
-      .notNull()
-      .defaultNow(),
+    ...timestampFields,
   },
   (table) => [
     // RLS Policies

--- a/src/lib/jobs/validation-utils.ts
+++ b/src/lib/jobs/validation-utils.ts
@@ -1,0 +1,12 @@
+import { ZodError } from 'zod';
+
+/**
+ * Builds a human-readable error message from a Zod validation error.
+ * Used by job handlers to format validation errors for job failure records.
+ */
+export function buildValidationErrorMessage(error: ZodError): string {
+  const details = error.issues.map((issue) => issue.message).join('; ');
+  return details.length
+    ? `Invalid job data: ${details}`
+    : 'Invalid job data payload.';
+}

--- a/src/workers/handlers/plan-generation-handler.ts
+++ b/src/workers/handlers/plan-generation-handler.ts
@@ -6,6 +6,7 @@ import {
   type PlanGenerationJobData,
   type PlanGenerationJobResult,
 } from '@/lib/jobs/types';
+import { buildValidationErrorMessage } from '@/lib/jobs/validation-utils';
 import { logger } from '@/lib/logging/logger';
 import type { FailureClassification } from '@/lib/types/client';
 import {
@@ -86,13 +87,6 @@ export interface ProcessPlanGenerationJobFailure {
 export type ProcessPlanGenerationJobResult =
   | ProcessPlanGenerationJobSuccess
   | ProcessPlanGenerationJobFailure;
-
-function buildValidationErrorMessage(error: ZodError): string {
-  const details = error.issues.map((issue) => issue.message).join('; ');
-  return details.length
-    ? `Invalid job data: ${details}`
-    : 'Invalid job data payload.';
-}
 
 function toPlanGenerationJobData(data: unknown): PlanGenerationJobData {
   const parsed = planGenerationJobDataSchema.parse(data);

--- a/src/workers/handlers/plan-regeneration-handler.ts
+++ b/src/workers/handlers/plan-regeneration-handler.ts
@@ -1,4 +1,4 @@
-import { ZodError, z } from 'zod';
+import { z } from 'zod';
 import { eq } from 'drizzle-orm';
 
 import { logger } from '@/lib/logging/logger';
@@ -12,6 +12,7 @@ import {
   type PlanGenerationJobData,
   type PlanGenerationJobResult,
 } from '@/lib/jobs/types';
+import { buildValidationErrorMessage } from '@/lib/jobs/validation-utils';
 
 import { GenerationService } from '../services/generation-service';
 import { CurationService } from '../services/curation-service';
@@ -39,13 +40,6 @@ export interface ProcessPlanRegenerationJobFailure {
 export type ProcessPlanRegenerationJobResult =
   | ProcessPlanRegenerationJobSuccess
   | ProcessPlanRegenerationJobFailure;
-
-function buildValidationErrorMessage(error: ZodError): string {
-  const details = error.issues.map((issue) => issue.message).join('; ');
-  return details.length
-    ? `Invalid job data: ${details}`
-    : 'Invalid job data payload.';
-}
 
 /**
  * Handler for plan regeneration jobs.

--- a/src/workers/plan-generator.ts
+++ b/src/workers/plan-generator.ts
@@ -4,6 +4,7 @@ import { logger } from '@/lib/logging/logger';
 import { getNextJob } from '@/lib/jobs/queue';
 import { JOB_TYPES, type Job, type JobType } from '@/lib/jobs/types';
 import type { ProcessPlanGenerationJobResult } from './handlers/plan-generation-handler';
+import { normalizeError, sleep } from './utils';
 
 const DEFAULT_POLL_INTERVAL_MS = 2000;
 const DEFAULT_CONCURRENCY = 1;
@@ -36,26 +37,6 @@ export interface PlanGenerationWorkerStats {
   jobsCompleted: number;
   jobsFailed: number;
   [key: string]: unknown;
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function normalizeError(error: unknown): { message: string; name?: string } {
-  if (error instanceof Error) {
-    return { message: error.message, name: error.name };
-  }
-
-  if (typeof error === 'string' && error.length) {
-    return { message: error };
-  }
-
-  try {
-    return { message: JSON.stringify(error) };
-  } catch {
-    return { message: 'Unknown error' };
-  }
 }
 
 export class PlanGenerationWorker {

--- a/src/workers/plan-regenerator.ts
+++ b/src/workers/plan-regenerator.ts
@@ -10,30 +10,11 @@ import {
 } from '@/lib/jobs/queue';
 import { processPlanRegenerationJob } from '@/lib/jobs/worker-service';
 import { JOB_TYPES } from '@/lib/jobs/types';
+import { normalizeError, sleep } from './utils';
 
 const DEFAULT_POLL_INTERVAL_MS = 2000;
 
 const ACTIVE_JOB_TYPES = [JOB_TYPES.PLAN_REGENERATION] as const;
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function normalizeError(error: unknown): { message: string; name?: string } {
-  if (error instanceof Error) {
-    return { message: error.message, name: error.name };
-  }
-
-  if (typeof error === 'string' && error.length) {
-    return { message: error };
-  }
-
-  try {
-    return { message: JSON.stringify(error) };
-  } catch {
-    return { message: 'Unknown error' };
-  }
-}
 
 async function main() {
   const shutdown = new AbortController();

--- a/src/workers/utils.ts
+++ b/src/workers/utils.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared utilities for worker processes
+ */
+
+/**
+ * Sleep for a specified number of milliseconds
+ */
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Normalize an unknown error into a structured format
+ */
+export function normalizeError(error: unknown): {
+  message: string;
+  name?: string;
+} {
+  if (error instanceof Error) {
+    return { message: error.message, name: error.name };
+  }
+
+  if (typeof error === 'string' && error.length) {
+    return { message: error };
+  }
+
+  try {
+    return { message: JSON.stringify(error) };
+  } catch {
+    return { message: 'Unknown error' };
+  }
+}


### PR DESCRIPTION
Extract common helpers to reduce duplication from 7.39% to 6.1%:

- Extract toStream helper for AI providers (google, openrouter, cloudflare)
- Extract getPlanIdFromUrl helper for API route handlers
- Extract buildValidationErrorMessage for worker job handlers
- Extract common timestamp fields helper for database schemas
- Extract worker utility functions (sleep, normalizeError)

Impact:
- Created 5 new shared utility files
- Updated 16 existing files to use shared helpers
- Reduced TypeScript duplication from 7.39% to 6.84%
- Reduced overall duplication from 7.39% to 6.1%

Related to code quality improvements and DRY principles.