### PR TITLE
fix: explicitly pass retryable flag to failJob

### DIFF
--- a/src/workers/services/persistence-service.ts
+++ b/src/workers/services/persistence-service.ts
@@ -61,8 +61,8 @@ export class PersistenceService {
   async failJob(input: JobFailureInput): Promise<void> {
     const { jobId, planId, userId, error, retryable, metadata } = input;
 
-    const failOptions: FailJobOptions | undefined = retryable
-      ? undefined
+    const failOptions: FailJobOptions = retryable
+      ? { retryable: true }
       : { retryable: false };
 
     await failJob(jobId, error, failOptions);


### PR DESCRIPTION
When a job fails with retryable=true, the PersistenceService now explicitly passes { retryable: true } to the failJob function instead of undefined.

This ensures that jobs marked as retryable will be retried regardless of the current attempt count, which is the expected behavior.

The issue was causing the e2e test "records retry attempts then surfaces ready status after recovery" to timeout because the job wasn't being properly scheduled for retry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal consistency of job failure handling by standardizing how failure options are structured and passed through the persistence layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->