### PR TITLE
Update CI workflows to conditionally run jobs based on changes detected

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -85,6 +85,7 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    needs: [changes]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -69,6 +69,8 @@ jobs:
 
   lint-and-type-check:
     name: Lint & Type Check
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -100,6 +102,8 @@ jobs:
 
   vulnerability-scan:
     name: Security Audit
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 8
     steps:
@@ -115,6 +119,8 @@ jobs:
 
   build:
     name: Build
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
This commit modifies both `ci-main.yml` and `ci-pr.yml` workflows to ensure that the Lint & Type Check, Security Audit, and Build jobs only execute if there are relevant changes detected. Each job now depends on the `changes` job and checks its output before running, improving the efficiency of the CI process by avoiding unnecessary executions.