### PR TITLE
Update CI workflows to include permissions for deployment jobs

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -649,6 +649,10 @@ jobs:
         needs.changes.outputs.workers == 'true' ||
         needs.changes.outputs.regenerator == 'true'
       )
+    permissions:
+      contents: read
+      actions: read
+      deployments: write
     uses: ./.github/workflows/deploy-production.yml
     with:
       deploy_migrations: ${{ needs.changes.outputs.migrations == 'true' }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -620,6 +620,10 @@ jobs:
         needs.changes.outputs.workers == 'true' ||
         needs.changes.outputs.regenerator == 'true'
       )
+    permissions:
+      contents: read
+      actions: read
+      deployments: write
     uses: ./.github/workflows/deploy-staging.yml
     with:
       deploy_migrations: ${{ needs.changes.outputs.migrations == 'true' }}


### PR DESCRIPTION
This commit adds specific permissions for the deployment jobs in both the production and staging CI workflows. The permissions now include read access for contents and actions, and write access for deployments, enhancing the security and functionality of the deployment processes.