### PR TITLE
fix(core): Harden PDF plan creation and upload handling

### DIFF
--- a/docs/context/architecture/plan-generation-architecture.md
+++ b/docs/context/architecture/plan-generation-architecture.md
@@ -476,14 +476,14 @@ import { db } from '@/lib/db/service-role';
 
 ### How RLS Works
 
-The `getDb()` client sets a session variable `app.user_id` from the authenticated Clerk user. RLS policies then filter:
+The `getDb()` client sets the `request.jwt.claims` session variable to a JSON payload containing the Clerk user ID (for example, `{ "sub": "clerk_user_id" }`). RLS policies then filter by extracting `sub`:
 
 ```sql
 -- Example policy on learning_plans
 CREATE POLICY "Users can only see their own plans"
   ON learning_plans
   FOR SELECT
-  USING (user_id = current_setting('app.user_id')::uuid);
+  USING (user_id = current_setting('request.jwt.claims', true)::json->>'sub');
 ```
 
 ---

--- a/src/lib/db/AGENTS.md
+++ b/src/lib/db/AGENTS.md
@@ -51,8 +51,9 @@ db/
 ```typescript
 // rls.ts creates clients that:
 // 1. Switch to auth role (has RLS policies)
-// 2. Set session variable: SET LOCAL app.user_id = '...'
-// 3. Execute queries (RLS filters by user_id)
+// 2. Set session variable: request.jwt.claims = {"sub": "<clerkUserId>"}
+//    via SELECT set_config('request.jwt.claims', '{"sub":"..."}', false)
+// 3. Execute queries (RLS filters by request.jwt.claims->>'sub')
 // 4. Must call cleanup() when done
 
 const { db, cleanup } = await createAuthenticatedRlsClient(userId);

--- a/src/lib/pdf/structure.ts
+++ b/src/lib/pdf/structure.ts
@@ -11,7 +11,7 @@ const HEADER_PATTERNS = [
 ];
 
 const isHeaderLine = (line: string): boolean => {
-  if (line.length === 0 || line.length > HEADER_MAX_LENGTH) {
+  if (line.length < 3 || line.length > HEADER_MAX_LENGTH) {
     return false;
   }
 


### PR DESCRIPTION
## Summary
- Prevent PDF plan rollback failures from masking original errors.
- Make PDF upload handlers sync at the boundary and accept MIME or extension matches.
- Tighten header detection length checks and align RLS docs with request.jwt.claims.

## Testing
- pnpm lint (warning: src/lib/security/malware-scanner.ts require-await)
- pnpm type-check
- pnpm build

## Related Linear tickets, Github issues, and Community forum posts

<!-- Link to Linear ticket: https://linear.app/n8n/issue/[TICKET-ID] -->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues -->

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)