### PR TITLE
Update CI workflow to conditionally run DB migration dry-run based on…

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -502,6 +502,8 @@ jobs:
 
   migration-dry-run:
     name: DB Migration Dry-Run
+    needs: [changes]
+    if: needs.changes.outputs.migrations == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     services:


### PR DESCRIPTION
… changes detected

This commit modifies the `ci-main.yml` workflow to ensure that the DB Migration Dry-Run job only executes if there are migrations detected. The job now depends on the `changes` job and checks its output before running, enhancing the efficiency of the CI process by avoiding unnecessary migrations.