### PR TITLE
Update environment configuration to set NODE_ENV to "test" in staging

### DIFF
--- a/fly.staging.regenerator.toml
+++ b/fly.staging.regenerator.toml
@@ -6,7 +6,7 @@ primary_region = "sjc"  # Change to region closest to your Neon database
   dockerfile = "Dockerfile.worker"
 
 [env]
-  NODE_ENV = "staging"
+  NODE_ENV = "test"
 
 [processes]
   app = "pnpm tsx src/workers/plan-regenerator.ts"

--- a/fly.staging.worker.toml
+++ b/fly.staging.worker.toml
@@ -6,7 +6,7 @@ primary_region = "sjc"  # Change to region closest to your Neon database
   dockerfile = "Dockerfile.worker"
 
 [env]
-  NODE_ENV = "staging"
+  NODE_ENV = "test"
 
 [processes]
   app = "pnpm tsx src/workers/index.ts"


### PR DESCRIPTION
This pull request updates environment configuration for staging worker deployments. The main change is setting the `NODE_ENV` variable to `"test"` instead of `"staging"` in both worker configuration files.

Environment configuration updates:

* Changed the `NODE_ENV` value from `"staging"` to `"test"` in `fly.staging.regenerator.toml` for the plan regenerator worker.
* Changed the `NODE_ENV` value from `"staging"` to `"test"` in `fly.staging.worker.toml` for the main worker process.