### PR TITLE
fix: worker health query casts

### DIFF
--- a/src/app/api/health/worker/route.ts
+++ b/src/app/api/health/worker/route.ts
@@ -50,10 +50,10 @@ export async function GET(request: Request) {
   try {
     const [agg] = await db
       .select({
-        stuckJobCount: sql<number>`count(*) filter (where ${jobQueue.status} = 'processing' and ${jobQueue.startedAt} < ${stuckThreshold})::int`,
+        stuckJobCount: sql<number>`count(*) filter (where ${jobQueue.status} = 'processing' and ${jobQueue.startedAt} < ${stuckThreshold}::timestamptz)::int`,
         backlogCount: sql<number>`count(*) filter (where ${jobQueue.status} = 'pending')::int`,
-        pendingRegenerationCount: sql<number>`count(*) filter (where ${jobQueue.status} = 'pending' and ${jobQueue.jobType} = ${JOB_TYPES.PLAN_REGENERATION})::int`,
-        stuckRegenerationCount: sql<number>`count(*) filter (where ${jobQueue.status} = 'processing' and ${jobQueue.jobType} = ${JOB_TYPES.PLAN_REGENERATION} and ${jobQueue.startedAt} < ${stuckThreshold})::int`,
+        pendingRegenerationCount: sql<number>`count(*) filter (where ${jobQueue.status} = 'pending' and ${jobQueue.jobType} = ${JOB_TYPES.PLAN_REGENERATION}::job_type)::int`,
+        stuckRegenerationCount: sql<number>`count(*) filter (where ${jobQueue.status} = 'processing' and ${jobQueue.jobType} = ${JOB_TYPES.PLAN_REGENERATION}::job_type and ${jobQueue.startedAt} < ${stuckThreshold}::timestamptz)::int`,
       })
       .from(jobQueue);
 


### PR DESCRIPTION
This pull request updates the SQL queries in the `GET` handler for the worker health API to ensure correct type casting for certain filter conditions. The main focus is on improving the accuracy and reliability of job status and type checks in the database layer.

**Database query improvements:**

* Explicitly casts `stuckThreshold` to `timestamptz` in queries checking if a job is stuck, ensuring correct comparison against `startedAt` timestamps.
* Adds explicit casting of `JOB_TYPES.PLAN_REGENERATION` to `job_type` in queries filtering by job type, which improves type safety and prevents mismatches.