### PR TITLE
feat: Phase 2 — Pre-Launch Hardening (#289, #290, #291)

### DIFF
--- a/prds/launch-readiness-audit/phase2-research.md
+++ b/prds/launch-readiness-audit/phase2-research.md
@@ -1,0 +1,382 @@
+# Phase 2: Pre-Launch Hardening — Research & Implementation Plans
+
+> **Parent PRD:** [#284 — Launch Readiness Hardening](https://github.com/saldanaj97/atlaris/issues/284)
+> **Prerequisite:** All three slices depend on [#288 — Lifecycle Ownership Consolidation](https://github.com/saldanaj97/atlaris/issues/288)
+> **Research date:** 2026-03-19
+> **Status:** Research complete — ready for implementation after #288 merges
+
+---
+
+## Slice 5: Status Delivery Cost Reduction (#289)
+
+### 1. Current State
+
+**Polling mechanism:** The `usePlanStatus` hook (`src/hooks/usePlanStatus.ts:162-165`) polls `GET /api/v1/plans/:planId/status` every **3 seconds** with a fixed `setInterval`. No backoff, no jitter. Polling starts when status is `pending` or `processing` and stops on `ready`/`failed` or after 3 consecutive failures.
+
+**Status endpoint cost:** Each poll executes **3 DB queries** against the RLS-enforced connection:
+
+1. `requireOwnedPlanById` — full plan row fetch with RLS check
+2. `SELECT id FROM modules WHERE planId = ? LIMIT 1` — module existence check
+3. `SELECT classification, createdAt FROM generation_attempts WHERE planId = ? ORDER BY createdAt DESC LIMIT 3` — recent attempts
+
+**Status derivation:** `derivePlanStatus()` in `src/features/plans/status.ts` is a pure function that maps `(generationStatus, hasModules, attemptsCount, attemptCap)` → `PlanStatus`. The DB enum values are `generating | pending_retry | ready | failed`; the client-facing values are `pending | processing | ready | failed`.
+
+**No caching layer:** No HTTP cache headers, no in-memory cache, no read model. Every 3s poll hits the full query path.
+
+**Other status consumers:**
+
+- `useStreamingPlanGeneration` (SSE, not polling) — used during initial generation
+- `useRetryGeneration` (SSE, not polling) — used during retry
+- `PlanPendingState` component — primary consumer of `usePlanStatus`
+- Plan list views — server-rendered snapshot, no polling
+
+### 2. Files to Change
+
+| File                                              | Change                                                                                               | Lines      |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ---------- |
+| `src/hooks/usePlanStatus.ts`                      | Replace `setInterval` with `setTimeout`-based exponential backoff + jitter                           | 153-171    |
+| `src/hooks/usePlanStatus.ts`                      | Extract polling config constants (initial interval, max interval, backoff multiplier, jitter factor) | New ~10-15 |
+| `src/app/api/v1/plans/[planId]/status/route.ts`   | Add lightweight read-model query; reduce to 1-2 DB queries; add `Cache-Control` header               | 25-99      |
+| `src/features/plans/status.ts`                    | No change — `derivePlanStatus` is already pure and well-factored                                     | —          |
+| `src/lib/db/schema/tables/learning-plans.ts`      | (Optional) Add `moduleCount` or `hasModules` denormalized column                                     | TBD        |
+| `src/features/plans/lifecycle/plan-operations.ts` | Update `markPlanGenerationSuccess` to set denormalized status fields if added                        | 175-198    |
+
+**New files:**
+| File | Purpose |
+|------|---------|
+| `src/shared/constants/polling.ts` | Backoff/jitter configuration constants |
+| `src/hooks/__tests__/usePlanStatus.test.ts` | Tests for backoff behavior (if not already present) |
+| `src/app/api/v1/plans/[planId]/status/__tests__/route.test.ts` | Tests for simplified read model |
+
+### 3. Implementation Steps (TDD)
+
+1. **Write polling backoff tests first:**
+   - Test that poll interval increases exponentially from initial (1s) to max (10s)
+   - Test that jitter adds ±20% randomization
+   - Test that interval resets on successful status change
+   - Test that terminal states (`ready`/`failed`) stop polling immediately
+
+2. **Implement backoff/jitter in `usePlanStatus`:**
+   - Replace `setInterval(fn, 3000)` with recursive `setTimeout` pattern
+   - Constants: `INITIAL_POLL_MS = 1000`, `MAX_POLL_MS = 10000`, `BACKOFF_MULTIPLIER = 1.5`, `JITTER_FACTOR = 0.2`
+   - On each poll: `nextDelay = min(currentDelay * BACKOFF_MULTIPLIER, MAX_POLL_MS) * (1 + random(-JITTER_FACTOR, +JITTER_FACTOR))`
+   - Reset delay to initial on status transition (e.g., `pending → processing`)
+
+3. **Write status endpoint read-model tests:**
+   - Test that status endpoint returns correct status with only 1-2 queries
+   - Test `Cache-Control: max-age=1, stale-while-revalidate=2` header is present
+   - Test each status state (pending, processing, ready, failed)
+
+4. **Simplify status endpoint:**
+   - Option A (preferred): Add denormalized `hasModules` boolean to `learning_plans` table, updated in `markPlanGenerationSuccess`. Eliminates the modules query entirely.
+   - Option B (no schema change): Skip modules query when `generationStatus !== 'ready'` (modules only matter for the `ready` + no-modules edge case)
+   - Add `Cache-Control: max-age=1, stale-while-revalidate=2` to response
+
+5. **Document the status contract:**
+   - Add JSDoc to `derivePlanStatus` explaining the state machine
+   - Document the stable response shape in the route file
+
+6. **Validate:**
+   - `pnpm test:changed` passes
+   - Manual test: create a plan, observe polling interval increases in Network tab
+
+### 4. Risk Areas
+
+- **#288 merge conflict (LOW):** The status endpoint and `usePlanStatus` hook are unlikely to be touched by #288 (lifecycle consolidation). The main overlap is `plan-operations.ts` where `markPlanGenerationSuccess/Failure` live — if #288 moves these into the lifecycle service, the denormalization logic location changes.
+- **Denormalized column migration:** Adding `hasModules` to `learning_plans` requires a DB migration. The existing snapshot collision between 0010 and 0011 may need resolution first.
+- **Backoff timing in tests:** Using `useFakeTimers` in test environment needs careful handling with React hooks. Consider testing the backoff logic as a pure function, then integration-testing the hook with short intervals.
+
+### 5. Estimated Overlap
+
+- **With #290:** No file overlap
+- **With #291:** `plan-operations.ts` is shared (status marking functions used by both DB boundary cleanup and status endpoint). If #291 changes how `markPlanGenerationSuccess` uses DB connections, the denormalized update must go through the same path.
+
+---
+
+## Slice 6: Retry & Idempotency Policy Centralization (#290)
+
+### 1. Current State
+
+**Retry is scattered across three layers with multiplication risk:**
+
+| Layer                | Location                                  | Max attempts            | Backoff               |
+| -------------------- | ----------------------------------------- | ----------------------- | --------------------- |
+| Provider (p-retry)   | `src/features/ai/providers/router.ts:154` | 2 (1 retry)             | 300-700ms randomized  |
+| Per-plan attempt cap | `src/shared/constants/generation.ts:12`   | 3 (env-overridable)     | None (user-initiated) |
+| Job queue            | `src/lib/db/queries/jobs.ts:442-514`      | Default 3, hard cap 100 | 2^n sec, max 300s     |
+
+**Critical multiplication risk:** The regeneration worker (`src/features/jobs/regeneration-worker.ts:164`) passes `retryable: true` for retryable failures, which bypasses the default `maxAttempts: 3` and uses `ABSOLUTE_MAX_ATTEMPTS = 100` instead. Combined with provider retry, this means **up to 200 AI calls** per regeneration request (100 job attempts × 2 provider attempts).
+
+**Duplicate detection exists in two layers:**
+
+1. Plan creation: `findRecentDuplicatePlan()` in `plan-operations.ts:260-283` — 60s window, matches userId + lowercase topic + status
+2. Job queue: `insertJobRecord()` in `jobs.ts:255-278` — atomically dedupes active jobs for the same planId. Pre-check via `getActiveRegenerationJob()` in regenerate route.
+
+**Idempotent patterns already present:**
+
+- Job completion/failure: `lockJobAndCheckTerminal()` prevents double-processing
+- Stripe webhooks: `INSERT ON CONFLICT DO NOTHING` dedup
+- RLS cleanup: tracked idempotent flag
+
+**No abandoned request cleanup:**
+
+- No cron for stuck `generating` plans
+- No cleanup for orphaned `in_progress` generation attempts
+- `cleanupOldJobs()` exists (`jobs.ts:207-224`) but is **never called** by any cron/trigger
+- Health check (`api/health/worker/route.ts`) detects stuck jobs but doesn't remediate
+
+**No circuit breaker:** Zero circuit breaker implementations found across the codebase.
+
+### 2. Files to Change
+
+| File                                                | Change                                                                          | Lines           |
+| --------------------------------------------------- | ------------------------------------------------------------------------------- | --------------- |
+| `src/features/ai/providers/router.ts`               | Move provider-level retry config behind centralized retry policy                | 154-165         |
+| `src/features/jobs/regeneration-worker.ts`          | Fix `retryable: true` override to respect bounded retry; use centralized policy | 164, 200-226    |
+| `src/lib/db/queries/jobs.ts`                        | Cap `retryable: true` override at `maxAttempts`, not `ABSOLUTE_MAX_ATTEMPTS`    | 98-113, 442-514 |
+| `src/shared/constants/generation.ts`                | Add centralized retry policy constants                                          | New section     |
+| `src/features/plans/lifecycle/service.ts`           | Integrate retry policy checks (after #288 consolidation)                        | 359-439         |
+| `src/app/api/v1/plans/[planId]/retry/route.ts`      | Ensure retry route delegates to lifecycle service retry policy                  | Throughout      |
+| `src/app/api/v1/plans/[planId]/regenerate/route.ts` | Ensure regenerate route delegates to lifecycle service                          | Throughout      |
+
+**New files:**
+| File | Purpose |
+|------|---------|
+| `src/features/plans/retry-policy.ts` | Single retry policy module: bounded retry semantics, multiplication guards, backoff config |
+| `src/features/plans/retry-policy.test.ts` | Tests for centralized retry policy |
+| `src/features/plans/cleanup.ts` | Abandoned request cleanup logic (stuck plans, orphaned attempts) |
+| `src/features/plans/cleanup.test.ts` | Tests for cleanup |
+
+### 3. Implementation Steps (TDD)
+
+1. **Write retry policy module tests first:**
+   - Test: provider retry × job retry never exceeds defined bound
+   - Test: `retryable: true` at job level still respects `maxAttempts` (not 100)
+   - Test: total AI calls per regeneration ≤ `maxAttempts * providerRetries` (e.g., 3 × 2 = 6)
+   - Test: retry policy returns `{ shouldRetry, delay, reason }` for each classification
+
+2. **Create centralized retry policy module:**
+
+   ```
+   src/features/plans/retry-policy.ts
+   ```
+
+   - Export `RetryPolicy` with: `MAX_PROVIDER_RETRIES = 1`, `MAX_JOB_RETRIES = 3`, `MAX_TOTAL_AI_CALLS = 6`
+   - Export `shouldRetryJob(classification, attemptNumber, maxAttempts)` — single source of truth
+   - Export `getRetryDelay(attemptNumber)` — exponential backoff with cap
+   - Export `computeEffectiveMaxAttempts(baseMax, retryableOverride)` — replaces the raw `ABSOLUTE_MAX_ATTEMPTS` fallback
+
+3. **Fix the multiplication bug:**
+   - In `jobs.ts:computeShouldRetry` (lines 98-113): when `retryable === true`, use `maxAttempts` (default 3) instead of `ABSOLUTE_MAX_ATTEMPTS` (100). Remove or dramatically reduce `ABSOLUTE_MAX_ATTEMPTS`.
+   - In `regeneration-worker.ts`: use `shouldRetryJob()` from the policy module instead of passing raw `retryable: true/false`.
+
+4. **Wire retry policy into lifecycle service (post-#288):**
+   - After #288 makes lifecycle service the single owner, add retry policy consultation before each generation attempt
+   - Lifecycle service checks: "has this plan exhausted retries?" before running generation
+
+5. **Write abandoned request cleanup tests:**
+   - Test: plans stuck in `generating` for > 10 minutes are marked `failed`
+   - Test: orphaned `in_progress` attempts older than timeout are finalized
+   - Test: cleanup does not touch active/healthy generations
+
+6. **Implement cleanup:**
+   - `cleanupStuckPlans(thresholdMs)`: marks plans with `generationStatus = 'generating'` and `updatedAt < now - threshold` as `'failed'`
+   - `cleanupOrphanedAttempts(thresholdMs)`: finalizes `in_progress` attempts older than threshold
+   - Wire `cleanupOldJobs()` (already exists) to a trigger — consider calling it from the health check or a periodic API route
+
+7. **Validate:**
+   - `pnpm test:changed` passes
+   - Verify: create a regeneration job, confirm max AI calls ≤ 6
+
+### 4. Risk Areas
+
+- **#288 merge conflict (HIGH):** The retry/regeneration routes are primary targets for #288's lifecycle consolidation. The retry route and regenerate route will likely be substantially refactored by #288. Plan to implement this slice **after** #288 merges and rebase.
+- **Job queue `ABSOLUTE_MAX_ATTEMPTS` change is behavioral:** Reducing from 100 to 3 changes retry behavior for all jobs. Ensure existing regeneration jobs in the queue aren't mid-retry when the change deploys. Consider a migration strategy or feature flag.
+- **Cleanup race condition:** Marking stuck plans as `failed` while they're actually still generating (slow AI response) could cause data loss. Use a generous threshold (≥ 2× the maximum possible generation time, e.g., 15 minutes).
+- **No cron infrastructure:** The codebase has no cron/scheduled job system. Cleanup would need to be triggered by the health check endpoint or an external cron (e.g., Vercel cron, GitHub Actions).
+
+### 5. Estimated Overlap
+
+- **With #289:** No file overlap
+- **With #291:** Shared files:
+  - `src/features/plans/lifecycle/service.ts` — both slices modify the lifecycle service
+  - `src/features/jobs/regeneration-worker.ts` — retry policy changes (this slice) and DB boundary changes (#291)
+  - `src/lib/db/queries/attempts.ts` — retry logic (this slice) and DB context handling (#291)
+  - `src/app/api/v1/plans/[planId]/retry/route.ts` — retry policy (this slice) and DB cleanup (#291)
+
+**Merge recommendation:** Implement #290 (retry policy) **before** #291 (DB boundaries) since retry policy is a logical dependency — knowing the retry bounds informs which DB connections need to stay open.
+
+---
+
+## Slice 7: Request-Time DB Boundary Cleanup (#291)
+
+### 1. Current State
+
+**The stream route opens TWO simultaneous RLS connections:**
+
+```
+Connection 1 (request-scoped):
+  Created by: withAuth → createAuthenticatedRlsClient()
+  Used for: rate limit check, plan creation (quota, dedup, atomic insert)
+  Closed: when Response(stream) is returned to Next.js (withAuth finally block)
+
+Connection 2 (stream-scoped):
+  Created by: createStreamDbClient() in route.ts:112
+  Used for: generation attempts (reserve slot, AI call, finalize, mark success/failure)
+  Closed: finally block in SSE stream callback (route.ts:299-301)
+```
+
+**Critical bug: Connection 1 is used after it's closed.**
+After `withAuth` returns the `Response(stream)`, Connection 1 is cleaned up. But `PlanPersistenceAdapter` still holds a reference to it. When `processGenerationAttempt` calls `markGenerationSuccess/Failure` (via `PlanPersistenceAdapter`), it uses the **already-closed** Connection 1. Similarly, `UsageRecordingAdapter` calls `getDb()` which returns the closed Connection 1 from `AsyncLocalStorage`.
+
+**Why this might not crash today:** The lifecycle service's `processGenerationAttempt` in the stream route is overridden by `deps?.overrides?.processGenerationAttempt` or called via `lifecycleService.processGenerationAttempt.bind(lifecycleService)`. The actual generation runs through `GenerationAdapter` which uses Connection 2. The lifecycle service's own `markGenerationSuccess/Failure` calls go through the adapter which uses Connection 1 — but #288 may change this plumbing.
+
+**Connection lifecycle timeline:**
+| Time | Event | Connection 1 | Connection 2 |
+|------|-------|-------------|-------------|
+| T0 | Request arrives | OPEN (withAuth) | — |
+| T1 | Rate limit + plan creation | ACTIVE | — |
+| T2 | Stream DB client created | OPEN | OPEN |
+| T3 | Response returned | **CLOSED** | OPEN |
+| T4 | AI generation (30-120s) | CLOSED | OPEN (idle) |
+| T5 | Mark success + record usage | CLOSED (⚠️ used!) | OPEN |
+| T6 | Stream completes | CLOSED | **CLOSED** |
+
+**Each RLS connection costs 3 round trips:** `SET ROLE` + `SET search_path` + `set_config` ≈ 15-30ms.
+
+**Factory wiring splits DB clients:**
+
+- `PlanPersistenceAdapter`, `QuotaAdapter`, `PdfOriginAdapter` → Connection 1 (`dbClient`)
+- `GenerationAdapter` → Connection 2 (`attemptsDbClient`)
+- `UsageRecordingAdapter` → **no injected client** (uses `getDb()` fallback → Connection 1)
+
+**Worker/background scope:** Uses `serviceRoleDb` directly from `src/lib/db/service-role.ts` — singleton, `max: 10` pool, never closed. Appropriate for background jobs.
+
+### 2. Files to Change
+
+| File                                                                | Change                                                                                              | Lines                         |
+| ------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ----------------------------- |
+| `src/app/api/v1/plans/stream/route.ts`                              | Eliminate dual-connection pattern; use single stream-scoped connection for all lifecycle operations | 94, 111-131, 299-301, 319-336 |
+| `src/features/plans/lifecycle/factory.ts`                           | Remove `dbClient`/`attemptsDbClient` split; accept single `dbClient`                                | 20-33                         |
+| `src/features/plans/lifecycle/adapters/usage-recording-adapter.ts`  | Accept injected `dbClient` instead of relying on `getDb()`                                          | 15-46                         |
+| `src/features/plans/lifecycle/adapters/plan-persistence-adapter.ts` | Ensure it uses the stream-scoped connection (same one as generation)                                | 20-63                         |
+| `src/features/plans/lifecycle/adapters/generation-adapter.ts`       | Align with single-connection pattern                                                                | 25-113                        |
+| `src/lib/db/rls.ts`                                                 | (Optional) Consider longer `idle_timeout` for stream clients                                        | 86-88                         |
+| `src/app/api/v1/plans/[planId]/retry/route.ts`                      | Apply same single-connection pattern if it has similar dual-connection setup                        | Throughout                    |
+| `src/app/api/v1/plans/[planId]/regenerate/route.ts`                 | Verify worker uses `serviceRoleDb` correctly (no RLS needed)                                        | Throughout                    |
+
+### 3. Implementation Steps (TDD)
+
+1. **Write DB boundary tests first:**
+   - Test: stream route opens exactly 1 RLS connection (not 2)
+   - Test: all lifecycle operations during generation use the same DB connection
+   - Test: DB connection is open for the entire duration of the stream, closed only in finally
+   - Test: `UsageRecordingAdapter` uses injected client, not `getDb()` fallback
+   - Test: worker/regeneration uses `serviceRoleDb` (no RLS client created)
+
+2. **Unify the factory to accept a single DB client:**
+   - Remove the `dbClient` / `attemptsDbClient` split in `factory.ts`
+   - All adapters receive the same `dbClient`
+   - `UsageRecordingAdapter` constructor accepts `dbClient` parameter
+
+3. **Restructure stream route connection lifecycle:**
+
+   ```
+   Current:
+     withAuth creates Connection 1 → plan creation
+     createStreamDbClient creates Connection 2 → generation
+     Connection 1 dies when Response returned; Connection 2 survives
+
+   Target:
+     withAuth creates Connection 1 → rate limit check ONLY
+     createStreamDbClient creates Connection 2 → ALL lifecycle operations
+     Connection 1 dies safely (only used for rate limit)
+     Connection 2 used for: plan creation + generation + usage recording
+   ```
+
+   - Move `getDb()` usage for rate limit check to be explicit (this is the only thing that needs the request-scoped connection)
+   - Create lifecycle service with `dbClient: streamDb` for **all** adapters
+   - Or better: defer rate limit check to also use `streamDb`
+
+4. **Fix `UsageRecordingAdapter` dependency:**
+   - Add `dbClient` to constructor
+   - Pass it through to `recordUsage()` and `incrementUsage()`
+   - Remove `getDb()` fallback from the adapter (fail-closed if no client injected)
+
+5. **Document remaining multi-context paths:**
+   - The `withAuth` layer will still create an RLS connection for auth — this is unavoidable and correct
+   - The stream-scoped RLS connection is the "real" DB context for all plan lifecycle operations
+   - Workers use `serviceRoleDb` — no RLS, no multi-context
+   - Add JSDoc comments to `factory.ts` explaining the single-client design
+
+6. **Consider idle_timeout for stream connections:**
+   - Current: `idle_timeout: 20` seconds
+   - During AI generation (30-120s), the connection is idle
+   - Increase to `idle_timeout: 180` (3 minutes) for stream-scoped connections to avoid premature closure
+   - Already noted in repository memory: "Streaming RLS clients need idle_timeout > max generation duration"
+
+7. **Validate:**
+   - `pnpm test:changed` passes
+   - Manual test: generate a plan, verify only 1 RLS connection is created (check logs for `SET ROLE` calls)
+   - Verify usage recording works correctly during generation (no stale-connection errors)
+
+### 4. Risk Areas
+
+- **#288 merge conflict (HIGH):** The factory wiring (`factory.ts`) and the stream route's DB client creation are primary #288 targets. #288 may already consolidate the dual-connection pattern. **Wait for #288 to merge before starting.**
+- **Connection 1 still needed for auth:** The `withAuth` middleware creates an RLS connection for authentication. We can't eliminate it entirely — but we can ensure it's only used for the auth check and rate limiting, not for downstream lifecycle operations.
+- **Rate limit check depends on `getDb()`:** `checkPlanGenerationRateLimit` (`src/lib/api/rate-limit.ts`) uses `getDb()` which returns the request-scoped connection. If we stop using `getDb()` for lifecycle operations, this still needs to work. The rate limit check runs **before** the stream DB client is created, so it naturally uses Connection 1.
+- **Test environment difference:** In tests, `createStreamDbClient` returns `getDb()` (service-role) with a noop cleanup. This means the dual-connection bug is invisible in tests. Need to add a test that explicitly verifies connection count.
+- **`idle_timeout` vs Neon pooler:** If using Neon's connection pooler for the stream client, `idle_timeout` may interact poorly with pooler-level timeouts. The RLS client already uses non-pooling connections, so this should be safe.
+
+### 5. Estimated Overlap
+
+- **With #289:** `plan-operations.ts` shared if status denormalization is added to `markPlanGenerationSuccess`
+- **With #290:** Shared files:
+  - `src/features/plans/lifecycle/service.ts` — both slices modify the lifecycle service
+  - `src/features/plans/lifecycle/factory.ts` — DB client wiring (this slice) and retry policy integration (#290)
+  - `src/features/jobs/regeneration-worker.ts` — DB context (this slice) and retry policy (#290)
+  - `src/lib/db/queries/attempts.ts` — DB context cleanup (this slice) and retry logic (#290)
+
+**Merge recommendation:** Implement #290 (retry policy) **first**, then #291 (DB boundaries). Retry policy is a pure logic change; DB boundaries are a plumbing change that's easier to do once retry logic is settled.
+
+---
+
+## Cross-Slice Analysis
+
+### Recommended Implementation Order
+
+```
+#288 merges (prerequisite)
+  │
+  ├── #289 Status Delivery Cost Reduction    ← Start immediately (low overlap)
+  │
+  ├── #290 Retry & Idempotency Policy        ← Start immediately (parallel with #289)
+  │     │
+  │     └── #291 DB Boundary Cleanup          ← Start after #290 (shared files)
+```
+
+**Rationale:**
+
+- #289 has minimal overlap with the other two slices — can proceed fully in parallel
+- #290 (retry policy) is a logical dependency for #291 (DB boundaries) — knowing retry bounds informs connection lifecycle
+- #291 touches the same lifecycle/factory/worker files as #290 — implementing it second reduces merge conflicts
+
+### Shared File Map
+
+| File                                                | #289                 | #290       | #291          |
+| --------------------------------------------------- | -------------------- | ---------- | ------------- |
+| `src/hooks/usePlanStatus.ts`                        | ✅ primary           | —          | —             |
+| `src/app/api/v1/plans/[planId]/status/route.ts`     | ✅ primary           | —          | —             |
+| `src/features/plans/lifecycle/service.ts`           | —                    | ✅         | ✅            |
+| `src/features/plans/lifecycle/factory.ts`           | —                    | —          | ✅ primary    |
+| `src/features/plans/lifecycle/adapters/*`           | —                    | —          | ✅ primary    |
+| `src/features/plans/lifecycle/plan-operations.ts`   | ✅ (if denormalized) | —          | ✅            |
+| `src/features/ai/providers/router.ts`               | —                    | ✅         | —             |
+| `src/features/jobs/regeneration-worker.ts`          | —                    | ✅         | ✅            |
+| `src/lib/db/queries/jobs.ts`                        | —                    | ✅ primary | —             |
+| `src/lib/db/queries/attempts.ts`                    | —                    | ✅         | ✅            |
+| `src/app/api/v1/plans/stream/route.ts`              | —                    | —          | ✅ primary    |
+| `src/app/api/v1/plans/[planId]/retry/route.ts`      | —                    | ✅         | ✅            |
+| `src/app/api/v1/plans/[planId]/regenerate/route.ts` | —                    | ✅         | ✅            |
+| `src/shared/constants/generation.ts`                | —                    | ✅         | —             |
+| `src/lib/db/rls.ts`                                 | —                    | —          | ✅ (optional) |

--- a/prds/launch-readiness-audit/phase2-todos.md
+++ b/prds/launch-readiness-audit/phase2-todos.md
@@ -1,0 +1,82 @@
+# Phase 2: Pre-Launch Hardening — Execution Tracker
+
+> **Parent PRD:** [#284](https://github.com/saldanaj97/atlaris/issues/284)
+> **Prerequisite:** #288 merged ✅ (commit 2b9b7fa)
+> **Status:** ✅ All slices implemented and validated
+
+## Execution Order
+
+```
+#289 Status Delivery Cost Reduction    ✅ Complete
+#290 Retry & Idempotency Policy        ✅ Complete
+#291 DB Boundary Cleanup               ✅ Complete
+```
+
+---
+
+## Slice 5: Status Delivery Cost Reduction (#289)
+
+### Implementation Steps
+
+- [x] 5.1 Create `src/shared/constants/polling.ts` with backoff/jitter config constants
+- [x] 5.2 Write tests for exponential backoff behavior in usePlanStatus hook
+- [x] 5.3 Replace `setInterval(3000)` in `usePlanStatus.ts` with `setTimeout`-based exponential backoff + jitter
+- [x] 5.4 Write tests for simplified status endpoint (reduced queries + cache headers)
+- [x] 5.5 Simplify status endpoint: skip modules query when not `ready`, add `Cache-Control` header
+- [x] 5.6 Document status contract with JSDoc on `derivePlanStatus`
+- [x] 5.7 Validate: lint, type-check, test:changed
+
+### Acceptance Criteria
+
+- [x] Status delivery no longer depends on aggressive fixed-interval polling
+- [x] Backoff and jitter are applied (initial=1s, max=10s, multiplier=1.5, jitter=±20%)
+- [x] Status endpoint uses 1-2 DB queries instead of 3
+- [x] Cache-Control headers present on status responses
+- [x] Status contract documented and stable across all states
+- [x] Tests cover status behavior for each state
+
+---
+
+## Slice 6: Retry & Idempotency Policy Centralization (#290)
+
+### Implementation Steps
+
+- [x] 6.1 Write tests for centralized retry policy module
+- [x] 6.2 Create `src/features/plans/retry-policy.ts` with bounded retry semantics
+- [x] 6.3 Fix multiplication bug: cap `retryable: true` at `maxAttempts` in `computeShouldRetry`
+- [x] 6.4 Wire retry policy into regeneration worker (replace raw `retryable: true/false`)
+- [x] 6.5 Move provider retry config behind centralized retry policy constants
+- [x] 6.6 Write tests for abandoned request cleanup
+- [x] 6.7 Create `src/features/plans/cleanup.ts` for stuck plans and orphaned attempts
+- [x] 6.8 Validate: lint, type-check, test:changed
+
+### Acceptance Criteria
+
+- [x] One module owns retry policy for all generation paths
+- [x] Retry counts are bounded (no accidental multiplication)
+- [x] `retryable: true` no longer bypasses to ABSOLUTE_MAX_ATTEMPTS(100)
+- [x] Abandoned requests cleaned up without consuming budget
+- [x] Tests cover bounded retry semantics and cleanup behavior
+
+---
+
+## Slice 7: Request-Time DB Boundary Cleanup (#291)
+
+### Implementation Steps
+
+- [x] 7.1 Write tests for DB boundary behavior (single connection, usage recording)
+- [x] 7.2 Add `dbClient` parameter to `UsageRecordingAdapter` constructor
+- [x] 7.3 Update `factory.ts` to accept single `dbClient` for all adapters
+- [x] 7.4 Restructure stream route: Connection 1 for auth/rate-limit only, Connection 2 for all lifecycle
+- [x] 7.5 Apply same single-connection pattern to retry route if applicable
+- [x] 7.6 Increase `idle_timeout` to 180s for stream-scoped connections
+- [x] 7.7 Document multi-context paths with JSDoc
+- [x] 7.8 Validate: lint, type-check, test:changed
+
+### Acceptance Criteria
+
+- [x] Generation flow opens minimum required DB contexts
+- [x] All lifecycle operations use stream-scoped connection
+- [x] UsageRecordingAdapter uses injected client (no getDb() fallback)
+- [x] Request-scoped vs worker-scoped boundaries documented
+- [x] Tests verify DB boundary behavior

--- a/prds/launch-readiness-audit/prd.md
+++ b/prds/launch-readiness-audit/prd.md
@@ -1,0 +1,97 @@
+# PRD: Launch Readiness Hardening and Cost Guardrails
+
+## Problem Statement
+
+Atlaris is carrying avoidable launch risk in the exact places that hurt the most: plan creation and generation do not have a single authoritative lifecycle, AI usage accounting is not reliably correct across the main generation path, and several expensive request paths do unnecessary work before they know whether the request should be allowed to proceed.
+
+From a user perspective, this creates a bad kind of unpredictability. A generation can be rejected after a plan shell already exists. Different entry points can enforce lifecycle rules differently. Retries and regenerations can multiply work. Status updates rely on hot polling instead of a cheaper and more deliberate contract. If these gaps stay in place, users will see phantom plans, confusing retry behavior, inconsistent quota outcomes, and slower or noisier status updates.
+
+From the business perspective, the same gaps create blind AI spend, unnecessary database/runtime cost, and support pain right before launch. AI usage and cost data must be trustworthy. Expensive generation work must be gated before new records are created. Observability volume must be tuned for signal, not vanity. The launch problem is not generic cleanup. The launch problem is closing the specific correctness and cost gaps that can damage margin, reliability, and trust.
+
+## Solution
+
+Run a focused launch-readiness hardening initiative that converts the audit findings into one execution plan with a clear priority order.
+
+The solution centers on five changes:
+
+1. Make the existing plan lifecycle service the single owner of create, generate, retry, and regeneration orchestration.
+2. Introduce one canonical AI usage contract and one shared cost-accounting path so every provider result is recorded consistently.
+3. Move durable gating, idempotency, and retry policy ahead of expensive work so invalid or duplicate requests do not create junk records or multiply provider spend.
+4. Reduce avoidable infrastructure burn by replacing aggressive polling with a cheaper status strategy and by tightening request-time database boundaries.
+5. Trim observability and third-party read costs so pre-launch operations preserve critical signal without burning budget.
+
+The goal is not a sweeping rewrite. The goal is to ship the minimum set of structural fixes that materially reduce launch risk now, while explicitly deferring lower-return cleanup until after launch.
+
+## User Stories
+
+1. As a learner, I want plan creation and generation to follow one consistent lifecycle, so that I do not get different behavior depending on which entry point I use.
+2. As a learner, I want rejected generations not to leave behind phantom or stuck plans, so that my plan list reflects real work.
+3. As a learner, I want retries and regenerations to avoid duplicate work, so that I do not see duplicated plans, confusing failures, or wasted quota.
+4. As a learner, I want my generation request to fail fast when I am over a durable limit, so that I do not wait on work that was never allowed.
+5. As a learner, I want generation status updates to feel timely without excessive refresh loops, so that the app feels responsive and stable.
+6. As a learner, I want failed generations to end in a clear and consistent state, so that I understand whether I can retry.
+7. As a learner using PDF input, I want proof, quota, and plan creation behavior to be consistent with normal generation flows, so that the system feels predictable.
+8. As a paying user, I want my AI usage to reflect real work only, so that billing and usage limits feel fair.
+9. As a paying user, I want abandoned or duplicated generations not to consume unnecessary budget, so that refreshes and disconnects do not silently waste value.
+10. As a paying user, I want model constraints and output limits to be enforced consistently, so that plan generation remains reliable across tiers.
+11. As a support agent, I want one lifecycle record to inspect when a user reports a plan-generation problem, so that I can diagnose issues quickly.
+12. As a support agent, I want usage and quota outcomes to line up with real generation attempts, so that I can explain charges and limits confidently.
+13. As an operator, I want AI token and cost metrics to be accurate for every generation path, so that I can monitor margin and detect regressions.
+14. As an operator, I want the system to avoid unnecessary database churn on status and stream flows, so that growth does not turn into a boring cost leak.
+15. As an operator, I want observability settings to preserve failures and high-value traces without flooding Sentry, so that monitoring stays useful and affordable.
+16. As an operator, I want duplicate or abandoned generation work to be minimized, so that infrastructure spend tracks real user value.
+17. As an operator, I want subscription status reads to avoid unnecessary live provider calls, so that the billing experience stays fast and resilient.
+18. As a developer, I want one module to own the plan lifecycle, so that fixes land once instead of being reimplemented across routes and workers.
+19. As a developer, I want AI usage normalization and cost calculation to live behind one contract, so that providers and persistence cannot silently drift apart.
+20. As a developer, I want durable limits, idempotency, and retry rules to be centralized, so that thin callers do not need to coordinate policy.
+21. As a developer, I want request-time database boundaries to be explicit, so that request-scoped and worker-scoped behavior is easy to reason about.
+22. As a developer, I want status reads to depend on a small and stable contract, so that I am not rebuilding expensive summaries on every poll.
+23. As a developer, I want launch-blocking fixes to be separated from post-launch cleanup, so that the team does not confuse urgency with scope creep.
+24. As a finance owner, I want output-token ceilings, AI spend visibility, and observability budgets in place before launch, so that unit economics are not guesswork.
+25. As a product owner, I want the launch hardening plan to target reliability and cost control first, so that we ship a stable product instead of polishing around structural risk.
+26. As a future maintainer, I want the remaining debt to be explicitly documented as deferred, so that the launch plan remains realistic and the follow-up work is not lost.
+
+## Implementation Decisions
+
+- Make the plan lifecycle service the authoritative owner of plan creation, generation execution, retry handling, and regeneration execution. Legacy orchestration paths become thin adapters or are removed.
+- Introduce a canonical generation-usage model at the provider boundary. Every AI provider returns the same usage fields, and all persistence/billing code consumes that shared shape.
+- Centralize AI cost calculation in one place. Missing usage data is treated as an explicit error or alert condition rather than being silently recorded as zero.
+- Enforce durable generation limits, quota checks, and idempotency before a new plan shell is created. The system should not create user-facing plan records for requests that are going to be rejected.
+- Define a single retry owner across provider calls, lifecycle attempts, and queued jobs. Retry multiplication must be intentional and bounded, not accidental.
+- Add explicit output-token ceilings based on model and expected plan shape so provider defaults cannot drive runaway output spend.
+- Tighten request-time database ownership so the generation flow does not open extra database contexts unless there is a hard requirement. If multiple contexts remain necessary, their roles must be explicit and observable.
+- Introduce a cheaper status contract. Prefer event-driven status delivery where practical; otherwise use stronger backoff, jitter, and a simplified read model instead of a hot polling loop.
+- Add default pagination and lighter-weight plan summaries for plan-list reads so read cost grows with intent, not with total historical rows.
+- Serve subscription status primarily from local state synchronized by webhooks, using live provider reads only for repair, administrative, or bounded fallback cases.
+- Reduce observability volume before launch. Keep exception reporting and high-value tracing, but lower replay, trace, and log-shipping defaults to a level that matches expected launch traffic.
+- Allow lightweight supporting persistence changes only where they materially enable idempotency, status snapshots, or lifecycle invariants. Avoid broad schema redesign in this initiative.
+- Sequence work by launch risk, not architectural purity. Accuracy of usage accounting, lifecycle consistency, and cost guardrails take precedence over deeper refactors with weaker near-term ROI.
+
+## Testing Decisions
+
+- Good tests for this work assert external behavior, persisted invariants, and user-visible state transitions rather than helper call order or internal sequencing.
+- Lifecycle tests should verify that the authoritative lifecycle boundary accepts validated input, enforces gating, creates or rejects plans correctly, finalizes generation state correctly, and records usage consistently across success and failure outcomes.
+- Usage-accounting tests should verify that provider results normalize into the canonical usage model, that cost calculation is deterministic, and that missing usage becomes an explicit failure path instead of a silent zeroed write.
+- Idempotency and retry-policy tests should verify duplicate submission handling, abandoned-request behavior, and bounded retry semantics across stream, retry, and regeneration flows.
+- Status-delivery tests should verify observable status behavior under pending, ready, failed, and retryable states while avoiding tests that depend on implementation-specific polling internals.
+- Read-path tests should verify pagination defaults, lightweight summaries, and billing-status fallback behavior based on stable response contracts.
+- Observability tests should focus on contract-level behavior where meaningful, such as environment-based sampling decisions or whether high-severity failures are still captured after volume reductions.
+- Similar prior art already exists in the codebase for plan streaming integration coverage, lifecycle race-condition coverage, worker processing coverage, and DB query helper testing. Reuse those behavioral patterns instead of introducing mock-heavy choreography tests.
+- Favor boundary tests around deep modules and thin adapter tests for wiring. Do not grow a new forest of shallow unit tests that only prove one helper called another helper.
+
+## Out of Scope
+
+- Rewriting the entire AI orchestration stack beyond the usage contract, retry ownership, and launch-critical guardrails.
+- Replatforming background jobs onto a different queue or worker system.
+- Redesigning pricing, tier packaging, or subscription product strategy.
+- Performing a full persistence rewrite for regeneration or attempt finalization when a smaller hardening step is sufficient for launch.
+- Rebuilding preview and CI infrastructure beyond low-effort cost controls and obvious launch-facing waste reduction.
+- Expanding PDF processing into a larger async platform initiative unless launch traffic proves it necessary.
+- General UI polish work unrelated to lifecycle consistency, status behavior, or user-visible reliability.
+- Broad architecture cleanup that does not directly reduce launch risk, operating cost, or billing correctness.
+
+## Further Notes
+
+- This PRD should be executed in phases. Phase 1 is launch-blocking correctness and spend visibility: canonical usage accounting, output-token caps, pre-creation gating, and clear lifecycle ownership. Phase 2 is pre-launch hardening: status-cost reduction, request-time DB boundary cleanup, retry/idempotency policy, and observability tuning. Phase 3 is post-launch cleanup: deeper persistence simplification, queue consolidation, and broader operational cost trimming.
+- Success criteria for launch readiness should be explicit. At minimum: every generation path records trustworthy usage or raises an explicit accounting failure, rejected requests do not create user-facing junk plans, one lifecycle boundary owns create and generate behavior, and status traffic no longer depends on an aggressive fixed poll loop.
+- This initiative is intentionally biased toward reducing real launch risk. If a proposed change is elegant but does not improve correctness, cost visibility, or operating leverage before launch, it belongs in follow-up work, not in the critical path.

--- a/prds/launch-readiness-audit/todos.md
+++ b/prds/launch-readiness-audit/todos.md
@@ -1,0 +1,231 @@
+# Launch Readiness Hardening — Todos
+
+> **Parent PRD:** [#284 — PRD: Launch Readiness Hardening and Cost Guardrails](https://github.com/saldanaj97/atlaris/issues/284)
+
+## Notes
+
+### **VERY IMPORTANT - MUST FOLLOW**
+
+- When you see "in parallel" in the execution order, it means those slices can be worked on simultaneously using subagents. It does NOT mean that the work within that slice is necessarily parallelizable — some slices may still have internal sequential steps or dependencies. The "parallel" label only indicates that the entire slice can be started without waiting for other slices to complete, not that every task within it can be done in parallel.
+- When spawning a subagent, make sure to use Opus 4.6 High as the model when dealing with semi-complex/complex tasks and GPT 5.4 mini High when dealing with simple tasks such as exploring, reading files, or writing very simple code.
+
+## Execution Order Summary
+
+```
+Can start immediately (parallel):
+  ├── #285 Canonical AI Usage Accounting Contract
+  ├── #287 Pre-Creation Gating & Quota Enforcement
+  └── #292 Observability Volume Tuning
+
+After #285:
+  └── #286 AI Cost Calculation & Output-Token Ceilings
+
+After #285 + #287:
+  └── #288 Lifecycle Ownership Consolidation
+
+After #288 (parallel):
+  ├── #289 Status Delivery Cost Reduction
+  ├── #290 Retry & Idempotency Policy Centralization
+  └── #291 Request-Time DB Boundary Cleanup
+
+Post-launch (parallel):
+  ├── #293 Read-Path Optimization & Subscription Caching
+  └── #294 Persistence Simplification & Queue Consolidation
+```
+
+---
+
+## Phase 1: Launch-Blocking Correctness & Spend Visibility
+
+> Slices 1 and 3 have no blockers and can start **in parallel**.
+> Slice 2 depends on slice 1. Slice 4 depends on slices 1 and 3.
+
+### 1. Canonical AI Usage Accounting Contract — [#285](https://github.com/saldanaj97/atlaris/issues/285)
+
+- **Blocked by:** None — can start immediately
+- **Parallel candidate:** Yes — can run in parallel with slice 3
+- **User stories:** 8, 12, 13, 19, 24
+
+**Summary:** Introduce one shared usage model at the provider boundary. All providers return the same fields. Persistence/billing consumes that shape. Missing usage → explicit error, not silent zero.
+
+**Acceptance criteria:**
+
+- [x] A single canonical usage type/interface exists that all AI providers return
+- [x] All provider adapters normalize their responses into this canonical shape
+- [x] Missing or incomplete usage data raises an explicit error/alert, never silently writes zero
+- [x] All persistence and billing paths consume only the canonical usage shape
+- [x] Existing tests pass; new boundary tests cover normalization and missing-data error paths
+
+---
+
+### 2. AI Cost Calculation & Output-Token Ceilings — [#286](https://github.com/saldanaj97/atlaris/issues/286)
+
+- **Blocked by:** [#285](https://github.com/saldanaj97/atlaris/issues/285) (Canonical AI Usage Accounting Contract)
+- **Parallel candidate:** No — must wait for slice 1
+- **User stories:** 10, 13, 16, 24
+
+**Summary:** Centralize cost calculation in one place. Add model-based output-token ceilings. Enforce consistently across tiers.
+
+**Acceptance criteria:**
+
+- [ ] Cost calculation lives in exactly one module/function
+- [ ] Cost is derived deterministically from the canonical usage model
+- [ ] Output-token ceilings are defined per model and enforced at the provider call boundary
+- [ ] Token limits are enforced consistently across all user tiers
+- [ ] Tests cover cost calculation determinism, ceiling enforcement, and tier consistency
+
+---
+
+### 3. Pre-Creation Gating & Quota Enforcement — [#287](https://github.com/saldanaj97/atlaris/issues/287)
+
+- **Blocked by:** None — can start immediately
+- **Parallel candidate:** Yes — can run in parallel with slice 1
+- **User stories:** 2, 4, 9, 20
+
+**Summary:** Enforce durable limits, quota checks, and idempotency before plan shell creation. Rejected requests must not leave junk records.
+
+**Acceptance criteria:**
+
+- [x] Quota and limit checks execute before any plan record is created
+- [x] Rejected requests return a clear error and leave zero user-visible plan records
+- [x] Duplicate/idempotent submissions are detected and handled before record creation
+- [x] Over-limit requests fail fast with an informative response
+- [x] Tests cover quota rejection, duplicate detection, and "no junk records" invariant
+
+---
+
+### 4. Lifecycle Ownership Consolidation — [#288](https://github.com/saldanaj97/atlaris/issues/288)
+
+- **Blocked by:** [#285](https://github.com/saldanaj97/atlaris/issues/285) (Canonical AI Usage Accounting Contract), [#287](https://github.com/saldanaj97/atlaris/issues/287) (Pre-Creation Gating & Quota Enforcement)
+- **Parallel candidate:** No — must wait for slices 1 and 3
+- **User stories:** 1, 3, 6, 7, 11, 18
+
+**Summary:** Make PlanLifecycleService the single owner of create/generate/retry/regenerate. Legacy orchestration becomes thin adapters or is removed. PDF flows consistent.
+
+**Acceptance criteria:**
+
+- [ ] PlanLifecycleService owns create, generate, retry, and regenerate for all entry points
+- [ ] Legacy orchestration paths are thin adapters delegating to the lifecycle service, or removed
+- [ ] PDF plan flows use the same lifecycle boundary as non-PDF flows
+- [ ] Failed generations end in a clear, consistent, user-visible state
+- [ ] One lifecycle record exists per generation attempt (inspectable by support)
+- [ ] Tests cover lifecycle consistency across stream, retry, regeneration, and PDF paths
+
+---
+
+## Phase 2: Pre-Launch Hardening
+
+> Slice 8 has no blockers and can start **in parallel with Phase 1 work**.
+> Slices 5, 6, and 7 all depend on slice 4 and can run **in parallel with each other** once slice 4 is done.
+
+### 5. Status Delivery Cost Reduction — [#289](https://github.com/saldanaj97/atlaris/issues/289)
+
+- **Blocked by:** [#288](https://github.com/saldanaj97/atlaris/issues/288) (Lifecycle Ownership Consolidation)
+- **Parallel candidate:** Yes — can run in parallel with slices 6 and 7 once slice 4 is done
+- **User stories:** 5, 14, 22
+
+**Summary:** Replace hot polling with event-driven or backoff/jitter strategy. Add simplified read model for status.
+
+**Acceptance criteria:**
+
+- [ ] Status delivery no longer depends on an aggressive fixed-interval polling loop
+- [ ] A simplified read model or event-driven mechanism serves status updates
+- [ ] Backoff and jitter are applied if polling is retained
+- [ ] Status contract is documented and stable across pending, ready, failed, and retryable states
+- [ ] Tests cover status behavior for each state without depending on polling internals
+
+---
+
+### 6. Retry & Idempotency Policy Centralization — [#290](https://github.com/saldanaj97/atlaris/issues/290)
+
+- **Blocked by:** [#288](https://github.com/saldanaj97/atlaris/issues/288) (Lifecycle Ownership Consolidation)
+- **Parallel candidate:** Yes — can run in parallel with slices 5 and 7 once slice 4 is done
+- **User stories:** 3, 9, 16, 20
+
+**Summary:** Define single retry owner across provider calls, lifecycle attempts, and queued jobs. Bounded retry semantics. Duplicate submission handling.
+
+**Acceptance criteria:**
+
+- [ ] One module/service owns retry policy for all generation paths
+- [ ] Retry counts are bounded and intentional (no accidental multiplication)
+- [ ] Duplicate submissions are detected and handled consistently
+- [ ] Abandoned requests are cleaned up without consuming budget
+- [ ] Tests cover duplicate handling, abandoned-request behavior, and bounded retry semantics
+
+---
+
+### 7. Request-Time DB Boundary Cleanup — [#291](https://github.com/saldanaj97/atlaris/issues/291)
+
+- **Blocked by:** [#288](https://github.com/saldanaj97/atlaris/issues/288) (Lifecycle Ownership Consolidation)
+- **Parallel candidate:** Yes — can run in parallel with slices 5 and 6 once slice 4 is done
+- **User stories:** 14, 21
+
+**Summary:** Tighten DB contexts in generation flow. Explicit roles for any remaining multi-context paths.
+
+**Acceptance criteria:**
+
+- [ ] Generation flow opens only the minimum required database contexts
+- [ ] Any remaining multi-context paths have documented, explicit roles
+- [ ] Request-scoped vs worker-scoped DB boundaries are clearly separated
+- [ ] No unnecessary extra DB connections are opened per request
+- [ ] Tests verify DB boundary behavior is correct and observable
+
+---
+
+### 8. Observability Volume Tuning — [#292](https://github.com/saldanaj97/atlaris/issues/292)
+
+- **Blocked by:** None — can start immediately
+- **Parallel candidate:** Yes — can run in parallel with any Phase 1 or Phase 2 work
+- **User stories:** 15
+
+**Summary:** Reduce Sentry replay/trace/log defaults. Keep exception reporting and high-value traces. Match expected launch traffic.
+
+**Acceptance criteria:**
+
+- [x] Sentry replay sample rate is reduced to a launch-appropriate level
+- [x] Trace sampling is tuned: high-value traces kept, low-value traces reduced
+- [x] Log-shipping volume is reduced without losing critical failure signals
+- [x] High-severity exceptions and errors are still captured reliably
+- [x] Environment-based sampling decisions are testable and documented
+
+---
+
+## Phase 3: Post-Launch Cleanup
+
+> Both slices can start after launch. Slice 9 has no blockers. Slice 10 depends on slice 4.
+
+### 9. Read-Path Optimization & Subscription Caching — [#293](https://github.com/saldanaj97/atlaris/issues/293)
+
+- **Blocked by:** None (post-launch)
+- **Parallel candidate:** Yes — can run in parallel with slice 10
+- **User stories:** 14, 17
+
+**Summary:** Add pagination defaults, lighter-weight plan summaries. Serve subscription status from local webhook-synced state.
+
+**Acceptance criteria:**
+
+- [ ] Plan-list endpoints return paginated results by default
+- [ ] Lightweight plan summaries are used for list views (not full plan objects)
+- [ ] Subscription status is served from webhook-synced local state
+- [ ] Live provider reads are only used for repair/admin/fallback, not default reads
+- [ ] Tests cover pagination defaults, summary contracts, and billing-status fallback behavior
+
+---
+
+### 10. Persistence Simplification & Queue Consolidation — [#294](https://github.com/saldanaj97/atlaris/issues/294)
+
+- **Blocked by:** [#288](https://github.com/saldanaj97/atlaris/issues/288) (Lifecycle Ownership Consolidation) — post-launch
+- **Parallel candidate:** Yes — can run in parallel with slice 9
+- **User stories:** 18, 21, 26
+
+**Summary:** Deeper persistence refactoring for generation/attempt state. Simplify background job paths.
+
+**Acceptance criteria:**
+
+- [ ] Generation/attempt persistence is simplified (fewer tables or cleaner state machine)
+- [ ] Background job paths are consolidated where possible
+- [ ] Remaining technical debt is explicitly documented as deferred with rationale
+- [ ] No regression in generation correctness or lifecycle behavior
+- [ ] Tests cover any persistence changes and verify no behavioral regressions
+
+---

--- a/prds/launch-readiness-audit/todos.md
+++ b/prds/launch-readiness-audit/todos.md
@@ -68,11 +68,11 @@ Post-launch (parallel):
 
 **Acceptance criteria:**
 
-- [ ] Cost calculation lives in exactly one module/function
-- [ ] Cost is derived deterministically from the canonical usage model
-- [ ] Output-token ceilings are defined per model and enforced at the provider call boundary
-- [ ] Token limits are enforced consistently across all user tiers
-- [ ] Tests cover cost calculation determinism, ceiling enforcement, and tier consistency
+- [x] Cost calculation lives in exactly one module/function
+- [x] Cost is derived deterministically from the canonical usage model
+- [x] Output-token ceilings are defined per model and enforced at the provider call boundary
+- [x] Token limits are enforced consistently across all user tiers
+- [x] Tests cover cost calculation determinism, ceiling enforcement, and tier consistency
 
 ---
 

--- a/prds/launch-readiness-audit/todos.md
+++ b/prds/launch-readiness-audit/todos.md
@@ -104,12 +104,12 @@ Post-launch (parallel):
 
 **Acceptance criteria:**
 
-- [ ] PlanLifecycleService owns create, generate, retry, and regenerate for all entry points
-- [ ] Legacy orchestration paths are thin adapters delegating to the lifecycle service, or removed
-- [ ] PDF plan flows use the same lifecycle boundary as non-PDF flows
-- [ ] Failed generations end in a clear, consistent, user-visible state
-- [ ] One lifecycle record exists per generation attempt (inspectable by support)
-- [ ] Tests cover lifecycle consistency across stream, retry, regeneration, and PDF paths
+- [x] PlanLifecycleService owns create, generate, retry, and regenerate for all entry points
+- [x] Legacy orchestration paths are thin adapters delegating to the lifecycle service, or removed
+- [x] PDF plan flows use the same lifecycle boundary as non-PDF flows
+- [x] Failed generations end in a clear, consistent, user-visible state
+- [x] One lifecycle record exists per generation attempt (inspectable by support)
+- [x] Tests cover lifecycle consistency across stream, retry, regeneration, and PDF paths
 
 ---
 

--- a/prds/retry-idempotency-centralization/todos.md
+++ b/prds/retry-idempotency-centralization/todos.md
@@ -1,0 +1,12 @@
+# Slice 6: Retry & Idempotency Policy Centralization (#290)
+
+## Tasks
+
+- [x] Create `src/shared/constants/retry-policy.ts` + `src/features/plans/retry-policy.ts` — centralized retry policy
+- [x] Fix `computeShouldRetry` bug in `src/lib/db/queries/jobs.ts` (CRITICAL)
+- [x] Wire retry policy into regeneration worker (logging)
+- [x] Wire provider retry config from centralized policy
+- [x] Create `src/features/plans/cleanup.ts` — abandoned request cleanup
+- [x] Write tests for retry-policy (17 tests)
+- [x] Write tests for cleanup (8 tests)
+- [x] Validate (lint ✓, type-check ✓, 200 tests pass ✓)

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -5,11 +5,14 @@
 
 import * as Sentry from '@sentry/nextjs';
 
+import { shouldEnableLogs, tracesSampler } from '@/lib/observability/sampling';
+
 Sentry.init({
   dsn: 'https://443a1b04060b39f8cb7665becc8d21d6@o4510462002462720.ingest.us.sentry.io/4510462272667648',
 
-  // Sample 10% of traces — 100% is wasteful pre-launch. Increase when you have real traffic.
-  tracesSampleRate: 0.1,
+  // Context-aware trace sampling — see src/lib/observability/sampling.ts for
+  // per-route rates and rationale.
+  tracesSampler,
 
   // Vercel AI integration (required for Edge - not enabled by default)
   integrations: (defaultIntegrations) => [
@@ -17,8 +20,9 @@ Sentry.init({
     Sentry.vercelAIIntegration(),
   ],
 
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
+  // SDK log shipping — disabled in production to reduce ingest volume.
+  // Errors are still captured via captureException.
+  enableLogs: shouldEnableLogs(),
 
   // Enable sending user PII (Personally Identifiable Information)
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -4,16 +4,21 @@
 
 import * as Sentry from '@sentry/nextjs';
 
+import { shouldEnableLogs, tracesSampler } from '@/lib/observability/sampling';
+
 Sentry.init({
   dsn: 'https://443a1b04060b39f8cb7665becc8d21d6@o4510462002462720.ingest.us.sentry.io/4510462272667648',
 
-  // Sample 10% of traces — 100% is wasteful pre-launch. Increase when you have real traffic.
-  tracesSampleRate: 0.1,
+  // Context-aware trace sampling — see src/lib/observability/sampling.ts for
+  // per-route rates and rationale.
+  tracesSampler,
 
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
+  // SDK log shipping — disabled in production to reduce ingest volume.
+  // Errors are still captured via captureException.
+  enableLogs: shouldEnableLogs(),
 
-  // Forward Pino logs to Sentry (pino is used in @/lib/logging/logger)
+  // Forward Pino logs to Sentry (pino is used in @/lib/logging/logger).
+  // Volume is controlled by pino's logger level (info in prod, debug in dev).
   // Vercel AI integration for micro-explanations (generateObject) + force for Vercel builds
   integrations: (defaultIntegrations) => [
     ...defaultIntegrations,

--- a/src/app/api/v1/plans/[planId]/retry/route.ts
+++ b/src/app/api/v1/plans/[planId]/retry/route.ts
@@ -122,7 +122,6 @@ export function createRetryHandler(deps?: {
 
         const lifecycleService = createPlanLifecycleService({
           dbClient: db,
-          attemptsDbClient: db,
           jobQueue: noopJobQueue,
         });
 

--- a/src/app/api/v1/plans/[planId]/retry/route.ts
+++ b/src/app/api/v1/plans/[planId]/retry/route.ts
@@ -1,48 +1,33 @@
 import {
   buildPlanStartEvent,
-  executeGenerationStream,
+  executeLifecycleGenerationStream,
   safeMarkPlanFailed,
-  withFallbackCleanup,
 } from '@/app/api/v1/plans/stream/helpers';
-import {
-  PLAN_GENERATION_LIMIT,
-  PLAN_GENERATION_WINDOW_MINUTES,
-} from '@/features/ai/generation-policy';
-import { ModelResolutionError } from '@/features/ai/model-resolution-error';
-import { resolveModelForTier } from '@/features/ai/model-resolver';
-import { runGenerationAttempt } from '@/features/ai/orchestrator';
 import {
   createEventStream,
   streamHeaders,
 } from '@/features/ai/streaming/events';
-import type {
-  GenerationInput,
-  IsoDateString,
-} from '@/features/ai/types/provider.types';
-import { resolveUserTier } from '@/features/billing/tier';
+import type { IsoDateString } from '@/features/ai/types/provider.types';
 import { parsePersistedPdfContext } from '@/features/pdf/context';
 import {
   requireOwnedPlanById,
   requirePlanIdFromRequest,
 } from '@/features/plans/api/route-context';
-import { withAuthAndRateLimit, withErrorBoundary } from '@/lib/api/auth';
+import { resolveUserTier } from '@/features/billing/tier';
 import {
-  normalizeThrownError,
-  toAttemptError,
-} from '@/lib/api/error-normalization';
-import { isFailureClassification } from '@/lib/api/error-response';
-import { AppError, RateLimitError } from '@/lib/api/errors';
+  createPlanLifecycleService,
+  type GenerationAttemptResult,
+  type JobQueuePort,
+  type ProcessGenerationInput,
+} from '@/features/plans/lifecycle';
+import { withAuthAndRateLimit, withErrorBoundary } from '@/lib/api/auth';
+import { AppError } from '@/lib/api/errors';
 import {
   checkPlanGenerationRateLimit,
   getPlanGenerationRateLimitHeaders,
 } from '@/lib/api/rate-limit';
-import {
-  finalizeAttemptFailure,
-  reserveAttemptSlot,
-} from '@/lib/db/queries/attempts';
 import { getDb } from '@/lib/db/runtime';
 import { logger } from '@/lib/logging/logger';
-import type { FailureClassification } from '@/shared/types/client.types';
 
 export const maxDuration = 60;
 
@@ -56,259 +41,171 @@ const toIsoDateString = (value: string | null): IsoDateString | undefined => {
   return ISO_DATE_PATTERN.test(value) ? (value as IsoDateString) : undefined;
 };
 
-const extractFailureClassification = (
-  error: unknown
-): FailureClassification | undefined => {
-  if (typeof error !== 'object' || error === null) {
-    return undefined;
-  }
+const RETRYABLE_STATUSES = new Set(['failed', 'pending_retry']);
 
-  const classification = (error as { classification?: unknown }).classification;
-  if (
-    typeof classification === 'string' &&
-    isFailureClassification(classification)
-  ) {
-    return classification;
-  }
-
-  return undefined;
+/** Stub JobQueuePort — retry route does not enqueue jobs. */
+const noopJobQueue: JobQueuePort = {
+  async enqueueJob() {
+    return '';
+  },
+  async completeJob() {},
+  async failJob() {},
 };
+
+/**
+ * Dependency injection interface for tests.
+ * Tests can override `processGenerationAttempt` to inject mocked generation behavior.
+ */
+export interface RetryDependencyOverrides {
+  processGenerationAttempt?: (
+    input: ProcessGenerationInput
+  ) => Promise<GenerationAttemptResult>;
+}
+
+/**
+ * Creates the retry POST handler with optional dependency overrides.
+ * Used by integration tests to supply mocks; production uses the default lifecycle service.
+ */
+export function createRetryHandler(deps?: {
+  overrides?: RetryDependencyOverrides;
+}) {
+  return withErrorBoundary(
+    withAuthAndRateLimit(
+      'aiGeneration',
+      async ({ req, user }): Promise<Response> => {
+        const planId = requirePlanIdFromRequest(req, 'second-to-last');
+
+        const db = getDb();
+        const rateLimit = await checkPlanGenerationRateLimit(user.id, db);
+        const generationRateLimitHeaders =
+          getPlanGenerationRateLimitHeaders(rateLimit);
+
+        const plan = await requireOwnedPlanById({
+          planId,
+          ownerUserId: user.id,
+          dbClient: db,
+        });
+
+        // Pre-flight: reject non-retryable plan statuses with a clear HTTP error
+        if (!RETRYABLE_STATUSES.has(plan.generationStatus ?? '')) {
+          throw new AppError(
+            "Plan is not eligible for retry. Only plans in 'failed' or 'pending_retry' may be retried.",
+            {
+              status: 400,
+              code: 'VALIDATION_ERROR',
+              classification: 'validation',
+              headers: generationRateLimitHeaders,
+            }
+          );
+        }
+
+        // Resolve tier for ProcessGenerationInput (lifecycle service handles model selection internally)
+        const tier = await resolveUserTier(user.id, db);
+
+        const lifecycleService = createPlanLifecycleService({
+          dbClient: db,
+          attemptsDbClient: db,
+          jobQueue: noopJobQueue,
+        });
+
+        // Build generation input from existing plan data
+        const pdfContext =
+          plan.origin === 'pdf'
+            ? parsePersistedPdfContext(plan.extractedContext)
+            : null;
+
+        const generationInput: ProcessGenerationInput = {
+          planId: plan.id,
+          userId: user.id,
+          tier,
+          input: {
+            topic: plan.topic,
+            notes: undefined,
+            pdfContext,
+            skillLevel: plan.skillLevel,
+            weeklyHours: plan.weeklyHours,
+            learningStyle: plan.learningStyle,
+            startDate: toIsoDateString(plan.startDate),
+            deadlineDate: toIsoDateString(plan.deadlineDate),
+          },
+        };
+
+        // Resolve the processGeneration function (allow test override)
+        const processGeneration =
+          deps?.overrides?.processGenerationAttempt ??
+          lifecycleService.processGenerationAttempt.bind(lifecycleService);
+
+        // ─── SSE stream (lifecycle service owns attempt management) ───
+        const stream = createEventStream(
+          async (emit, _controller, streamContext) => {
+            emit(
+              buildPlanStartEvent({
+                planId,
+                input: {
+                  topic: plan.topic,
+                  skillLevel: plan.skillLevel,
+                  weeklyHours: plan.weeklyHours,
+                  learningStyle: plan.learningStyle,
+                  notes: undefined,
+                  startDate: toIsoDateString(plan.startDate) ?? undefined,
+                  deadlineDate: toIsoDateString(plan.deadlineDate) ?? undefined,
+                  visibility: 'private',
+                  origin: plan.origin ?? 'ai',
+                },
+              })
+            );
+
+            await executeLifecycleGenerationStream({
+              reqSignal: req.signal,
+              streamSignal: streamContext.signal,
+              planId: plan.id,
+              userId: user.id,
+              emit,
+              processGeneration: () => processGeneration(generationInput),
+              onUnhandledError: async (error, startedAt) => {
+                logger.error(
+                  {
+                    planId: plan.id,
+                    userId: user.id,
+                    classification: 'provider_error',
+                    durationMs: Math.max(0, Date.now() - startedAt),
+                    error:
+                      error instanceof Error
+                        ? {
+                            name: error.name,
+                            message: error.message,
+                            stack: error.stack,
+                          }
+                        : { value: String(error) },
+                  },
+                  'Unhandled exception during retry generation; marking plan failed'
+                );
+
+                await safeMarkPlanFailed(plan.id, user.id, db);
+              },
+              fallbackClassification: 'provider_error',
+            });
+          }
+        );
+
+        return new Response(stream, {
+          status: 200,
+          headers: {
+            ...streamHeaders,
+            ...generationRateLimitHeaders,
+          },
+        });
+      }
+    )
+  );
+}
 
 /**
  * POST /api/v1/plans/:planId/retry
  *
  * Retries generation for a failed plan. Returns a streaming response.
- * Attempt cap, failed-state requirement, and in-progress checks are enforced
- * atomically inside reserveAttemptSlot before streaming starts.
+ * Delegates to PlanLifecycleService for attempt management, generation,
+ * failure marking, and usage recording. The route is a thin adapter that
+ * handles HTTP-level validation (ownership, plan status) and SSE streaming.
  */
-export const POST = withErrorBoundary(
-  withAuthAndRateLimit(
-    'aiGeneration',
-    async ({ req, user }): Promise<Response> => {
-      const planId = requirePlanIdFromRequest(req, 'second-to-last');
-
-      const db = getDb();
-      const rateLimit = await checkPlanGenerationRateLimit(user.id, db);
-      const generationRateLimitHeaders =
-        getPlanGenerationRateLimitHeaders(rateLimit);
-
-      const plan = await requireOwnedPlanById({
-        planId,
-        ownerUserId: user.id,
-        dbClient: db,
-      });
-
-      // Tier-gated provider resolution (retries use default model for the tier)
-      const userTier = await resolveUserTier(user.id, db);
-      const { provider } = (() => {
-        try {
-          return resolveModelForTier(userTier);
-        } catch (error) {
-          if (error instanceof ModelResolutionError) {
-            throw new AppError(error.message, {
-              status: 500,
-              code: error.code,
-              details: error.details,
-              headers: generationRateLimitHeaders,
-            });
-          }
-
-          throw error;
-        }
-      })();
-
-      // Build generation input from existing plan data
-      const generationInput = {
-        topic: plan.topic,
-        // Notes are not stored on the plan currently
-        notes: undefined,
-        pdfContext:
-          plan.origin === 'pdf'
-            ? parsePersistedPdfContext(plan.extractedContext)
-            : null,
-        skillLevel: plan.skillLevel,
-        weeklyHours: plan.weeklyHours,
-        learningStyle: plan.learningStyle,
-        startDate: toIsoDateString(plan.startDate),
-        deadlineDate: toIsoDateString(plan.deadlineDate),
-      } satisfies GenerationInput;
-
-      // Atomically reserve an attempt slot before starting the stream so we can
-      // return proper HTTP error codes for rejected attempts.
-      const reservation = await reserveAttemptSlot({
-        planId,
-        userId: user.id,
-        input: generationInput,
-        dbClient: db,
-        allowedGenerationStatuses: ['failed', 'pending_retry'],
-      });
-
-      if (!reservation.reserved) {
-        switch (reservation.reason) {
-          case 'capped':
-            throw new AppError(
-              'Maximum retry attempts reached for this plan. Please create a new plan.',
-              {
-                status: 429,
-                code: 'ATTEMPTS_CAPPED',
-                classification: 'capped',
-                headers: generationRateLimitHeaders,
-              }
-            );
-          case 'rate_limited':
-            throw new RateLimitError(
-              `Rate limit exceeded. Maximum ${PLAN_GENERATION_LIMIT} plan generation requests allowed per ${PLAN_GENERATION_WINDOW_MINUTES} minutes.`,
-              { retryAfter: reservation.retryAfter, remaining: 0 },
-              { headers: generationRateLimitHeaders }
-            );
-          case 'invalid_status':
-            throw new AppError(
-              "Plan is not eligible for retry. Only plans in 'failed' or 'pending_retry' may be retried.",
-              {
-                status: 400,
-                code: 'VALIDATION_ERROR',
-                classification: 'validation',
-                headers: generationRateLimitHeaders,
-              }
-            );
-          case 'in_progress':
-            throw new AppError(
-              'A generation is already in progress for this plan.',
-              {
-                status: 409,
-                code: 'CONFLICT',
-                classification: 'conflict',
-                headers: generationRateLimitHeaders,
-              }
-            );
-          default: {
-            const unknownReason: never = reservation.reason;
-            throw new AppError('Unexpected reservation failure reason.', {
-              status: 500,
-              code: 'UNKNOWN_RESERVATION_REASON',
-              details: { reason: String(unknownReason) },
-              headers: generationRateLimitHeaders,
-            });
-          }
-        }
-      }
-
-      let stream: ReadableStream<Uint8Array>;
-      try {
-        stream = createEventStream(async (emit, _controller, streamContext) => {
-          emit(
-            buildPlanStartEvent({
-              planId,
-              input: {
-                topic: generationInput.topic,
-                skillLevel: generationInput.skillLevel,
-                weeklyHours: generationInput.weeklyHours,
-                learningStyle: generationInput.learningStyle,
-                notes: generationInput.notes,
-                startDate: generationInput.startDate ?? undefined,
-                deadlineDate: generationInput.deadlineDate ?? undefined,
-                visibility: 'private',
-                origin: plan.origin ?? 'ai',
-              },
-            })
-          );
-
-          await executeGenerationStream({
-            reqSignal: req.signal,
-            streamSignal: streamContext.signal,
-            planId: plan.id,
-            userId: user.id,
-            dbClient: db,
-            emit,
-            runGeneration: () =>
-              runGenerationAttempt(
-                {
-                  planId: plan.id,
-                  userId: user.id,
-                  input: generationInput,
-                },
-                {
-                  provider,
-                  dbClient: db,
-                  reservation,
-                }
-              ),
-            onUnhandledError: async (attemptError, startedAt) => {
-              const normalizedAttemptError = normalizeThrownError(attemptError);
-
-              await withFallbackCleanup(
-                async () => {
-                  const classification =
-                    extractFailureClassification(attemptError) ??
-                    'provider_error';
-
-                  await finalizeAttemptFailure({
-                    attemptId: reservation.attemptId,
-                    planId: plan.id,
-                    preparation: reservation,
-                    classification,
-                    durationMs: Math.max(0, Date.now() - startedAt),
-                    error: toAttemptError(normalizedAttemptError),
-                    dbClient: db,
-                  });
-                },
-                () => safeMarkPlanFailed(plan.id, user.id, db),
-                {
-                  planId: plan.id,
-                  attemptId: reservation.attemptId,
-                  originalError: normalizedAttemptError,
-                  messageFinalize:
-                    'Failed to finalize attempt on retry error; falling back to plan-level cleanup',
-                  messageBoth:
-                    'Plan-level cleanup (safeMarkPlanFailed) failed after finalize error',
-                }
-              );
-
-              logger.error(
-                {
-                  planId: plan.id,
-                  userId: user.id,
-                  error: normalizedAttemptError,
-                  stack: normalizedAttemptError.stack,
-                },
-                'Plan retry generation failed'
-              );
-            },
-            mapUnhandledErrorToClientError: toAttemptError,
-            fallbackClassification: 'provider_error',
-          });
-        });
-      } catch (setupError) {
-        await finalizeAttemptFailure({
-          attemptId: reservation.attemptId,
-          planId: plan.id,
-          preparation: reservation,
-          classification: 'provider_error',
-          durationMs: 0,
-          error: toAttemptError(setupError),
-          dbClient: db,
-        }).catch(async (finalizeErr) => {
-          logger.error(
-            {
-              planId: plan.id,
-              attemptId: reservation.attemptId,
-              finalizeErr,
-              setupError,
-            },
-            'Failed to finalize attempt after stream setup error'
-          );
-          await safeMarkPlanFailed(plan.id, user.id, db);
-        });
-        throw setupError;
-      }
-
-      return new Response(stream, {
-        status: 200,
-        headers: {
-          ...streamHeaders,
-          ...generationRateLimitHeaders,
-        },
-      });
-    }
-  )
-);
+export const POST = createRetryHandler();

--- a/src/app/api/v1/plans/[planId]/retry/route.ts
+++ b/src/app/api/v1/plans/[planId]/retry/route.ts
@@ -9,18 +9,20 @@ import {
 } from '@/features/ai/streaming/events';
 import type { IsoDateString } from '@/features/ai/types/provider.types';
 import { parsePersistedPdfContext } from '@/features/pdf/context';
+import type { FailureClassification } from '@/shared/types/client.types';
 import {
   requireOwnedPlanById,
   requirePlanIdFromRequest,
 } from '@/features/plans/api/route-context';
 import { resolveUserTier } from '@/features/billing/tier';
-import {
-  createPlanLifecycleService,
-  type GenerationAttemptResult,
-  type JobQueuePort,
-  type ProcessGenerationInput,
+import { createPlanLifecycleService } from '@/features/plans/lifecycle';
+import type {
+  GenerationAttemptResult,
+  JobQueuePort,
+  ProcessGenerationInput,
 } from '@/features/plans/lifecycle';
 import { withAuthAndRateLimit, withErrorBoundary } from '@/lib/api/auth';
+import type { PlainHandler } from '@/lib/api/auth';
 import { AppError } from '@/lib/api/errors';
 import {
   checkPlanGenerationRateLimit,
@@ -53,6 +55,22 @@ const noopJobQueue: JobQueuePort = {
 };
 
 /**
+ * Derives a {@link FailureClassification} from an unknown thrown value.
+ * Falls back to `'provider_error'` when the error carries no recognisable classification.
+ */
+function classifyError(error: unknown): FailureClassification | 'unknown' {
+  if (error instanceof AppError) {
+    return error.classification() ?? 'provider_error';
+  }
+  if (error instanceof Error) {
+    if (error.name === 'AbortError' || error.name === 'TimeoutError') {
+      return 'timeout';
+    }
+  }
+  return 'provider_error';
+}
+
+/**
  * Dependency injection interface for tests.
  * Tests can override `processGenerationAttempt` to inject mocked generation behavior.
  */
@@ -68,7 +86,7 @@ export interface RetryDependencyOverrides {
  */
 export function createRetryHandler(deps?: {
   overrides?: RetryDependencyOverrides;
-}) {
+}): PlainHandler {
   return withErrorBoundary(
     withAuthAndRateLimit(
       'aiGeneration',
@@ -147,8 +165,8 @@ export function createRetryHandler(deps?: {
                   weeklyHours: plan.weeklyHours,
                   learningStyle: plan.learningStyle,
                   notes: undefined,
-                  startDate: toIsoDateString(plan.startDate) ?? undefined,
-                  deadlineDate: toIsoDateString(plan.deadlineDate) ?? undefined,
+                  startDate: toIsoDateString(plan.startDate),
+                  deadlineDate: toIsoDateString(plan.deadlineDate),
                   visibility: 'private',
                   origin: plan.origin ?? 'ai',
                 },
@@ -163,11 +181,12 @@ export function createRetryHandler(deps?: {
               emit,
               processGeneration: () => processGeneration(generationInput),
               onUnhandledError: async (error, startedAt) => {
+                const classification = classifyError(error);
                 logger.error(
                   {
                     planId: plan.id,
                     userId: user.id,
-                    classification: 'provider_error',
+                    classification,
                     durationMs: Math.max(0, Date.now() - startedAt),
                     error:
                       error instanceof Error

--- a/src/app/api/v1/plans/[planId]/status/route.ts
+++ b/src/app/api/v1/plans/[planId]/status/route.ts
@@ -39,14 +39,18 @@ export const GET = withErrorBoundary(
       dbClient: db,
     });
 
-    // Check if plan has modules (indicates successful generation)
-    const planModules = await db
-      .select({ id: modules.id })
-      .from(modules)
-      .where(eq(modules.planId, planId))
-      .limit(1);
-
-    const hasModules = planModules.length > 0;
+    // Only query modules when generationStatus is 'ready' — that's the only
+    // state where hasModules can change the derived status result.
+    const hasModules =
+      plan.generationStatus === 'ready'
+        ? (
+            await db
+              .select({ id: modules.id })
+              .from(modules)
+              .where(eq(modules.planId, planId))
+              .limit(1)
+          ).length > 0
+        : false;
 
     // Fetch bounded recent attempts (max retries is ATTEMPT_CAP), derive count + latest in memory.
     const recentAttempts = await db
@@ -88,14 +92,17 @@ export const GET = withErrorBoundary(
       );
     }
 
-    return json({
-      planId: plan.id,
-      status,
-      attempts,
-      latestError,
-      createdAt: plan.createdAt?.toISOString(),
-      updatedAt: plan.updatedAt?.toISOString(),
-    });
+    return json(
+      {
+        planId: plan.id,
+        status,
+        attempts,
+        latestError,
+        createdAt: plan.createdAt?.toISOString(),
+        updatedAt: plan.updatedAt?.toISOString(),
+      },
+      { headers: { 'Cache-Control': 'max-age=1, stale-while-revalidate=2' } }
+    );
   })
 );
 

--- a/src/app/api/v1/plans/route.ts
+++ b/src/app/api/v1/plans/route.ts
@@ -59,7 +59,6 @@ export const POST: PlainHandler = withErrorBoundary(
     // Delegate plan creation to PlanLifecycleService
     const lifecycleService = createPlanLifecycleService({
       dbClient: db,
-      attemptsDbClient: db,
       jobQueue: noopJobQueue,
     });
 

--- a/src/app/api/v1/plans/route.ts
+++ b/src/app/api/v1/plans/route.ts
@@ -10,6 +10,7 @@ import {
   createPlanLifecycleService,
   type JobQueuePort,
 } from '@/features/plans/lifecycle';
+import type { CreateLearningPlanInput } from '@/features/plans/validation/learningPlans.types';
 import {
   checkPlanGenerationRateLimit,
   getPlanGenerationRateLimitHeaders,
@@ -38,13 +39,10 @@ const noopJobQueue: JobQueuePort = {
 
 export const POST: PlainHandler = withErrorBoundary(
   withAuthAndRateLimit('mutation', async ({ req, userId, user }) => {
-    let body: Record<string, unknown>;
+    let body: CreateLearningPlanInput;
     try {
       const parsed: unknown = await req.json();
-      body = createLearningPlanSchema.parse(parsed) as unknown as Record<
-        string,
-        unknown
-      >;
+      body = createLearningPlanSchema.parse(parsed);
     } catch (error) {
       if (error instanceof ZodError) {
         throw new ValidationError('Invalid request body.', error.flatten());
@@ -65,43 +63,43 @@ export const POST: PlainHandler = withErrorBoundary(
       jobQueue: noopJobQueue,
     });
 
-    const typedBody = body as {
-      topic: string;
-      skillLevel: 'beginner' | 'intermediate' | 'advanced';
-      weeklyHours: number;
-      learningStyle: 'reading' | 'video' | 'practice' | 'mixed';
-      startDate?: string;
-      deadlineDate?: string;
-      origin?: string;
-      extractedContent?: unknown;
-      pdfProofToken?: string;
-      pdfExtractionHash?: string;
-    };
+    const isPdfOrigin = body.origin === 'pdf';
 
-    const isPdfOrigin = typedBody.origin === 'pdf';
+    if (isPdfOrigin) {
+      if (!body.pdfProofToken || !body.pdfExtractionHash) {
+        throw new ValidationError(
+          'pdfProofToken and pdfExtractionHash are required for PDF-based plans.',
+          {
+            pdfProofToken: body.pdfProofToken ? undefined : 'Required',
+            pdfExtractionHash: body.pdfExtractionHash ? undefined : 'Required',
+          }
+        );
+      }
+    }
+
     const createResult = isPdfOrigin
       ? await lifecycleService.createPdfPlan({
           userId: user.id,
           authUserId: userId,
-          body,
-          topic: typedBody.topic,
-          skillLevel: typedBody.skillLevel,
-          weeklyHours: typedBody.weeklyHours,
-          learningStyle: typedBody.learningStyle,
-          startDate: typedBody.startDate,
-          deadlineDate: typedBody.deadlineDate,
-          extractedContent: typedBody.extractedContent,
-          pdfProofToken: typedBody.pdfProofToken as string,
-          pdfExtractionHash: typedBody.pdfExtractionHash as string,
+          body: body as Record<string, unknown>,
+          topic: body.topic,
+          skillLevel: body.skillLevel,
+          weeklyHours: body.weeklyHours,
+          learningStyle: body.learningStyle,
+          startDate: body.startDate,
+          deadlineDate: body.deadlineDate,
+          extractedContent: body.extractedContent,
+          pdfProofToken: body.pdfProofToken!,
+          pdfExtractionHash: body.pdfExtractionHash!,
         })
       : await lifecycleService.createPlan({
           userId: user.id,
-          topic: typedBody.topic,
-          skillLevel: typedBody.skillLevel,
-          weeklyHours: typedBody.weeklyHours,
-          learningStyle: typedBody.learningStyle,
-          startDate: typedBody.startDate,
-          deadlineDate: typedBody.deadlineDate,
+          topic: body.topic,
+          skillLevel: body.skillLevel,
+          weeklyHours: body.weeklyHours,
+          learningStyle: body.learningStyle,
+          startDate: body.startDate,
+          deadlineDate: body.deadlineDate,
         });
 
     // Map lifecycle result to HTTP response
@@ -112,9 +110,9 @@ export const POST: PlainHandler = withErrorBoundary(
           {
             id: createResult.planId,
             topic: createResult.normalizedInput.topic,
-            skillLevel: typedBody.skillLevel,
-            weeklyHours: typedBody.weeklyHours,
-            learningStyle: typedBody.learningStyle,
+            skillLevel: createResult.normalizedInput.skillLevel,
+            weeklyHours: createResult.normalizedInput.weeklyHours,
+            learningStyle: createResult.normalizedInput.learningStyle,
             visibility: 'private',
             origin: isPdfOrigin ? 'pdf' : 'ai',
             createdAt: now.toISOString(),

--- a/src/app/api/v1/plans/route.ts
+++ b/src/app/api/v1/plans/route.ts
@@ -5,11 +5,11 @@ import {
   withAuthAndRateLimit,
   withErrorBoundary,
 } from '@/lib/api/auth';
-import { ValidationError } from '@/lib/api/errors';
+import { AppError, ValidationError } from '@/lib/api/errors';
 import {
-  insertPlanWithRollback,
-  preparePlanCreationPreflight,
-} from '@/features/plans/api/preflight';
+  createPlanLifecycleService,
+  type JobQueuePort,
+} from '@/features/plans/lifecycle';
 import {
   checkPlanGenerationRateLimit,
   getPlanGenerationRateLimitHeaders,
@@ -17,7 +17,6 @@ import {
 import { json } from '@/lib/api/response';
 import { getPlanSummariesForUser } from '@/lib/db/queries/plans';
 import { getDb } from '@/lib/db/runtime';
-import type { CreateLearningPlanInput } from '@/features/plans/validation/learningPlans.types';
 import { createLearningPlanSchema } from '@/features/plans/validation/learningPlans';
 
 export const GET: PlainHandler = withErrorBoundary(
@@ -28,13 +27,24 @@ export const GET: PlainHandler = withErrorBoundary(
   })
 );
 
-// Use shared validation constants to avoid duplication
+/** Stub JobQueuePort — non-streaming plan route does not enqueue jobs. */
+const noopJobQueue: JobQueuePort = {
+  async enqueueJob() {
+    return '';
+  },
+  async completeJob() {},
+  async failJob() {},
+};
 
 export const POST: PlainHandler = withErrorBoundary(
   withAuthAndRateLimit('mutation', async ({ req, userId, user }) => {
-    let body: CreateLearningPlanInput;
+    let body: Record<string, unknown>;
     try {
-      body = createLearningPlanSchema.parse(await req.json());
+      const parsed: unknown = await req.json();
+      body = createLearningPlanSchema.parse(parsed) as unknown as Record<
+        string,
+        unknown
+      >;
     } catch (error) {
       if (error instanceof ZodError) {
         throw new ValidationError('Invalid request body.', error.flatten());
@@ -48,37 +58,100 @@ export const POST: PlainHandler = withErrorBoundary(
     const generationRateLimitHeaders =
       getPlanGenerationRateLimitHeaders(rateLimit);
 
-    const preflight = await preparePlanCreationPreflight({
-      body,
-      authUserId: userId,
-      user,
+    // Delegate plan creation to PlanLifecycleService
+    const lifecycleService = createPlanLifecycleService({
       dbClient: db,
+      attemptsDbClient: db,
+      jobQueue: noopJobQueue,
     });
 
-    const created = await insertPlanWithRollback({
-      preflight,
-      dbClient: db,
-    });
+    const typedBody = body as {
+      topic: string;
+      skillLevel: 'beginner' | 'intermediate' | 'advanced';
+      weeklyHours: number;
+      learningStyle: 'reading' | 'video' | 'practice' | 'mixed';
+      startDate?: string;
+      deadlineDate?: string;
+      origin?: string;
+      extractedContent?: unknown;
+      pdfProofToken?: string;
+      pdfExtractionHash?: string;
+    };
 
-    // Build response from preflight + insert result to avoid post-insert re-fetch
-    // under RLS (same user context should see the row, but avoids dependency on
-    // visibility and gives consistent 201 semantics). Use preparedInput as the
-    // canonical source so the returned object reflects normalized/validated values.
-    const now = new Date();
-    const { preparedInput } = preflight;
-    return json(
-      {
-        id: created.id,
-        topic: preparedInput.topic,
-        skillLevel: preparedInput.skillLevel,
-        weeklyHours: preparedInput.weeklyHours,
-        learningStyle: preparedInput.learningStyle,
-        visibility: 'private',
-        origin: preparedInput.origin,
-        createdAt: now.toISOString(),
-        status: 'generating',
-      },
-      { status: 201, headers: generationRateLimitHeaders }
-    );
+    const isPdfOrigin = typedBody.origin === 'pdf';
+    const createResult = isPdfOrigin
+      ? await lifecycleService.createPdfPlan({
+          userId: user.id,
+          authUserId: userId,
+          body,
+          topic: typedBody.topic,
+          skillLevel: typedBody.skillLevel,
+          weeklyHours: typedBody.weeklyHours,
+          learningStyle: typedBody.learningStyle,
+          startDate: typedBody.startDate,
+          deadlineDate: typedBody.deadlineDate,
+          extractedContent: typedBody.extractedContent,
+          pdfProofToken: typedBody.pdfProofToken as string,
+          pdfExtractionHash: typedBody.pdfExtractionHash as string,
+        })
+      : await lifecycleService.createPlan({
+          userId: user.id,
+          topic: typedBody.topic,
+          skillLevel: typedBody.skillLevel,
+          weeklyHours: typedBody.weeklyHours,
+          learningStyle: typedBody.learningStyle,
+          startDate: typedBody.startDate,
+          deadlineDate: typedBody.deadlineDate,
+        });
+
+    // Map lifecycle result to HTTP response
+    switch (createResult.status) {
+      case 'success': {
+        const now = new Date();
+        return json(
+          {
+            id: createResult.planId,
+            topic: createResult.normalizedInput.topic,
+            skillLevel: typedBody.skillLevel,
+            weeklyHours: typedBody.weeklyHours,
+            learningStyle: typedBody.learningStyle,
+            visibility: 'private',
+            origin: isPdfOrigin ? 'pdf' : 'ai',
+            createdAt: now.toISOString(),
+            status: 'generating',
+          },
+          { status: 201, headers: generationRateLimitHeaders }
+        );
+      }
+      case 'duplicate_detected':
+        throw new AppError(
+          'A plan with this topic is already being generated. Please wait for it to complete.',
+          {
+            status: 409,
+            code: 'DUPLICATE_PLAN',
+            details: { existingPlanId: createResult.existingPlanId },
+          }
+        );
+      case 'quota_rejected':
+        throw new AppError(createResult.reason, {
+          status: 403,
+          code: 'QUOTA_EXCEEDED',
+          details: { upgradeUrl: createResult.upgradeUrl },
+        });
+      case 'permanent_failure':
+      case 'retryable_failure': {
+        const err =
+          'error' in createResult
+            ? createResult.error
+            : new Error('Plan creation failed');
+        const isRetryable = createResult.status === 'retryable_failure';
+        throw new AppError(err.message, {
+          status: isRetryable ? 503 : 400,
+          code: isRetryable
+            ? 'PLAN_CREATION_TEMPORARY_FAILURE'
+            : 'PLAN_CREATION_FAILED',
+        });
+      }
+    }
   })
 );

--- a/src/app/api/v1/plans/stream/helpers.ts
+++ b/src/app/api/v1/plans/stream/helpers.ts
@@ -1,4 +1,3 @@
-import { getModelById } from '@/features/ai/ai-models';
 import { isRetryableClassification } from '@/features/ai/failures';
 import {
   sanitizeSseError,
@@ -11,6 +10,7 @@ import type { StreamingEvent } from '@/features/ai/types/streaming.types';
 import type { GenerationAttemptResult } from '@/features/plans/lifecycle/types';
 import { incrementUsage } from '@/features/billing/usage-metrics';
 import { getCorrelationId } from '@/lib/api/context';
+import { safeNormalizeUsage } from '@/features/ai/usage';
 import type { AttemptsDbClient } from '@/lib/db/queries/types/attempts.types';
 import { getDb } from '@/lib/db/runtime';
 import { recordUsage } from '@/lib/db/usage';
@@ -277,37 +277,13 @@ export function buildPlanStartEvent({
 }
 
 /**
- * Attempts to record usage information from generation metadata. Errors are logged but do not throw.
+ * Attempts to record usage information from generation metadata.
+ * Normalizes raw provider metadata into canonical usage shape.
+ * Errors are logged but do not throw.
  *
  * @param userId - ID of the user to associate usage with
  * @param result - GenerationResult containing metadata and usage information
  */
-function computeCostCents(
-  modelId: string,
-  inputTokens: number,
-  outputTokens: number
-): number {
-  const model = getModelById(modelId);
-  if (!model) {
-    logger.warn(
-      {
-        modelId,
-        inputTokens,
-        outputTokens,
-        source: 'computeCostCents',
-        lookup: 'getModelById',
-      },
-      'computeCostCents: getModelById returned null for unknown/misconfigured modelId, returning 0'
-    );
-    return 0;
-  }
-  if (inputTokens === 0 && outputTokens === 0) return 0;
-  const totalUsd =
-    (inputTokens / 1_000_000) * model.inputCostPerMillion +
-    (outputTokens / 1_000_000) * model.outputCostPerMillion;
-  return Math.round(totalUsd * 100);
-}
-
 export async function tryRecordUsage(
   userId: string,
   result: GenerationResult,
@@ -317,26 +293,17 @@ export async function tryRecordUsage(
   try {
     const usageRecorder = deps?.recordUsage ?? recordUsage;
     const usageIncrementer = deps?.incrementUsage ?? incrementUsage;
-    const usage = result.metadata?.usage;
-    const modelId = result.metadata?.model ?? 'unknown';
-    const inputTokens = usage?.promptTokens;
-    const outputTokens = usage?.completionTokens;
-    const costCents =
-      modelId !== 'unknown' &&
-      typeof inputTokens === 'number' &&
-      typeof outputTokens === 'number'
-        ? computeCostCents(modelId, inputTokens, outputTokens)
-        : 0;
+
+    const canonical = safeNormalizeUsage(result.metadata);
 
     await usageRecorder(
       {
         userId,
-        provider: result.metadata?.provider ?? 'unknown',
-        model: modelId,
-        inputTokens,
-        outputTokens,
-        costCents,
-        kind: 'plan',
+        provider: canonical.provider,
+        model: canonical.model,
+        inputTokens: canonical.inputTokens,
+        outputTokens: canonical.outputTokens,
+        costCents: canonical.estimatedCostCents,
       },
       dbClient
     );

--- a/src/app/api/v1/plans/stream/route.ts
+++ b/src/app/api/v1/plans/stream/route.ts
@@ -102,7 +102,10 @@ export function createStreamHandler(deps?: {
         const generationRateLimitHeaders =
           getPlanGenerationRateLimitHeaders(rateLimit);
 
-        // ─── Plan creation via lifecycle service ─────────────────
+        // ─── Stream-scoped DB connection for ALL lifecycle operations ─────
+        // Connection 1 (db from getDb/withAuth) is only for rate limiting above.
+        // All plan creation, generation, usage recording, and success/failure marking
+        // use this stream-scoped connection that survives the entire SSE stream.
         logger.info(
           { authUserId: userId },
           'Creating plan via lifecycle service'
@@ -125,8 +128,7 @@ export function createStreamHandler(deps?: {
         };
 
         const lifecycleService = createPlanLifecycleService({
-          dbClient: db,
-          attemptsDbClient: streamDb,
+          dbClient: streamDb,
           jobQueue: noopJobQueue,
         });
 
@@ -328,7 +330,9 @@ async function createStreamDbClient(authUserId: string): Promise<{
   }
 
   const { createAuthenticatedRlsClient } = await import('@/lib/db/rls');
-  const { db, cleanup } = await createAuthenticatedRlsClient(authUserId);
+  const { db, cleanup } = await createAuthenticatedRlsClient(authUserId, {
+    idleTimeout: 180,
+  });
   return {
     dbClient: db,
     cleanup,

--- a/src/app/api/v1/plans/stream/route.ts
+++ b/src/app/api/v1/plans/stream/route.ts
@@ -94,6 +94,14 @@ export function createStreamHandler(deps?: {
         const db = getDb();
         const internalUserId = currentUser.id;
 
+        // ─── Rate limiting (generation-specific, checked BEFORE plan creation) ──
+        const rateLimit = await checkPlanGenerationRateLimit(
+          internalUserId,
+          db
+        );
+        const generationRateLimitHeaders =
+          getPlanGenerationRateLimitHeaders(rateLimit);
+
         // ─── Plan creation via lifecycle service ─────────────────
         logger.info(
           { authUserId: userId },
@@ -153,6 +161,16 @@ export function createStreamHandler(deps?: {
 
         if (createResult.status !== 'success') {
           await closeStreamDb();
+          if (createResult.status === 'duplicate_detected') {
+            throw new AppError(
+              'A plan with this topic is already being generated. Please wait for it to complete.',
+              {
+                status: 409,
+                code: 'DUPLICATE_PLAN',
+                details: { existingPlanId: createResult.existingPlanId },
+              }
+            );
+          }
           if (createResult.status === 'quota_rejected') {
             throw new AppError(createResult.reason, {
               status: 403,
@@ -182,14 +200,6 @@ export function createStreamHandler(deps?: {
           { planId, userId: internalUserId, authUserId: userId },
           'Plan created via lifecycle service'
         );
-
-        // ─── Rate limiting (generation-specific) ─────────────────
-        const rateLimit = await checkPlanGenerationRateLimit(
-          internalUserId,
-          db
-        );
-        const generationRateLimitHeaders =
-          getPlanGenerationRateLimitHeaders(rateLimit);
 
         // ─── Model override from URL params ──────────────────────
         const url = new URL(req.url);

--- a/src/features/ai/cost.ts
+++ b/src/features/ai/cost.ts
@@ -28,7 +28,8 @@ export const DEFAULT_OUTPUT_TOKEN_CEILING = 32_768;
 /**
  * Compute estimated cost in **USD cents** from model pricing and token counts.
  *
- * Returns 0 when the model is not in the registry or both counts are zero.
+ * Throws when the model is not in the registry (unknown models must not
+ * silently waive charges). Returns 0 when both counts are zero.
  * The result is deterministic: identical inputs always produce identical output.
  */
 export function computeCostCents(
@@ -49,8 +50,10 @@ export function computeCostCents(
 
   const model = getModelById(modelId);
   if (!model) {
-    logger.warn({ modelId }, 'Unknown model in computeCostCents — returning 0');
-    return 0;
+    logger.error({ modelId }, 'Unknown model in computeCostCents');
+    throw new Error(
+      `Unknown model "${modelId}" in computeCostCents — cannot determine pricing.`
+    );
   }
   if (inputTokens === 0 && outputTokens === 0) return 0;
 

--- a/src/features/ai/cost.ts
+++ b/src/features/ai/cost.ts
@@ -13,6 +13,7 @@
  */
 
 import { getModelById } from '@/features/ai/ai-models';
+import { logger } from '@/lib/logging/logger';
 import type { CanonicalAIUsage } from '@/shared/types/ai-usage.types';
 
 /**
@@ -35,8 +36,22 @@ export function computeCostCents(
   inputTokens: number,
   outputTokens: number
 ): number {
+  if (
+    !Number.isFinite(inputTokens) ||
+    !Number.isFinite(outputTokens) ||
+    inputTokens < 0 ||
+    outputTokens < 0
+  ) {
+    throw new Error(
+      `Invalid token counts: inputTokens=${inputTokens}, outputTokens=${outputTokens}. Values must be finite and >= 0.`
+    );
+  }
+
   const model = getModelById(modelId);
-  if (!model) return 0;
+  if (!model) {
+    logger.warn({ modelId }, 'Unknown model in computeCostCents — returning 0');
+    return 0;
+  }
   if (inputTokens === 0 && outputTokens === 0) return 0;
 
   const totalUsd =
@@ -69,5 +84,12 @@ export function calculateCostFromUsage(usage: CanonicalAIUsage): number {
  */
 export function getOutputTokenCeiling(modelId: string): number {
   const model = getModelById(modelId);
-  return model?.maxOutputTokens ?? DEFAULT_OUTPUT_TOKEN_CEILING;
+  if (!model) {
+    logger.warn(
+      { modelId },
+      'Unknown model in getOutputTokenCeiling — falling back to DEFAULT_OUTPUT_TOKEN_CEILING'
+    );
+    return DEFAULT_OUTPUT_TOKEN_CEILING;
+  }
+  return model.maxOutputTokens ?? DEFAULT_OUTPUT_TOKEN_CEILING;
 }

--- a/src/features/ai/cost.ts
+++ b/src/features/ai/cost.ts
@@ -1,0 +1,73 @@
+/**
+ * Centralized AI cost calculation and output-token ceilings.
+ *
+ * This is the **single source of truth** for:
+ * 1. Deterministic cost computation from model pricing and token counts.
+ * 2. Output-token ceilings per model — enforced at the provider call boundary.
+ *
+ * All persistence, billing, and provider code should import from this module.
+ * Ceilings are model-specific and tier-independent: the same model always
+ * gets the same ceiling regardless of the user's subscription tier.
+ *
+ * @module features/ai/cost
+ */
+
+import { getModelById } from '@/features/ai/ai-models';
+import type { CanonicalAIUsage } from '@/shared/types/ai-usage.types';
+
+/**
+ * Default output-token ceiling applied to models that do not declare
+ * `maxOutputTokens` (e.g., the `openrouter/free` router or unknown models).
+ *
+ * Set conservatively to prevent runaway output spend while still allowing
+ * complete structured plan generation.
+ */
+export const DEFAULT_OUTPUT_TOKEN_CEILING = 32_768;
+
+/**
+ * Compute estimated cost in **USD cents** from model pricing and token counts.
+ *
+ * Returns 0 when the model is not in the registry or both counts are zero.
+ * The result is deterministic: identical inputs always produce identical output.
+ */
+export function computeCostCents(
+  modelId: string,
+  inputTokens: number,
+  outputTokens: number
+): number {
+  const model = getModelById(modelId);
+  if (!model) return 0;
+  if (inputTokens === 0 && outputTokens === 0) return 0;
+
+  const totalUsd =
+    (inputTokens / 1_000_000) * model.inputCostPerMillion +
+    (outputTokens / 1_000_000) * model.outputCostPerMillion;
+
+  return Math.round(totalUsd * 100);
+}
+
+/**
+ * Derive cost deterministically from a {@link CanonicalAIUsage} shape.
+ *
+ * Recalculates from the model pricing registry rather than trusting the
+ * pre-computed `estimatedCostCents` field, ensuring auditability.
+ */
+export function calculateCostFromUsage(usage: CanonicalAIUsage): number {
+  return computeCostCents(usage.model, usage.inputTokens, usage.outputTokens);
+}
+
+/**
+ * Return the output-token ceiling for a given model.
+ *
+ * Uses the model's `maxOutputTokens` when defined; otherwise falls back
+ * to {@link DEFAULT_OUTPUT_TOKEN_CEILING}. The ceiling is model-specific
+ * and tier-independent — every user tier gets the same ceiling for the
+ * same model.
+ *
+ * Callers at the provider boundary pass this value as `maxTokens` to
+ * prevent unbounded output generation.
+ */
+export function getOutputTokenCeiling(modelId: string): number {
+  const model = getModelById(modelId);
+  return model?.maxOutputTokens ?? DEFAULT_OUTPUT_TOKEN_CEILING;
+}

--- a/src/features/ai/providers/openrouter.ts
+++ b/src/features/ai/providers/openrouter.ts
@@ -166,12 +166,12 @@ export class OpenRouterProvider implements AiPlanGenerationProvider {
           });
         }
 
-        // Defaulting undefined to 0 simplifies downstream handling; consumers cannot distinguish
-        // "provider reported zero" from "provider did not report usage."
+        // Initialize with undefined so downstream normalization can detect
+        // missing usage (rather than silently treating absent data as zero).
         const metadataUsage: ProviderUsage = {
-          promptTokens: 0,
-          completionTokens: 0,
-          totalTokens: 0,
+          promptTokens: undefined,
+          completionTokens: undefined,
+          totalTokens: undefined,
         };
         const isStreamingResponse = isAsyncIterable(response);
         // Streaming: when SDK returns AsyncIterable we yield chunk-by-chunk; otherwise single-chunk fallback.

--- a/src/features/ai/providers/openrouter.ts
+++ b/src/features/ai/providers/openrouter.ts
@@ -1,6 +1,7 @@
 import { OpenRouter } from '@openrouter/sdk';
 import * as Sentry from '@sentry/nextjs';
 
+import { getOutputTokenCeiling } from '@/features/ai/cost';
 import { buildSystemPrompt, buildUserPrompt } from '@/features/ai/prompts';
 import {
   ProviderError,
@@ -129,6 +130,7 @@ export class OpenRouterProvider implements AiPlanGenerationProvider {
               stream: true,
               temperature: this.temperature,
               responseFormat: { type: 'json_object' },
+              maxTokens: getOutputTokenCeiling(this.model),
             },
             requestOptions
           );

--- a/src/features/ai/providers/router.ts
+++ b/src/features/ai/providers/router.ts
@@ -1,4 +1,8 @@
-import { RETRY_BACKOFF_MS } from '@/features/ai/constants';
+import {
+  MAX_PROVIDER_RETRIES,
+  PROVIDER_RETRY_MAX_MS,
+  PROVIDER_RETRY_MIN_MS,
+} from '@/features/plans/retry-policy';
 import {
   ProviderError,
   ProviderInvalidResponseError,
@@ -152,9 +156,9 @@ export class RouterGenerationProvider implements AiPlanGenerationProvider {
       try {
         // Retry only transient provider failures.
         const result = await pRetry(() => provider.generate(input, options), {
-          retries: 1,
-          minTimeout: RETRY_BACKOFF_MS.min,
-          maxTimeout: RETRY_BACKOFF_MS.max,
+          retries: MAX_PROVIDER_RETRIES,
+          minTimeout: PROVIDER_RETRY_MIN_MS,
+          maxTimeout: PROVIDER_RETRY_MAX_MS,
           randomize: true,
           signal: options?.signal,
           onFailedAttempt: ({ error }) => {

--- a/src/features/ai/types/provider.types.ts
+++ b/src/features/ai/types/provider.types.ts
@@ -11,6 +11,9 @@ export type {
   ProviderUsage,
 } from '@/shared/types/ai-provider.types';
 
+export type { CanonicalAIUsage } from '@/shared/types/ai-usage.types';
+export { IncompleteUsageError } from '@/shared/types/ai-usage.types';
+
 export type { PdfContext };
 
 export type ProviderGenerateResult = {

--- a/src/features/ai/usage.ts
+++ b/src/features/ai/usage.ts
@@ -20,7 +20,9 @@ import * as Sentry from '@sentry/nextjs';
 
 /**
  * @deprecated Import directly from `@/features/ai/cost` instead.
- * This re-export exists only for backward compatibility and will be removed.
+ * This re-export exists only for backward compatibility and will be
+ * removed in v0.5.0 (or by 2025-09-01, whichever comes first).
+ * TODO: Create a tracking issue to remove this re-export.
  */
 export { computeCostCents } from '@/features/ai/cost';
 
@@ -52,11 +54,18 @@ export function normalizeToCanonicalUsage(
   const resolvedOutputTokens = usage?.completionTokens ?? 0;
   const resolvedTotalTokens =
     usage?.totalTokens ?? resolvedInputTokens + resolvedOutputTokens;
-  const estimatedCostCents = computeCostCents(
-    resolvedModel,
-    resolvedInputTokens,
-    resolvedOutputTokens
-  );
+  let estimatedCostCents: number;
+  try {
+    estimatedCostCents = computeCostCents(
+      resolvedModel,
+      resolvedInputTokens,
+      resolvedOutputTokens
+    );
+  } catch {
+    // Unknown models default to 0 cost here; the IncompleteUsageError
+    // thrown below already surfaces the missing/unknown model field.
+    estimatedCostCents = 0;
+  }
 
   const canonical: CanonicalAIUsage = {
     inputTokens: resolvedInputTokens,

--- a/src/features/ai/usage.ts
+++ b/src/features/ai/usage.ts
@@ -1,0 +1,127 @@
+/**
+ * Canonical AI usage normalization and cost computation.
+ *
+ * This module bridges raw provider metadata (ProviderMetadata) to the
+ * canonical usage shape (CanonicalAIUsage). All persistence and billing
+ * code should consume CanonicalAIUsage — never raw metadata fields.
+ */
+
+import { getModelById } from '@/features/ai/ai-models';
+import { logger } from '@/lib/logging/logger';
+import type { ProviderMetadata } from '@/shared/types/ai-provider.types';
+import {
+  type CanonicalAIUsage,
+  IncompleteUsageError,
+} from '@/shared/types/ai-usage.types';
+import * as Sentry from '@sentry/nextjs';
+
+/**
+ * Compute estimated cost in USD cents from model pricing and token counts.
+ * Returns 0 when the model is not in the registry or both counts are zero.
+ */
+export function computeCostCents(
+  modelId: string,
+  inputTokens: number,
+  outputTokens: number
+): number {
+  const model = getModelById(modelId);
+  if (!model) {
+    return 0;
+  }
+  if (inputTokens === 0 && outputTokens === 0) return 0;
+  const totalUsd =
+    (inputTokens / 1_000_000) * model.inputCostPerMillion +
+    (outputTokens / 1_000_000) * model.outputCostPerMillion;
+  return Math.round(totalUsd * 100);
+}
+
+/**
+ * Strictly normalize provider metadata into a CanonicalAIUsage.
+ *
+ * Throws {@link IncompleteUsageError} if any required field (provider,
+ * model, inputTokens, outputTokens) is missing or undefined. The error
+ * carries a best-effort `partialUsage` so callers can still record data
+ * after logging.
+ */
+export function normalizeToCanonicalUsage(
+  metadata: ProviderMetadata | undefined
+): CanonicalAIUsage {
+  const missingFields: string[] = [];
+
+  const provider = metadata?.provider;
+  const model = metadata?.model;
+  const usage = metadata?.usage;
+
+  if (!provider) missingFields.push('provider');
+  if (!model) missingFields.push('model');
+  if (usage?.promptTokens == null) missingFields.push('inputTokens');
+  if (usage?.completionTokens == null) missingFields.push('outputTokens');
+
+  const resolvedProvider = provider ?? 'unknown';
+  const resolvedModel = model ?? 'unknown';
+  const resolvedInputTokens = usage?.promptTokens ?? 0;
+  const resolvedOutputTokens = usage?.completionTokens ?? 0;
+  const resolvedTotalTokens =
+    usage?.totalTokens ?? resolvedInputTokens + resolvedOutputTokens;
+  const estimatedCostCents = computeCostCents(
+    resolvedModel,
+    resolvedInputTokens,
+    resolvedOutputTokens
+  );
+
+  const canonical: CanonicalAIUsage = {
+    inputTokens: resolvedInputTokens,
+    outputTokens: resolvedOutputTokens,
+    totalTokens: resolvedTotalTokens,
+    model: resolvedModel,
+    provider: resolvedProvider,
+    estimatedCostCents,
+  };
+
+  if (missingFields.length > 0) {
+    throw new IncompleteUsageError(
+      `Incomplete AI usage data: missing [${missingFields.join(', ')}] from ${resolvedProvider}/${resolvedModel}`,
+      canonical,
+      missingFields
+    );
+  }
+
+  return canonical;
+}
+
+/**
+ * Normalize provider metadata to canonical usage, logging an explicit
+ * error (never silently defaulting) when data is incomplete.
+ *
+ * Always returns a {@link CanonicalAIUsage} so downstream recording can
+ * proceed, but missing fields are surfaced via structured logs and Sentry.
+ */
+export function safeNormalizeUsage(
+  metadata: ProviderMetadata | undefined
+): CanonicalAIUsage {
+  try {
+    return normalizeToCanonicalUsage(metadata);
+  } catch (error) {
+    if (error instanceof IncompleteUsageError) {
+      logger.error(
+        {
+          source: 'canonical-usage',
+          event: 'incomplete_usage_data',
+          missingFields: error.missingFields,
+          partialUsage: error.partialUsage,
+        },
+        error.message
+      );
+      Sentry.captureException(error, {
+        level: 'warning',
+        tags: { source: 'canonical-usage' },
+        extra: {
+          missingFields: error.missingFields,
+          partialUsage: error.partialUsage,
+        },
+      });
+      return error.partialUsage;
+    }
+    throw error;
+  }
+}

--- a/src/features/ai/usage.ts
+++ b/src/features/ai/usage.ts
@@ -1,12 +1,15 @@
 /**
- * Canonical AI usage normalization and cost computation.
+ * Canonical AI usage normalization.
  *
  * This module bridges raw provider metadata (ProviderMetadata) to the
  * canonical usage shape (CanonicalAIUsage). All persistence and billing
  * code should consume CanonicalAIUsage — never raw metadata fields.
+ *
+ * Cost computation is delegated to `@/features/ai/cost` — the single
+ * source of truth for pricing and output-token ceilings.
  */
 
-import { getModelById } from '@/features/ai/ai-models';
+import { computeCostCents } from '@/features/ai/cost';
 import { logger } from '@/lib/logging/logger';
 import type { ProviderMetadata } from '@/shared/types/ai-provider.types';
 import {
@@ -15,25 +18,8 @@ import {
 } from '@/shared/types/ai-usage.types';
 import * as Sentry from '@sentry/nextjs';
 
-/**
- * Compute estimated cost in USD cents from model pricing and token counts.
- * Returns 0 when the model is not in the registry or both counts are zero.
- */
-export function computeCostCents(
-  modelId: string,
-  inputTokens: number,
-  outputTokens: number
-): number {
-  const model = getModelById(modelId);
-  if (!model) {
-    return 0;
-  }
-  if (inputTokens === 0 && outputTokens === 0) return 0;
-  const totalUsd =
-    (inputTokens / 1_000_000) * model.inputCostPerMillion +
-    (outputTokens / 1_000_000) * model.outputCostPerMillion;
-  return Math.round(totalUsd * 100);
-}
+// Re-export for backward compatibility
+export { computeCostCents } from '@/features/ai/cost';
 
 /**
  * Strictly normalize provider metadata into a CanonicalAIUsage.

--- a/src/features/ai/usage.ts
+++ b/src/features/ai/usage.ts
@@ -18,7 +18,10 @@ import {
 } from '@/shared/types/ai-usage.types';
 import * as Sentry from '@sentry/nextjs';
 
-// Re-export for backward compatibility
+/**
+ * @deprecated Import directly from `@/features/ai/cost` instead.
+ * This re-export exists only for backward compatibility and will be removed.
+ */
 export { computeCostCents } from '@/features/ai/cost';
 
 /**

--- a/src/features/jobs/regeneration-worker.ts
+++ b/src/features/jobs/regeneration-worker.ts
@@ -28,7 +28,6 @@ const noOpJobQueue: JobQueuePort = {
 
 const lifecycleService = createPlanLifecycleService({
   dbClient: db,
-  attemptsDbClient: db,
   jobQueue: noOpJobQueue,
 });
 

--- a/src/features/jobs/regeneration-worker.ts
+++ b/src/features/jobs/regeneration-worker.ts
@@ -6,6 +6,7 @@ import {
   type GenerationAttemptResult,
   type JobQueuePort,
 } from '@/features/plans/lifecycle';
+import { shouldRetryJob } from '@/features/plans/retry-policy';
 import { planRegenerationOverridesSchema } from '@/features/plans/validation/learningPlans';
 import { learningPlans } from '@/lib/db/schema';
 import { db } from '@/lib/db/service-role';
@@ -160,6 +161,19 @@ export async function processNextRegenerationJob(): Promise<ProcessRegenerationJ
       }
 
       case 'retryable_failure': {
+        const decision = shouldRetryJob({
+          attemptNumber: job.attempts + 1,
+          maxAttempts: job.maxAttempts,
+          retryable: true,
+        });
+        logger.info(
+          {
+            jobId: job.id,
+            classification: result.classification,
+            retryDecision: decision.reason,
+          },
+          'Regeneration job retryable failure — retry decision applied'
+        );
         await failJob(job.id, result.error.message, { retryable: true });
         return {
           processed: true,

--- a/src/features/plans/cleanup.ts
+++ b/src/features/plans/cleanup.ts
@@ -1,0 +1,85 @@
+import { generationAttempts, learningPlans } from '@/lib/db/schema';
+import type { DbClient } from '@/lib/db/types';
+import { logger } from '@/lib/logging/logger';
+import { and, eq, isNull, lt, sql } from 'drizzle-orm';
+
+/** Plans stuck in 'generating' longer than this are considered abandoned. */
+export const STUCK_PLAN_THRESHOLD_MS = 15 * 60 * 1000; // 15 minutes
+
+/** In-progress attempts older than this are considered orphaned. */
+export const ORPHANED_ATTEMPT_THRESHOLD_MS = 15 * 60 * 1000; // 15 minutes
+
+/**
+ * Marks plans stuck in 'generating' status for longer than the threshold as 'failed'.
+ * Uses a generous threshold (15min) to avoid marking slow-but-active generations as failed.
+ */
+export async function cleanupStuckPlans(
+  dbClient: DbClient,
+  thresholdMs: number = STUCK_PLAN_THRESHOLD_MS
+): Promise<{ cleaned: number }> {
+  const cutoff = new Date(Date.now() - thresholdMs);
+
+  const result = await dbClient
+    .update(learningPlans)
+    .set({
+      generationStatus: 'failed',
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(learningPlans.generationStatus, 'generating'),
+        lt(learningPlans.updatedAt, cutoff)
+      )
+    );
+
+  const cleaned = result.count ?? 0;
+
+  if (cleaned > 0) {
+    logger.info(
+      { source: 'cleanup', event: 'stuck_plans_cleaned', count: cleaned },
+      `Marked ${cleaned} stuck plan(s) as failed`
+    );
+  }
+
+  return { cleaned };
+}
+
+/**
+ * Finalizes orphaned 'in_progress' generation attempts older than the threshold.
+ * Sets classification to 'timeout' for attempts that were never completed.
+ */
+export async function cleanupOrphanedAttempts(
+  dbClient: DbClient,
+  thresholdMs: number = ORPHANED_ATTEMPT_THRESHOLD_MS
+): Promise<{ cleaned: number }> {
+  const cutoff = new Date(Date.now() - thresholdMs);
+
+  const result = await dbClient
+    .update(generationAttempts)
+    .set({
+      classification: 'timeout',
+      status: sql<string>`'failure'`,
+    })
+    .where(
+      and(
+        isNull(generationAttempts.classification),
+        eq(generationAttempts.status, 'in_progress'),
+        lt(generationAttempts.createdAt, cutoff)
+      )
+    );
+
+  const cleaned = result.count ?? 0;
+
+  if (cleaned > 0) {
+    logger.info(
+      {
+        source: 'cleanup',
+        event: 'orphaned_attempts_cleaned',
+        count: cleaned,
+      },
+      `Finalized ${cleaned} orphaned attempt(s)`
+    );
+  }
+
+  return { cleaned };
+}

--- a/src/features/plans/lifecycle/adapters/generation-adapter.ts
+++ b/src/features/plans/lifecycle/adapters/generation-adapter.ts
@@ -4,12 +4,15 @@
  * Wraps the AI orchestrator's `runGenerationAttempt()` function,
  * mapping between the port interface and the orchestrator's types.
  * Handles model/provider resolution internally via `resolveModelForTier()`.
+ * Normalizes raw provider metadata into CanonicalAIUsage at the boundary.
  */
 
 import { resolveModelForTier } from '@/features/ai/model-resolver';
 import { runGenerationAttempt } from '@/features/ai/orchestrator';
+import { safeNormalizeUsage } from '@/features/ai/usage';
 import type { PdfContext } from '@/features/pdf/context.types';
 import type { GenerationInput } from '@/features/ai/types/provider.types';
+import type { CanonicalAIUsage } from '@/shared/types/ai-usage.types';
 import type { AttemptsDbClient } from '@/lib/db/queries/types/attempts.types';
 
 import type { GenerationPort } from '../ports';
@@ -45,6 +48,7 @@ export class GenerationAdapter implements GenerationPort {
         status: 'success';
         modules: GeneratedModule[];
         metadata: Record<string, unknown>;
+        usage: CanonicalAIUsage;
         durationMs: number;
       }
     | {
@@ -52,6 +56,7 @@ export class GenerationAdapter implements GenerationPort {
         classification: FailureClassification;
         error: Error;
         metadata?: Record<string, unknown>;
+        usage?: CanonicalAIUsage;
         durationMs: number;
       }
   > {
@@ -91,6 +96,7 @@ export class GenerationAdapter implements GenerationPort {
         status: 'success',
         modules: result.modules as GeneratedModule[],
         metadata: result.metadata as Record<string, unknown>,
+        usage: safeNormalizeUsage(result.metadata),
         durationMs: result.durationMs,
       };
     }
@@ -100,6 +106,7 @@ export class GenerationAdapter implements GenerationPort {
       classification: result.classification,
       error: result.error,
       metadata: result.metadata as Record<string, unknown> | undefined,
+      usage: result.metadata ? safeNormalizeUsage(result.metadata) : undefined,
       durationMs: result.durationMs,
     };
   }

--- a/src/features/plans/lifecycle/adapters/generation-adapter.ts
+++ b/src/features/plans/lifecycle/adapters/generation-adapter.ts
@@ -13,7 +13,7 @@ import { safeNormalizeUsage } from '@/features/ai/usage';
 import type { PdfContext } from '@/features/pdf/context.types';
 import type { GenerationInput } from '@/features/ai/types/provider.types';
 import type { CanonicalAIUsage } from '@/shared/types/ai-usage.types';
-import type { AttemptsDbClient } from '@/lib/db/queries/types/attempts.types';
+import type { DbClient } from '@/lib/db/types';
 
 import type { GenerationPort } from '../ports';
 import type {
@@ -23,7 +23,7 @@ import type {
 } from '../types';
 
 export class GenerationAdapter implements GenerationPort {
-  constructor(private readonly dbClient: AttemptsDbClient) {}
+  constructor(private readonly dbClient: DbClient) {}
 
   async runGeneration(params: {
     planId: string;

--- a/src/features/plans/lifecycle/adapters/plan-persistence-adapter.ts
+++ b/src/features/plans/lifecycle/adapters/plan-persistence-adapter.ts
@@ -7,6 +7,7 @@
 import { PlanLimitReachedError } from '@/features/plans/errors';
 import {
   atomicCheckAndInsertPlan,
+  findRecentDuplicatePlan,
   markPlanGenerationFailure,
   markPlanGenerationSuccess,
 } from '@/features/plans/lifecycle/plan-operations';
@@ -43,6 +44,13 @@ export class PlanPersistenceAdapter implements PlanPersistencePort {
 
   async findCappedPlanWithoutModules(userId: string): Promise<string | null> {
     return findCappedPlanWithoutModules(userId, this.dbClient);
+  }
+
+  async findRecentDuplicatePlan(
+    userId: string,
+    normalizedTopic: string
+  ): Promise<string | null> {
+    return findRecentDuplicatePlan(userId, normalizedTopic, this.dbClient);
   }
 
   async markGenerationSuccess(planId: string): Promise<void> {

--- a/src/features/plans/lifecycle/adapters/usage-recording-adapter.ts
+++ b/src/features/plans/lifecycle/adapters/usage-recording-adapter.ts
@@ -3,33 +3,42 @@
  *
  * Thin wrapper around `recordUsage()` from the DB usage module.
  * Accepts CanonicalAIUsage — all normalization happens upstream.
+ *
+ * Receives an injected `dbClient` so that all DB writes go through the
+ * same connection as the rest of the lifecycle (avoiding the closed-connection bug).
  */
 
 import { incrementUsage } from '@/features/billing/usage-metrics';
 import { recordUsage } from '@/lib/db/usage';
 import { logger } from '@/lib/logging/logger';
+import type { DbClient } from '@/lib/db/types';
 import type { CanonicalAIUsage } from '@/shared/types/ai-usage.types';
 
 import type { UsageRecordingPort } from '@/features/plans/lifecycle/ports';
 
 export class UsageRecordingAdapter implements UsageRecordingPort {
+  constructor(private readonly dbClient: DbClient) {}
+
   async recordUsage(params: {
     userId: string;
     usage: CanonicalAIUsage;
     kind?: 'plan' | 'regeneration';
   }): Promise<void> {
-    await recordUsage({
-      userId: params.userId,
-      provider: params.usage.provider,
-      model: params.usage.model,
-      inputTokens: params.usage.inputTokens,
-      outputTokens: params.usage.outputTokens,
-      costCents: params.usage.estimatedCostCents,
-    });
+    await recordUsage(
+      {
+        userId: params.userId,
+        provider: params.usage.provider,
+        model: params.usage.model,
+        inputTokens: params.usage.inputTokens,
+        outputTokens: params.usage.outputTokens,
+        costCents: params.usage.estimatedCostCents,
+      },
+      this.dbClient
+    );
 
     if (params.kind) {
       try {
-        await incrementUsage(params.userId, params.kind);
+        await incrementUsage(params.userId, params.kind, this.dbClient);
       } catch (error) {
         logger.error(
           {

--- a/src/features/plans/lifecycle/adapters/usage-recording-adapter.ts
+++ b/src/features/plans/lifecycle/adapters/usage-recording-adapter.ts
@@ -2,26 +2,30 @@
  * UsageRecordingAdapter — production implementation of UsageRecordingPort.
  *
  * Thin wrapper around `recordUsage()` from the DB usage module.
+ * Accepts CanonicalAIUsage — all normalization happens upstream.
  */
 
 import { incrementUsage } from '@/features/billing/usage-metrics';
 import { recordUsage } from '@/lib/db/usage';
 import { logger } from '@/lib/logging/logger';
+import type { CanonicalAIUsage } from '@/shared/types/ai-usage.types';
 
 import type { UsageRecordingPort } from '../ports';
 
 export class UsageRecordingAdapter implements UsageRecordingPort {
   async recordUsage(params: {
     userId: string;
-    provider: string;
-    model: string;
-    inputTokens?: number | null;
-    outputTokens?: number | null;
-    costCents?: number | null;
-    requestId?: string | null;
+    usage: CanonicalAIUsage;
     kind?: 'plan' | 'regeneration';
   }): Promise<void> {
-    await recordUsage(params);
+    await recordUsage({
+      userId: params.userId,
+      provider: params.usage.provider,
+      model: params.usage.model,
+      inputTokens: params.usage.inputTokens,
+      outputTokens: params.usage.outputTokens,
+      costCents: params.usage.estimatedCostCents,
+    });
 
     if (params.kind) {
       try {

--- a/src/features/plans/lifecycle/adapters/usage-recording-adapter.ts
+++ b/src/features/plans/lifecycle/adapters/usage-recording-adapter.ts
@@ -10,7 +10,7 @@ import { recordUsage } from '@/lib/db/usage';
 import { logger } from '@/lib/logging/logger';
 import type { CanonicalAIUsage } from '@/shared/types/ai-usage.types';
 
-import type { UsageRecordingPort } from '../ports';
+import type { UsageRecordingPort } from '@/features/plans/lifecycle/ports';
 
 export class UsageRecordingAdapter implements UsageRecordingPort {
   async recordUsage(params: {

--- a/src/features/plans/lifecycle/factory.ts
+++ b/src/features/plans/lifecycle/factory.ts
@@ -1,12 +1,19 @@
 /**
  * Factory for creating a fully-wired PlanLifecycleService instance.
  *
- * Wires the QuotaAdapter, PlanPersistenceAdapter, PdfOriginAdapter,
- * GenerationAdapter, and UsageRecordingAdapter automatically.
- * The JobQueue port must be provided by the caller.
+ * Creates a PlanLifecycleService with all adapters wired to a single DB connection.
+ *
+ * Design: All lifecycle operations (plan creation, generation, usage recording,
+ * success/failure marking) use the same database connection. This prevents the
+ * "closed connection" bug where Connection 1 (request-scoped) was used for
+ * lifecycle operations after withAuth's finally block closed it.
+ *
+ * Connection scoping:
+ *   - Stream route: stream-scoped RLS connection (survives entire generation)
+ *   - Retry route: request-scoped RLS connection (synchronous with request)
+ *   - Workers: service-role connection (no RLS needed)
  */
 
-import type { AttemptsDbClient } from '@/lib/db/queries/types/attempts.types';
 import type { DbClient } from '@/lib/db/types';
 
 import { GenerationAdapter } from './adapters/generation-adapter';
@@ -19,15 +26,14 @@ import { PlanLifecycleService } from './service';
 
 export function createPlanLifecycleService(params: {
   dbClient: DbClient;
-  attemptsDbClient: AttemptsDbClient;
   jobQueue: JobQueuePort;
 }): PlanLifecycleService {
   return new PlanLifecycleService({
     planPersistence: new PlanPersistenceAdapter(params.dbClient),
     quota: new QuotaAdapter(params.dbClient),
     pdfOrigin: new PdfOriginAdapter(params.dbClient),
-    generation: new GenerationAdapter(params.attemptsDbClient),
-    usageRecording: new UsageRecordingAdapter(),
+    generation: new GenerationAdapter(params.dbClient),
+    usageRecording: new UsageRecordingAdapter(params.dbClient),
     jobQueue: params.jobQueue,
   });
 }

--- a/src/features/plans/lifecycle/index.ts
+++ b/src/features/plans/lifecycle/index.ts
@@ -27,6 +27,7 @@ export {
   atomicCheckAndInsertPlan,
   checkPlanDurationCap,
   checkPlanLimit,
+  findRecentDuplicatePlan,
   markPlanGenerationFailure,
   markPlanGenerationSuccess,
 } from './plan-operations';
@@ -40,6 +41,7 @@ export type {
   RetryableFailure,
   PermanentFailure,
   QuotaRejection,
+  DuplicateDetected,
   ProcessGenerationInput,
   GenerationAttemptResult,
   GenerationSuccess,

--- a/src/features/plans/lifecycle/plan-operations.ts
+++ b/src/features/plans/lifecycle/plan-operations.ts
@@ -8,7 +8,7 @@ import { learningPlans, users } from '@/lib/db/schema';
 import { logger } from '@/lib/logging/logger';
 import type { PdfContext } from '@/features/pdf/context.types';
 import type { DbClient } from '@/lib/db/types';
-import { eq, sql } from 'drizzle-orm';
+import { eq, sql, and, gte } from 'drizzle-orm';
 
 import { TIER_LIMITS } from '@/features/billing/tier-limits';
 import type { SubscriptionTier } from '@/features/billing/tier-limits.types';
@@ -16,6 +16,9 @@ import { resolveUserTier } from '@/features/billing/tier';
 
 import { PlanCreationError, PlanLimitReachedError } from '../errors';
 import { UserNotFoundError } from '@/features/billing/errors';
+
+/** Window (in seconds) for detecting duplicate plan submissions. */
+const DUPLICATE_DETECTION_WINDOW_SECONDS = 60;
 
 // Explicit upgrade path mapping: current tier -> recommended next tier
 const UPGRADE_PATH: Record<SubscriptionTier, SubscriptionTier> = {
@@ -245,4 +248,36 @@ export function checkPlanDurationCap(params: {
     };
   }
   return { allowed: true };
+}
+
+/**
+ * Find a recent plan with the same normalized topic for the given user.
+ * Used for duplicate/idempotent submission detection.
+ *
+ * Matches plans created within the dedup window that are still active
+ * (generating or ready), using case-insensitive topic comparison.
+ */
+export async function findRecentDuplicatePlan(
+  userId: string,
+  normalizedTopic: string,
+  dbClient: DbClient
+): Promise<string | null> {
+  const windowStart = new Date(
+    Date.now() - DUPLICATE_DETECTION_WINDOW_SECONDS * 1000
+  );
+
+  const [row] = await dbClient
+    .select({ id: learningPlans.id })
+    .from(learningPlans)
+    .where(
+      and(
+        eq(learningPlans.userId, userId),
+        sql`lower(${learningPlans.topic}) = lower(${normalizedTopic})`,
+        gte(learningPlans.createdAt, windowStart),
+        sql`${learningPlans.generationStatus} IN ('generating', 'ready')`
+      )
+    )
+    .limit(1);
+
+  return row?.id ?? null;
 }

--- a/src/features/plans/lifecycle/ports.ts
+++ b/src/features/plans/lifecycle/ports.ts
@@ -6,6 +6,8 @@
  * these interfaces — never on concrete implementations.
  */
 
+import type { CanonicalAIUsage } from '@/shared/types/ai-usage.types';
+
 import type {
   AtomicInsertResult,
   DurationCapResult,
@@ -31,6 +33,12 @@ export interface PlanPersistencePort {
 
   /** Find a plan that has exhausted generation attempts (capped without modules). */
   findCappedPlanWithoutModules(userId: string): Promise<string | null>;
+
+  /** Find a recent duplicate plan with the same normalized topic (dedup window). */
+  findRecentDuplicatePlan(
+    userId: string,
+    normalizedTopic: string
+  ): Promise<string | null>;
 
   /** Mark a plan's generation as successful. */
   markGenerationSuccess(this: void, planId: string): Promise<void>;
@@ -124,6 +132,7 @@ export interface GenerationPort {
         status: 'success';
         modules: GeneratedModule[];
         metadata: Record<string, unknown>;
+        usage: CanonicalAIUsage;
         durationMs: number;
       }
     | {
@@ -131,6 +140,7 @@ export interface GenerationPort {
         classification: FailureClassification;
         error: Error;
         metadata?: Record<string, unknown>;
+        usage?: CanonicalAIUsage;
         durationMs: number;
       }
   >;
@@ -144,12 +154,7 @@ export interface UsageRecordingPort {
     this: void,
     params: {
       userId: string;
-      provider: string;
-      model: string;
-      inputTokens?: number | null;
-      outputTokens?: number | null;
-      costCents?: number | null;
-      requestId?: string | null;
+      usage: CanonicalAIUsage;
       kind?: 'plan' | 'regeneration';
     }
   ): Promise<void>;

--- a/src/features/plans/lifecycle/ports.ts
+++ b/src/features/plans/lifecycle/ports.ts
@@ -27,15 +27,20 @@ export type { FailureClassification } from './types';
 export interface PlanPersistencePort {
   /** Atomically check plan limit and insert a new plan within a transaction. */
   atomicInsertPlan(
+    this: void,
     userId: string,
     planData: PlanInsertData
   ): Promise<AtomicInsertResult>;
 
   /** Find a plan that has exhausted generation attempts (capped without modules). */
-  findCappedPlanWithoutModules(userId: string): Promise<string | null>;
+  findCappedPlanWithoutModules(
+    this: void,
+    userId: string
+  ): Promise<string | null>;
 
   /** Find a recent duplicate plan with the same normalized topic (dedup window). */
   findRecentDuplicatePlan(
+    this: void,
     userId: string,
     normalizedTopic: string
   ): Promise<string | null>;
@@ -51,40 +56,56 @@ export interface PlanPersistencePort {
 
 export interface QuotaPort {
   /** Resolve the user's current subscription tier. */
-  resolveUserTier(userId: string): Promise<SubscriptionTier>;
+  resolveUserTier(this: void, userId: string): Promise<SubscriptionTier>;
 
   /** Check if the plan duration is within the tier's cap. */
-  checkDurationCap(params: {
-    tier: SubscriptionTier;
-    weeklyHours: number;
-    totalWeeks: number;
-  }): DurationCapResult;
+  checkDurationCap(
+    this: void,
+    params: {
+      tier: SubscriptionTier;
+      weeklyHours: number;
+      totalWeeks: number;
+    }
+  ): DurationCapResult;
 
   /** Normalize plan dates and compute total weeks based on tier constraints. */
-  normalizePlanDuration(params: {
-    tier: SubscriptionTier;
-    weeklyHours: number;
-    startDate?: string | null;
-    deadlineDate?: string | null;
-    today?: Date;
-  }): NormalizedDuration;
+  normalizePlanDuration(
+    this: void,
+    params: {
+      tier: SubscriptionTier;
+      weeklyHours: number;
+      startDate?: string | null;
+      deadlineDate?: string | null;
+      today?: Date;
+    }
+  ): NormalizedDuration;
 
   /** Reserve a PDF quota slot for PDF-origin plans. */
-  reservePdfQuota(userId: string): Promise<PdfQuotaReservationResult>;
+  reservePdfQuota(
+    this: void,
+    userId: string
+  ): Promise<PdfQuotaReservationResult>;
 
   /** Roll back a previously reserved PDF quota slot on failure. */
-  rollbackPdfQuota(userId: string, reserved: boolean): Promise<void>;
+  rollbackPdfQuota(
+    this: void,
+    userId: string,
+    reserved: boolean
+  ): Promise<void>;
 }
 
 // ─── PdfOriginPort ───────────────────────────────────────────────
 
 export interface PdfOriginPort {
   /** Verify PDF proof token and prepare plan input from extracted PDF context. */
-  preparePlanInput(params: {
-    body: Record<string, unknown>;
-    authUserId: string;
-    internalUserId: string;
-  }): Promise<{
+  preparePlanInput(
+    this: void,
+    params: {
+      body: Record<string, unknown>;
+      authUserId: string;
+      internalUserId: string;
+    }
+  ): Promise<{
     origin: 'pdf';
     extractedContext: unknown;
     topic: string;
@@ -96,10 +117,13 @@ export interface PdfOriginPort {
   }>;
 
   /** Roll back PDF usage reservation on failure. */
-  rollbackPdfUsage(params: {
-    internalUserId: string;
-    reserved: boolean;
-  }): Promise<void>;
+  rollbackPdfUsage(
+    this: void,
+    params: {
+      internalUserId: string;
+      reserved: boolean;
+    }
+  ): Promise<void>;
 }
 
 // ─── GenerationPort ──────────────────────────────────────────────
@@ -164,19 +188,27 @@ export interface UsageRecordingPort {
 
 export interface JobQueuePort {
   /** Enqueue a job for background processing. */
-  enqueueJob(params: {
-    type: string;
-    planId: string | null;
-    userId: string;
-    data: Record<string, unknown>;
-    priority?: number;
-  }): Promise<string>;
+  enqueueJob(
+    this: void,
+    params: {
+      type: string;
+      planId: string | null;
+      userId: string;
+      data: Record<string, unknown>;
+      priority?: number;
+    }
+  ): Promise<string>;
 
   /** Mark a job as completed with its result. */
-  completeJob(jobId: string, result: Record<string, unknown>): Promise<void>;
+  completeJob(
+    this: void,
+    jobId: string,
+    result: Record<string, unknown>
+  ): Promise<void>;
 
   /** Mark a job as failed with an error message. */
   failJob(
+    this: void,
     jobId: string,
     error: string,
     options?: { retryable?: boolean }

--- a/src/features/plans/lifecycle/service.ts
+++ b/src/features/plans/lifecycle/service.ts
@@ -173,6 +173,9 @@ export class PlanLifecycleService {
       tier,
       normalizedInput: {
         topic: normalizedTopic,
+        skillLevel: input.skillLevel,
+        weeklyHours: input.weeklyHours,
+        learningStyle: input.learningStyle,
         startDate: duration.startDate,
         deadlineDate: duration.deadlineDate,
       },
@@ -326,6 +329,9 @@ export class PlanLifecycleService {
         tier,
         normalizedInput: {
           topic: prepared.topic,
+          skillLevel: input.skillLevel,
+          weeklyHours: input.weeklyHours,
+          learningStyle: input.learningStyle,
           startDate: duration.startDate,
           deadlineDate: duration.deadlineDate,
           pdfContext: prepared.extractedContext as PdfContext | null,

--- a/src/features/plans/lifecycle/service.ts
+++ b/src/features/plans/lifecycle/service.ts
@@ -120,7 +120,24 @@ export class PlanLifecycleService {
 
     const normalizedTopic = input.topic.trim();
 
-    // 6. Atomic insert (checks plan limit + inserts within a single transaction)
+    // 6. Duplicate detection — return existing plan for idempotent submissions
+    const existingPlanId =
+      await this.ports.planPersistence.findRecentDuplicatePlan(
+        input.userId,
+        normalizedTopic
+      );
+    if (existingPlanId) {
+      logger.info(
+        { userId: input.userId, existingPlanId },
+        'plan.lifecycle.create: duplicate detected'
+      );
+      return {
+        status: 'duplicate_detected',
+        existingPlanId,
+      };
+    }
+
+    // 7. Atomic insert (checks plan limit + inserts within a single transaction)
     const insertResult = await this.ports.planPersistence.atomicInsertPlan(
       input.userId,
       {
@@ -239,7 +256,25 @@ export class PlanLifecycleService {
       };
     }
 
-    // 6. Reserve PDF quota + verify proof via PdfOriginPort
+    // 6. Duplicate detection — return existing plan for idempotent submissions
+    const normalizedTopic = input.topic.trim();
+    const existingPlanId =
+      await this.ports.planPersistence.findRecentDuplicatePlan(
+        input.userId,
+        normalizedTopic
+      );
+    if (existingPlanId) {
+      logger.info(
+        { userId: input.userId, existingPlanId },
+        'plan.lifecycle.create_pdf: duplicate detected'
+      );
+      return {
+        status: 'duplicate_detected',
+        existingPlanId,
+      };
+    }
+
+    // 7. Reserve PDF quota + verify proof via PdfOriginPort
     const prepared = await this.ports.pdfOrigin.preparePlanInput({
       body: input.body,
       authUserId: input.authUserId,
@@ -250,7 +285,7 @@ export class PlanLifecycleService {
       'plan.lifecycle.create_pdf: pdf quota reserved'
     );
 
-    // 7. Atomic insert — rollback PDF quota on any failure after reservation
+    // 8. Atomic insert — rollback PDF quota on any failure after reservation
     let succeeded = false;
     try {
       const insertResult = await this.ports.planPersistence.atomicInsertPlan(
@@ -343,19 +378,9 @@ export class PlanLifecycleService {
     if (generationResult.status === 'success') {
       await this.ports.planPersistence.markGenerationSuccess(input.planId);
 
-      // Extract usage from metadata for recording
-      const metadata = generationResult.metadata;
       await this.ports.usageRecording.recordUsage({
         userId: input.userId,
-        provider: (metadata.provider as string) ?? 'unknown',
-        model: (metadata.model as string) ?? 'unknown',
-        inputTokens: (metadata.usage as Record<string, unknown>)
-          ?.inputTokens as number | undefined,
-        outputTokens: (metadata.usage as Record<string, unknown>)
-          ?.outputTokens as number | undefined,
-        costCents: (metadata.usage as Record<string, unknown>)?.costCents as
-          | number
-          | undefined,
+        usage: generationResult.usage,
         kind: 'plan',
       });
 
@@ -393,22 +418,14 @@ export class PlanLifecycleService {
       };
     }
 
-    // Permanent failure — record usage (attempt consumed)
-    const metadata = generationResult.metadata;
-    await this.ports.usageRecording.recordUsage({
-      userId: input.userId,
-      provider: (metadata?.provider as string) ?? 'unknown',
-      model: (metadata?.model as string) ?? 'unknown',
-      inputTokens: (metadata?.usage as Record<string, unknown>)?.inputTokens as
-        | number
-        | undefined,
-      outputTokens: (metadata?.usage as Record<string, unknown>)
-        ?.outputTokens as number | undefined,
-      costCents: (metadata?.usage as Record<string, unknown>)?.costCents as
-        | number
-        | undefined,
-      kind: 'plan',
-    });
+    // Permanent failure — record usage if available (attempt consumed)
+    if (generationResult.usage) {
+      await this.ports.usageRecording.recordUsage({
+        userId: input.userId,
+        usage: generationResult.usage,
+        kind: 'plan',
+      });
+    }
 
     logger.warn(
       { planId: input.planId, classification },

--- a/src/features/plans/lifecycle/types.ts
+++ b/src/features/plans/lifecycle/types.ts
@@ -123,6 +123,12 @@ export type QuotaRejection = {
   readonly upgradeUrl?: string;
 };
 
+/** A duplicate plan was detected (idempotent return). */
+export type DuplicateDetected = {
+  readonly status: 'duplicate_detected';
+  readonly existingPlanId: string;
+};
+
 /**
  * Discriminated union of all possible outcomes from plan creation.
  * The service never throws for these expected lifecycle outcomes.
@@ -131,7 +137,8 @@ export type CreatePlanResult =
   | CreatePlanSuccess
   | RetryableFailure
   | PermanentFailure
-  | QuotaRejection;
+  | QuotaRejection
+  | DuplicateDetected;
 
 // ─── Generated module types ──────────────────────────────────────
 

--- a/src/features/plans/lifecycle/types.ts
+++ b/src/features/plans/lifecycle/types.ts
@@ -94,6 +94,9 @@ export type CreatePlanSuccess = {
   /** Normalized values produced during creation — used by the route for generation input. */
   readonly normalizedInput: {
     readonly topic: string;
+    readonly skillLevel: 'beginner' | 'intermediate' | 'advanced';
+    readonly weeklyHours: number;
+    readonly learningStyle: 'reading' | 'video' | 'practice' | 'mixed';
     readonly startDate: string | null;
     readonly deadlineDate: string | null;
     readonly pdfContext?: PdfContext | null;

--- a/src/features/plans/retry-policy.ts
+++ b/src/features/plans/retry-policy.ts
@@ -1,0 +1,78 @@
+/**
+ * Centralized retry policy for plan generation.
+ *
+ * Constants live in @/shared/constants/retry-policy so both lib/ and features/
+ * layers can import them. This module re-exports them and adds decision functions.
+ */
+export {
+  JOB_RETRY_BASE_SECONDS,
+  JOB_RETRY_MAX_DELAY_SECONDS,
+  MAX_JOB_RETRIES,
+  MAX_PROVIDER_RETRIES,
+  MAX_TOTAL_AI_CALLS_PER_JOB,
+  PROVIDER_RETRY_MAX_MS,
+  PROVIDER_RETRY_MIN_MS,
+} from '@/shared/constants/retry-policy';
+
+import {
+  JOB_RETRY_BASE_SECONDS,
+  JOB_RETRY_MAX_DELAY_SECONDS,
+} from '@/shared/constants/retry-policy';
+
+export interface RetryDecision {
+  shouldRetry: boolean;
+  delay?: number; // ms
+  reason: string;
+}
+
+/**
+ * Determines whether a job should be retried based on its attempt count
+ * and the classification of the failure.
+ */
+export function shouldRetryJob(params: {
+  attemptNumber: number; // current attempt (1-based)
+  maxAttempts: number; // configured max for this job
+  retryable: boolean; // whether the failure is classified as retryable
+}): RetryDecision {
+  if (!params.retryable) {
+    return { shouldRetry: false, reason: 'Permanent failure — not retryable' };
+  }
+  if (params.attemptNumber >= params.maxAttempts) {
+    return {
+      shouldRetry: false,
+      reason: `Attempt cap reached (${params.attemptNumber}/${params.maxAttempts})`,
+    };
+  }
+  const delay = getRetryDelay(params.attemptNumber);
+  return {
+    shouldRetry: true,
+    delay,
+    reason: `Retryable — attempt ${params.attemptNumber}/${params.maxAttempts}`,
+  };
+}
+
+/**
+ * Computes exponential backoff delay for job retries.
+ */
+export function getRetryDelay(attemptNumber: number): number {
+  const delaySeconds = Math.min(
+    JOB_RETRY_MAX_DELAY_SECONDS,
+    Math.pow(JOB_RETRY_BASE_SECONDS, attemptNumber)
+  );
+  return delaySeconds * 1000;
+}
+
+/**
+ * Computes the effective max attempts, replacing the dangerous
+ * ABSOLUTE_MAX_ATTEMPTS fallback with bounded semantics.
+ *
+ * Previously: retryable=true → ABSOLUTE_MAX_ATTEMPTS(100)
+ * Now: retryable=true → baseMax (default MAX_JOB_RETRIES)
+ */
+export function computeEffectiveMaxAttempts(
+  baseMax: number,
+  retryableOverride?: boolean
+): number {
+  if (retryableOverride === false) return 0; // No retries
+  return baseMax;
+}

--- a/src/features/plans/status.ts
+++ b/src/features/plans/status.ts
@@ -1,6 +1,22 @@
 import type { PlanStatus } from '@/shared/types/client.types';
 import type { GenerationStatus } from '@/shared/types/db.types';
 
+/**
+ * Derives the client-facing plan status from database state.
+ *
+ * State machine:
+ *   pending    → plan created, generation not started or between retries
+ *   processing → actively generating or pending retry
+ *   ready      → generation succeeded (modules exist)
+ *   failed     → generation permanently failed or attempt cap exhausted
+ *
+ * Priority rules:
+ *   1. hasModules        → always 'ready' (modules are the ground truth)
+ *   2. status 'failed'   → 'failed'
+ *   3. status 'generating' | 'pending_retry' → 'processing'
+ *   4. attemptsCount ≥ attemptCap            → 'failed' (exhausted)
+ *   5. Default           → 'pending'
+ */
 export function derivePlanStatus(params: {
   generationStatus: GenerationStatus;
   hasModules: boolean;

--- a/src/hooks/usePlanStatus.ts
+++ b/src/hooks/usePlanStatus.ts
@@ -2,6 +2,7 @@
 
 import { parseApiErrorResponse } from '@/lib/api/error-response';
 import { clientLogger } from '@/lib/logging/client';
+import { computeNextDelay, INITIAL_POLL_MS } from '@/shared/constants/polling';
 import { PLAN_STATUSES } from '@/shared/types/client';
 import type { PlanStatus } from '@/shared/types/client.types';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -61,6 +62,9 @@ export function usePlanStatus(
   const [pollingError, setPollingError] = useState<string | null>(null);
   const [isPolling, setIsPolling] = useState(false);
   const consecutiveFailuresRef = useRef(0);
+  const previousStatusRef = useRef<PlanStatus>(initialStatus);
+  const delayRef = useRef(INITIAL_POLL_MS);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const previousPlanIdRef = useRef(planId);
   // Track latest initialStatus without making planId-reset effect depend on it.
   // This prevents a spurious full reset when initialStatus changes on the same plan.
@@ -95,6 +99,7 @@ export function usePlanStatus(
 
       const data = parseResult.data;
 
+      previousStatusRef.current = data.status;
       setStatus(data.status);
       setAttempts(data.attempts);
 
@@ -157,15 +162,43 @@ export function usePlanStatus(
     }
 
     setIsPolling(true);
-    void fetchStatus();
+    delayRef.current = INITIAL_POLL_MS;
 
-    // Then poll every 3 seconds
-    const pollInterval = setInterval(() => {
-      void fetchStatus();
-    }, 3000);
+    let cancelled = false;
+
+    const schedulePoll = () => {
+      if (cancelled) return;
+      timeoutRef.current = setTimeout(() => {
+        if (cancelled) return;
+        const prevStatus = previousStatusRef.current;
+        void fetchStatus().then(() => {
+          if (cancelled) return;
+          // Reset backoff when a status transition occurs
+          if (previousStatusRef.current !== prevStatus) {
+            delayRef.current = INITIAL_POLL_MS;
+          } else {
+            delayRef.current = computeNextDelay(delayRef.current);
+          }
+          schedulePoll();
+        });
+      }, delayRef.current);
+    };
+
+    // Fire the first poll immediately, then start the backoff loop
+    void (async () => {
+      await fetchStatus();
+      if (!cancelled) {
+        delayRef.current = computeNextDelay(delayRef.current);
+        schedulePoll();
+      }
+    })();
 
     return () => {
-      clearInterval(pollInterval);
+      cancelled = true;
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
       setIsPolling(false);
     };
   }, [shouldPoll, fetchStatus]);

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -4,6 +4,13 @@
 
 import * as Sentry from '@sentry/nextjs';
 
+import {
+  getReplayErrorSampleRate,
+  getReplaySessionSampleRate,
+  shouldEnableLogs,
+  tracesSampler,
+} from '@/lib/observability/sampling';
+
 const sendDefaultPii =
   process.env.NEXT_PUBLIC_SENTRY_SEND_DEFAULT_PII?.trim().toLowerCase() ===
   'true';
@@ -11,21 +18,19 @@ const sendDefaultPii =
 Sentry.init({
   dsn: 'https://443a1b04060b39f8cb7665becc8d21d6@o4510462002462720.ingest.us.sentry.io/4510462272667648',
 
-  // Add optional integrations for additional features
+  // Session replay — see src/lib/observability/sampling.ts for per-env rates.
   integrations: [Sentry.replayIntegration()],
 
-  // Sample 10% of traces — 100% is wasteful pre-launch. Increase when you have real traffic.
-  tracesSampleRate: 0.1,
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
+  // Context-aware trace sampling (replaces flat tracesSampleRate).
+  tracesSampler,
 
-  // Define how likely Replay events are sampled.
-  // This sets the sample rate to be 10%. You may want this to be 100% while
-  // in development and sample at a lower rate in production
-  replaysSessionSampleRate: 0.1,
+  // SDK log shipping — disabled in production to reduce ingest volume.
+  enableLogs: shouldEnableLogs(),
 
-  // Define how likely Replay events are sampled when an error occurs.
-  replaysOnErrorSampleRate: 1.0,
+  // Replay: 10 % sessions in prod (cost control), 100 % error replays (always).
+  // See src/lib/observability/sampling.ts for full rationale.
+  replaysSessionSampleRate: getReplaySessionSampleRate(),
+  replaysOnErrorSampleRate: getReplayErrorSampleRate(),
 
   // Intentionally gated: enable PII forwarding only with explicit opt-in via env.
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -11,6 +11,11 @@ import {
   tracesSampler,
 } from '@/lib/observability/sampling';
 
+// NOTE: We read `process.env` directly here instead of importing from
+// `@/lib/config/env` because that module eagerly validates server-only
+// secrets (NEON_AUTH_*, DATABASE_URL, etc.) at import time, which would
+// throw in this client-side instrumentation bundle. NEXT_PUBLIC_* vars
+// are also not exposed through the server env config.
 const sendDefaultPii =
   process.env.NEXT_PUBLIC_SENTRY_SEND_DEFAULT_PII?.trim().toLowerCase() ===
   'true';

--- a/src/lib/db/queries/jobs.ts
+++ b/src/lib/db/queries/jobs.ts
@@ -40,10 +40,10 @@ import {
  */
 
 const MAX_MONITORING_ROWS = 200;
-/** Hard cap on attempts regardless of retryable override; prevents unbounded retries. */
-const ABSOLUTE_MAX_ATTEMPTS = 100;
+import { JOB_RETRY_MAX_DELAY_SECONDS } from '@/shared/constants/retry-policy';
+
 /** Cap for exponential retry delay in seconds (5 minutes). */
-const MAX_RETRY_DELAY_SECONDS = 300;
+const MAX_RETRY_DELAY_SECONDS = JOB_RETRY_MAX_DELAY_SECONDS;
 
 const jobQueueSelect = {
   id: jobQueue.id,
@@ -98,17 +98,13 @@ async function lockJobAndCheckTerminal(
 function computeShouldRetry(
   retryable: boolean | undefined,
   nextAttempts: number,
-  maxAttempts: number,
-  absoluteMaxAttempts: number
+  maxAttempts: number
 ): boolean {
   if (retryable === false) {
     return false;
   }
 
-  if (retryable === true) {
-    return nextAttempts < absoluteMaxAttempts;
-  }
-
+  // retryable === true OR undefined: both respect maxAttempts (no ABSOLUTE_MAX bypass)
   return nextAttempts < maxAttempts;
 }
 
@@ -429,13 +425,13 @@ export async function completeJobRecord(
  * is set to failed with completedAt set.
  *
  * Retry decision: when retryable is undefined, shouldRetry follows
- * nextAttempts < current.maxAttempts. When retryable is true, it can override
- * current.maxAttempts but is bounded by ABSOLUTE_MAX_ATTEMPTS for safety.
+ * nextAttempts < current.maxAttempts. When retryable is true, it also
+ * respects current.maxAttempts (bounded by MAX_JOB_RETRIES from the retry policy).
  * When retryable is false, retry is never scheduled.
  *
  * @param jobId - Job id to fail
  * @param error - Error message to record
- * @param retryable - Optional retry override; when true, overrides maxAttempts but capped by ABSOLUTE_MAX_ATTEMPTS
+ * @param retryable - Optional retry override; when true, respects maxAttempts (no unbounded escalation)
  * @param dbClient - Database client (default: getDb())
  * @returns Updated job row as Job, or null if job not found or already terminal
  */
@@ -462,8 +458,7 @@ export async function failJobRecord(
     const shouldRetry = computeShouldRetry(
       retryable,
       nextAttempts,
-      current.maxAttempts,
-      ABSOLUTE_MAX_ATTEMPTS
+      current.maxAttempts
     );
 
     const retryDelaySeconds = Math.min(

--- a/src/lib/db/rls.ts
+++ b/src/lib/db/rls.ts
@@ -73,7 +73,8 @@ type RlsClientResult = {
  * ```
  */
 export async function createAuthenticatedRlsClient(
-  authUserId: string
+  authUserId: string,
+  options?: { idleTimeout?: number }
 ): Promise<RlsClientResult> {
   const jwtClaims = JSON.stringify({ sub: authUserId });
 
@@ -84,7 +85,7 @@ export async function createAuthenticatedRlsClient(
   const connectionUrl = databaseEnv.nonPoolingUrl || databaseEnv.url;
   const sql: Sql = postgres(connectionUrl, {
     max: 1, // Single connection per client (important for session variable isolation)
-    idle_timeout: 20, // Close idle connections after 20s
+    idle_timeout: options?.idleTimeout ?? 20, // Default 20s; stream routes use longer timeouts
     connect_timeout: 10, // Timeout for connection attempts
   });
 

--- a/src/lib/db/usage.ts
+++ b/src/lib/db/usage.ts
@@ -8,11 +8,10 @@ type RecordUsageParams = {
   userId: string;
   provider: string;
   model: string;
-  inputTokens?: number | null;
-  outputTokens?: number | null;
-  costCents?: number | null;
+  inputTokens: number;
+  outputTokens: number;
+  costCents: number;
   requestId?: string | null;
-  kind?: 'plan' | 'regeneration';
 };
 
 export async function recordUsage(
@@ -23,9 +22,9 @@ export async function recordUsage(
     userId: params.userId,
     provider: params.provider,
     model: params.model,
-    inputTokens: params.inputTokens ?? 0,
-    outputTokens: params.outputTokens ?? 0,
-    costCents: params.costCents ?? 0,
+    inputTokens: params.inputTokens,
+    outputTokens: params.outputTokens,
+    costCents: params.costCents,
     requestId: params.requestId ?? null,
   });
 }

--- a/src/lib/observability/sampling.ts
+++ b/src/lib/observability/sampling.ts
@@ -1,0 +1,142 @@
+/**
+ * Observability sampling configuration for Sentry.
+ *
+ * Tuned for launch readiness: conservative in production to reduce
+ * third-party read costs (replay storage, trace ingest, log shipping),
+ * generous in development for full debugging visibility.
+ *
+ * Sampling budget (production):
+ *   Errors/exceptions  → 100 % (always captured, non-negotiable)
+ *   Error replays      → 100 % (highest-value replay signal)
+ *   Session replays    →  10 % (enough for UX insight, caps Sentry replay cost)
+ *   API route traces   →  20 % (primary performance signal)
+ *   Default traces     →   5 % (background pages, navigations)
+ *   Health / static    →   0 % (zero diagnostic value)
+ *   SDK log shipping   → off  (pino still logs locally; errors go via captureException)
+ */
+
+// ---------------------------------------------------------------------------
+// Environment helpers
+// ---------------------------------------------------------------------------
+
+type Environment = 'production' | 'development' | 'test';
+
+/**
+ * Resolve the current runtime environment.
+ * Works on both client (inlined at build time) and server (runtime).
+ */
+export function getEnvironment(): Environment {
+  const env =
+    typeof process !== 'undefined' ? process.env.NODE_ENV : 'development';
+  if (env === 'production') return 'production';
+  if (env === 'test') return 'test';
+  return 'development';
+}
+
+// ---------------------------------------------------------------------------
+// Replay sample rates
+// ---------------------------------------------------------------------------
+
+/**
+ * Session replay sample rate (non-error sessions).
+ * Production: 10 % — sufficient for UX analysis while keeping replay costs low.
+ * Development: 100 % — full visibility for local debugging.
+ */
+export function getReplaySessionSampleRate(): number {
+  switch (getEnvironment()) {
+    case 'production':
+      return 0.1;
+    case 'development':
+      return 1.0;
+    case 'test':
+      return 0;
+  }
+}
+
+/**
+ * Error-triggered replay sample rate.
+ * Always 100 % — every error replay is high-value for root-cause analysis.
+ */
+export function getReplayErrorSampleRate(): number {
+  return 1.0;
+}
+
+// ---------------------------------------------------------------------------
+// Trace sampling
+// ---------------------------------------------------------------------------
+
+/** Patterns with zero diagnostic value — always drop in production. */
+const LOW_VALUE_PATTERNS: RegExp[] = [
+  /\/_next\//,
+  /\/favicon\.ico/,
+  /\/api\/health/,
+  /\/robots\.txt/,
+  /\/sitemap/,
+  /\.(css|js|png|jpg|jpeg|gif|svg|woff2?|ttf|eot|ico)(\?|$)/,
+];
+
+/** High-value server work — sample more aggressively. */
+const HIGH_VALUE_PATTERNS: RegExp[] = [
+  /\/api\//, // API routes (after low-value filter excludes health)
+];
+
+/**
+ * Sentry `tracesSampler` — replaces the flat `tracesSampleRate` with
+ * context-aware decisions.
+ *
+ * The function receives the sampling context from Sentry and returns a
+ * number between 0 and 1 (or boolean) indicating the probability that
+ * the trace should be recorded.
+ *
+ * Exported as a standalone pure function so it can be unit-tested without
+ * booting Sentry.
+ */
+export function tracesSampler(context: {
+  name?: string;
+  parentSampled?: boolean;
+  attributes?: Record<string, unknown>;
+}): number {
+  const env = getEnvironment();
+  const name = context.name ?? '';
+
+  // Inherit parent sampling decision for distributed traces so child
+  // spans are never orphaned from their parent.
+  if (context.parentSampled !== undefined) {
+    return context.parentSampled ? 1.0 : 0;
+  }
+
+  // Low-value: health checks, static assets, favicons.
+  if (LOW_VALUE_PATTERNS.some((p) => p.test(name))) {
+    return env === 'production' ? 0 : 0.01;
+  }
+
+  // High-value: API routes (the main performance signal).
+  if (HIGH_VALUE_PATTERNS.some((p) => p.test(name))) {
+    return env === 'production' ? 0.2 : 1.0;
+  }
+
+  // Default: page loads, navigations, background work.
+  switch (env) {
+    case 'production':
+      return 0.05;
+    case 'development':
+      return 0.5;
+    case 'test':
+      return 0;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Log shipping
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether to enable Sentry SDK log shipping (`enableLogs`).
+ *
+ * Production: disabled — reduces ingest volume. Errors are still captured
+ * via `captureException`; pino logs locally for operational tailing.
+ * Development/test: enabled for full observability during debugging.
+ */
+export function shouldEnableLogs(): boolean {
+  return getEnvironment() !== 'production';
+}

--- a/src/lib/observability/sampling.ts
+++ b/src/lib/observability/sampling.ts
@@ -24,6 +24,12 @@ type Environment = 'production' | 'development' | 'test';
 /**
  * Resolve the current runtime environment.
  * Works on both client (inlined at build time) and server (runtime).
+ *
+ * NOTE: We intentionally read `process.env.NODE_ENV` directly instead of
+ * importing from `@/lib/config/env`. That module eagerly validates
+ * server-only secrets (e.g. NEON_AUTH_*) at import time, which would
+ * throw in client bundles and Sentry edge/instrumentation configs that
+ * load before the full server environment is available.
  */
 export function getEnvironment(): Environment {
   const env =
@@ -94,7 +100,7 @@ const HIGH_VALUE_PATTERNS: RegExp[] = [
 export function tracesSampler(context: {
   name?: string;
   parentSampled?: boolean;
-  attributes?: Record<string, unknown>;
+  _attributes?: Record<string, unknown>;
 }): number {
   const env = getEnvironment();
   const name = context.name ?? '';
@@ -133,10 +139,20 @@ export function tracesSampler(context: {
 /**
  * Whether to enable Sentry SDK log shipping (`enableLogs`).
  *
+ * Override: set `SENTRY_ENABLE_LOGS=true` to force-enable log shipping in
+ * any environment (useful for ops debugging in production).
+ *
+ * Default behaviour:
  * Production: disabled — reduces ingest volume. Errors are still captured
  * via `captureException`; pino logs locally for operational tailing.
  * Development/test: enabled for full observability during debugging.
  */
 export function shouldEnableLogs(): boolean {
+  const override =
+    typeof process !== 'undefined'
+      ? process.env.SENTRY_ENABLE_LOGS?.trim().toLowerCase()
+      : undefined;
+  if (override === 'true' || override === '1') return true;
+  if (override === 'false' || override === '0') return false;
   return getEnvironment() !== 'production';
 }

--- a/src/shared/constants/polling.ts
+++ b/src/shared/constants/polling.ts
@@ -1,0 +1,32 @@
+/**
+ * Polling configuration for exponential backoff with jitter.
+ *
+ * Used by the plan-status polling hook to reduce unnecessary network
+ * and database load while keeping the UI responsive to status changes.
+ */
+
+/** Delay (ms) for the very first poll after mount. */
+export const INITIAL_POLL_MS = 1_000;
+
+/** Upper bound (ms) for any single poll delay. */
+export const MAX_POLL_MS = 10_000;
+
+/** Multiplier applied to the current delay on each successive poll. */
+export const BACKOFF_MULTIPLIER = 1.5;
+
+/** ±20 % random jitter to prevent thundering-herd synchronisation. */
+export const JITTER_FACTOR = 0.2;
+
+/**
+ * Compute the next poll delay using exponential backoff + jitter.
+ *
+ * 1. Multiply `currentDelay` by {@link BACKOFF_MULTIPLIER}.
+ * 2. Cap at {@link MAX_POLL_MS}.
+ * 3. Apply uniform random jitter in the range ±{@link JITTER_FACTOR}.
+ * 4. Clamp the result to [{@link INITIAL_POLL_MS}, {@link MAX_POLL_MS}].
+ */
+export function computeNextDelay(currentDelay: number): number {
+  const base = Math.min(currentDelay * BACKOFF_MULTIPLIER, MAX_POLL_MS);
+  const jitter = 1 + (Math.random() * 2 - 1) * JITTER_FACTOR;
+  return Math.max(INITIAL_POLL_MS, Math.min(base * jitter, MAX_POLL_MS));
+}

--- a/src/shared/constants/retry-policy.ts
+++ b/src/shared/constants/retry-policy.ts
@@ -1,0 +1,36 @@
+/**
+ * Centralized retry-policy constants for plan generation.
+ * Single source of truth for retry bounds across all generation paths.
+ *
+ * Located in shared/ so both lib/ and features/ layers can import safely.
+ *
+ * Retry layers:
+ *   1. Provider (p-retry): MAX_PROVIDER_RETRIES attempts per AI call
+ *   2. Job queue: MAX_JOB_RETRIES attempts per enqueued job
+ *   3. Per-plan: DEFAULT_ATTEMPT_CAP user-initiated retries
+ *
+ * Total AI calls per job = MAX_JOB_RETRIES × (MAX_PROVIDER_RETRIES + 1)
+ * This is bounded by MAX_TOTAL_AI_CALLS_PER_JOB.
+ */
+
+/** p-retry retries per AI call (2 total attempts including initial). */
+export const MAX_PROVIDER_RETRIES = 1;
+
+/** Max job-level retry attempts before permanent failure. */
+export const MAX_JOB_RETRIES = 3;
+
+/** Upper bound on total AI calls a single job can trigger. */
+export const MAX_TOTAL_AI_CALLS_PER_JOB =
+  MAX_JOB_RETRIES * (MAX_PROVIDER_RETRIES + 1); // = 6
+
+/** Base seconds for exponential backoff on job retries. */
+export const JOB_RETRY_BASE_SECONDS = 2;
+
+/** Cap for exponential retry delay in seconds (5 minutes). */
+export const JOB_RETRY_MAX_DELAY_SECONDS = 300;
+
+/** Minimum backoff (ms) for provider-level p-retry. */
+export const PROVIDER_RETRY_MIN_MS = 300;
+
+/** Maximum backoff (ms) for provider-level p-retry. */
+export const PROVIDER_RETRY_MAX_MS = 700;

--- a/src/shared/types/ai-usage.types.ts
+++ b/src/shared/types/ai-usage.types.ts
@@ -1,0 +1,51 @@
+/**
+ * Canonical AI usage accounting contract.
+ *
+ * This is the single source of truth for AI usage data.
+ * All providers normalize their responses into this shape.
+ * All persistence and billing code consumes only this type.
+ *
+ * Missing or incomplete usage data must raise an explicit error/alert —
+ * never silently default to zero.
+ */
+
+/**
+ * Canonical usage shape returned by all AI providers and consumed by all
+ * persistence and billing paths. Every field is required — normalization
+ * functions enforce this at the provider boundary.
+ */
+export type CanonicalAIUsage = {
+  /** Number of input/prompt tokens consumed. */
+  readonly inputTokens: number;
+  /** Number of output/completion tokens generated. */
+  readonly outputTokens: number;
+  /** Total tokens (input + output). */
+  readonly totalTokens: number;
+  /** AI model identifier (e.g., 'google/gemini-2.0-flash-exp:free'). */
+  readonly model: string;
+  /** Provider identifier (e.g., 'openrouter', 'mock'). */
+  readonly provider: string;
+  /** Estimated cost in USD cents, computed from model pricing. */
+  readonly estimatedCostCents: number;
+};
+
+/**
+ * Thrown when provider metadata is missing required usage fields.
+ * Carries partial usage so callers can still record best-effort data
+ * after logging the error.
+ */
+export class IncompleteUsageError extends Error {
+  public readonly partialUsage: CanonicalAIUsage;
+  public readonly missingFields: readonly string[];
+
+  constructor(
+    message: string,
+    partialUsage: CanonicalAIUsage,
+    missingFields: readonly string[]
+  ) {
+    super(message);
+    this.name = 'IncompleteUsageError';
+    this.partialUsage = partialUsage;
+    this.missingFields = missingFields;
+  }
+}

--- a/src/shared/types/ai-usage.types.ts
+++ b/src/shared/types/ai-usage.types.ts
@@ -44,6 +44,7 @@ export class IncompleteUsageError extends Error {
     missingFields: readonly string[]
   ) {
     super(message);
+    Object.setPrototypeOf(this, IncompleteUsageError.prototype);
     this.name = 'IncompleteUsageError';
     this.partialUsage = partialUsage;
     this.missingFields = missingFields;

--- a/tests/fixtures/canonical-usage.factory.ts
+++ b/tests/fixtures/canonical-usage.factory.ts
@@ -1,0 +1,15 @@
+import type { CanonicalAIUsage } from '@/shared/types/ai-usage.types';
+
+export function makeCanonicalUsage(
+  overrides?: Partial<CanonicalAIUsage>
+): CanonicalAIUsage {
+  return {
+    inputTokens: 100,
+    outputTokens: 200,
+    totalTokens: 300,
+    model: 'gpt-4o',
+    provider: 'openai',
+    estimatedCostCents: 0,
+    ...overrides,
+  };
+}

--- a/tests/integration/api/plans-retry.spec.ts
+++ b/tests/integration/api/plans-retry.spec.ts
@@ -1,15 +1,17 @@
-import { POST } from '@/app/api/v1/plans/[planId]/retry/route';
+import {
+  createRetryHandler,
+  POST,
+} from '@/app/api/v1/plans/[planId]/retry/route';
+import type { GenerationAttemptResult } from '@/features/plans/lifecycle';
 import { generationAttempts } from '@/lib/db/schema';
 import { db } from '@/lib/db/service-role';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  seedFailedAttemptsForDurableWindow,
-  seedMaxAttemptsForPlan,
-} from '../../fixtures/attempts';
+import { seedFailedAttemptsForDurableWindow } from '../../fixtures/attempts';
 import { createPlanForRetryTest } from '../../fixtures/plans';
 import { setTestUser } from '../../helpers/auth';
 import { ensureUser, resetDbForIntegrationTestFile } from '../../helpers/db';
+import { readStreamingResponse } from '../../helpers/streaming';
 
 type RetryAttemptOverrides = Partial<
   Omit<typeof generationAttempts.$inferInsert, 'planId'>
@@ -121,7 +123,7 @@ describe('POST /api/v1/plans/:planId/retry', () => {
     });
   });
 
-  it('returns 429 when plan attempt cap is already reached', async () => {
+  it('emits SSE error event when plan attempt cap is already reached', async () => {
     const authUserId = 'auth_retry_capped';
     setTestUser(authUserId);
     const userId = await ensureUser({
@@ -134,22 +136,34 @@ describe('POST /api/v1/plans/:planId/retry', () => {
       planOverrides: { topic: 'Capped plan' },
     });
 
-    await seedMaxAttemptsForPlan(plan.id);
+    const cappedResult: GenerationAttemptResult = {
+      status: 'permanent_failure',
+      classification: 'capped',
+      error: new Error('Generation attempt cap reached'),
+    };
 
-    await withRunGenerationAttemptSpy(async (runSpy) => {
-      const response = await POST(
-        new Request(`http://localhost/api/v1/plans/${plan.id}/retry`, {
-          method: 'POST',
-        })
-      );
-      expect(response.status).toBe(429);
-      const body = (await response.json()) as { error?: string };
-      expect(body.error).toContain('Maximum retry attempts reached');
-      expect(runSpy).not.toHaveBeenCalled();
+    const postWithCappedMock = createRetryHandler({
+      overrides: {
+        processGenerationAttempt: async () => cappedResult,
+      },
     });
+
+    const response = await postWithCappedMock(
+      new Request(`http://localhost/api/v1/plans/${plan.id}/retry`, {
+        method: 'POST',
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const events = await readStreamingResponse(response);
+    const errorEvent = events.find((e) => e.type === 'error');
+    expect(errorEvent).toBeDefined();
+    expect(errorEvent!.data!.code).toBe('ATTEMPTS_EXHAUSTED');
+    expect(errorEvent!.data!.classification).toBe('capped');
+    expect(errorEvent!.data!.retryable).toBe(false);
   });
 
-  it('returns 409 when another attempt is already in progress', async () => {
+  it('emits SSE error event when another attempt is already in progress', async () => {
     const authUserId = 'auth_retry_in_progress';
     setTestUser(authUserId);
     const userId = await ensureUser({
@@ -160,19 +174,34 @@ describe('POST /api/v1/plans/:planId/retry', () => {
     const plan = await createTestPlanWithAttempt({
       userId,
       planOverrides: { topic: 'Plan in progress' },
-      attemptOverrides: { status: 'in_progress' },
     });
 
-    await withRunGenerationAttemptSpy(async (runSpy) => {
-      const response = await POST(
-        new Request(`http://localhost/api/v1/plans/${plan.id}/retry`, {
-          method: 'POST',
-        })
-      );
-      expect(response.status).toBe(409);
-      const body = (await response.json()) as { error?: string };
-      expect(body.error).toContain('already in progress');
-      expect(runSpy).not.toHaveBeenCalled();
+    const conflictResult: GenerationAttemptResult = {
+      status: 'retryable_failure',
+      classification: 'rate_limit',
+      error: new Error(
+        'A generation is already in progress for this plan (concurrent conflict)'
+      ),
+    };
+
+    const postWithConflictMock = createRetryHandler({
+      overrides: {
+        processGenerationAttempt: async () => conflictResult,
+      },
     });
+
+    const response = await postWithConflictMock(
+      new Request(`http://localhost/api/v1/plans/${plan.id}/retry`, {
+        method: 'POST',
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const events = await readStreamingResponse(response);
+    const errorEvent = events.find((e) => e.type === 'error');
+    expect(errorEvent).toBeDefined();
+    expect(errorEvent!.data!.code).toBe('RATE_LIMITED');
+    expect(errorEvent!.data!.classification).toBe('rate_limit');
+    expect(errorEvent!.data!.retryable).toBe(true);
   });
 });

--- a/tests/integration/api/plans-stream.spec.ts
+++ b/tests/integration/api/plans-stream.spec.ts
@@ -642,7 +642,6 @@ describe('POST /api/v1/plans/stream', () => {
           const { getDb: getDbFn } = await import('@/lib/db/runtime');
           const svc = createSvc({
             dbClient: getDbFn(),
-            attemptsDbClient: getDbFn(),
             jobQueue: {
               async enqueueJob() {
                 return '';

--- a/tests/integration/db/usage.spec.ts
+++ b/tests/integration/db/usage.spec.ts
@@ -48,7 +48,6 @@ describe('AI usage logging', () => {
       inputTokens: 10,
       outputTokens: 100,
       costCents: 0,
-      kind: 'plan',
     });
 
     const rows = await db

--- a/tests/unit/ai/cost.spec.ts
+++ b/tests/unit/ai/cost.spec.ts
@@ -183,7 +183,7 @@ describe('tier consistency', () => {
       expect(proCounterpart).toBeDefined();
 
       const freeCeiling = getOutputTokenCeiling(freeModel.id);
-      const proCeiling = getOutputTokenCeiling(freeModel.id);
+      const proCeiling = getOutputTokenCeiling(proCounterpart!.id);
       expect(freeCeiling).toBe(proCeiling);
     }
   });
@@ -192,18 +192,21 @@ describe('tier consistency', () => {
     const freeModels = getModelsForTier('free');
     const starterModels = getModelsForTier('starter');
 
-    expect(freeModels.length).toBe(starterModels.length);
-    for (let i = 0; i < freeModels.length; i++) {
-      expect(getOutputTokenCeiling(freeModels[i].id)).toBe(
-        getOutputTokenCeiling(starterModels[i].id)
+    const freeMap = new Map(freeModels.map((m) => [m.id, m]));
+    const starterMap = new Map(starterModels.map((m) => [m.id, m]));
+
+    const freeIds = new Set(freeMap.keys());
+    const starterIds = new Set(starterMap.keys());
+    expect(freeIds).toEqual(starterIds);
+
+    for (const id of freeIds) {
+      expect(getOutputTokenCeiling(id)).toBe(
+        getOutputTokenCeiling(starterMap.get(id)!.id)
       );
     }
   });
 
-  it('ceilings are tier-independent — defined by model, not by tier', () => {
-    // This test verifies that getOutputTokenCeiling is a pure function
-    // of modelId, with no tier parameter. The function signature itself
-    // guarantees tier independence.
+  it('getOutputTokenCeiling is a pure function of modelId (no tier parameter)', () => {
     const allModels = AVAILABLE_MODELS;
     for (const model of allModels) {
       const ceiling1 = getOutputTokenCeiling(model.id);

--- a/tests/unit/ai/cost.spec.ts
+++ b/tests/unit/ai/cost.spec.ts
@@ -16,8 +16,10 @@ import type { CanonicalAIUsage } from '@/shared/types/ai-usage.types';
 // ─── computeCostCents ────────────────────────────────────────────
 
 describe('computeCostCents', () => {
-  it('returns 0 for unknown model', () => {
-    expect(computeCostCents('unknown-model', 1000, 500)).toBe(0);
+  it('throws for unknown model', () => {
+    expect(() => computeCostCents('unknown-model', 1000, 500)).toThrow(
+      /Unknown model "unknown-model"/
+    );
   });
 
   it('returns 0 when both token counts are 0', () => {
@@ -85,7 +87,7 @@ describe('calculateCostFromUsage', () => {
     expect(calculateCostFromUsage(usage)).toBe(750);
   });
 
-  it('returns 0 for unknown model regardless of estimatedCostCents', () => {
+  it('throws for unknown model regardless of estimatedCostCents', () => {
     const usage: CanonicalAIUsage = {
       inputTokens: 100_000,
       outputTokens: 50_000,
@@ -94,7 +96,9 @@ describe('calculateCostFromUsage', () => {
       provider: 'openrouter',
       estimatedCostCents: 500,
     };
-    expect(calculateCostFromUsage(usage)).toBe(0);
+    expect(() => calculateCostFromUsage(usage)).toThrow(
+      /Unknown model "totally-unknown-model"/
+    );
   });
 
   it('is deterministic — repeated calls return same value', () => {
@@ -180,10 +184,14 @@ describe('tier consistency', () => {
     // Free models are a subset of pro models
     for (const freeModel of freeTierModels) {
       const proCounterpart = proTierModels.find((m) => m.id === freeModel.id);
-      expect(proCounterpart).toBeDefined();
+      if (!proCounterpart) {
+        throw new Error(
+          `Free-tier model "${freeModel.id}" has no pro-tier counterpart`
+        );
+      }
 
       const freeCeiling = getOutputTokenCeiling(freeModel.id);
-      const proCeiling = getOutputTokenCeiling(proCounterpart!.id);
+      const proCeiling = getOutputTokenCeiling(proCounterpart.id);
       expect(freeCeiling).toBe(proCeiling);
     }
   });
@@ -198,12 +206,6 @@ describe('tier consistency', () => {
     const freeIds = new Set(freeMap.keys());
     const starterIds = new Set(starterMap.keys());
     expect(freeIds).toEqual(starterIds);
-
-    for (const id of freeIds) {
-      expect(getOutputTokenCeiling(id)).toBe(
-        getOutputTokenCeiling(starterMap.get(id)!.id)
-      );
-    }
   });
 
   it('getOutputTokenCeiling is a pure function of modelId (no tier parameter)', () => {

--- a/tests/unit/ai/cost.spec.ts
+++ b/tests/unit/ai/cost.spec.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AVAILABLE_MODELS,
+  getModelById,
+  getModelsForTier,
+} from '@/features/ai/ai-models';
+import {
+  calculateCostFromUsage,
+  computeCostCents,
+  DEFAULT_OUTPUT_TOKEN_CEILING,
+  getOutputTokenCeiling,
+} from '@/features/ai/cost';
+import type { CanonicalAIUsage } from '@/shared/types/ai-usage.types';
+
+// ─── computeCostCents ────────────────────────────────────────────
+
+describe('computeCostCents', () => {
+  it('returns 0 for unknown model', () => {
+    expect(computeCostCents('unknown-model', 1000, 500)).toBe(0);
+  });
+
+  it('returns 0 when both token counts are 0', () => {
+    expect(computeCostCents('openai/gpt-4o', 0, 0)).toBe(0);
+  });
+
+  it('returns 0 for free models', () => {
+    expect(
+      computeCostCents('google/gemini-2.0-flash-exp:free', 100_000, 50_000)
+    ).toBe(0);
+  });
+
+  it('computes cost correctly for paid models', () => {
+    // openai/gpt-4o: inputCostPerMillion = 2.5, outputCostPerMillion = 10
+    // 1M input tokens at $2.5/M = $2.50 = 250 cents
+    // 500K output tokens at $10/M = $5.00 = 500 cents
+    // Total = 750 cents
+    expect(computeCostCents('openai/gpt-4o', 1_000_000, 500_000)).toBe(750);
+  });
+
+  it('rounds to nearest cent', () => {
+    // 100 input tokens at $2.5/M = $0.00025 = 0.025 cents → rounds to 0
+    expect(computeCostCents('openai/gpt-4o', 100, 0)).toBe(0);
+    // 10_000 input tokens at $2.5/M = $0.025 = 2.5 cents → rounds to 3
+    expect(computeCostCents('openai/gpt-4o', 10_000, 0)).toBe(3);
+  });
+
+  it('is deterministic — same input always produces same output', () => {
+    const model = 'openai/gpt-4o';
+    const input = 123_456;
+    const output = 78_901;
+    const results = Array.from({ length: 100 }, () =>
+      computeCostCents(model, input, output)
+    );
+    const unique = new Set(results);
+    expect(unique.size).toBe(1);
+  });
+
+  it('computes cost for every paid model in the registry', () => {
+    const paidModels = AVAILABLE_MODELS.filter(
+      (m) => m.inputCostPerMillion > 0 || m.outputCostPerMillion > 0
+    );
+    expect(paidModels.length).toBeGreaterThan(0);
+    for (const model of paidModels) {
+      const cost = computeCostCents(model.id, 1_000_000, 1_000_000);
+      // Cost should be positive for non-trivial usage on paid models
+      expect(cost).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ─── calculateCostFromUsage ──────────────────────────────────────
+
+describe('calculateCostFromUsage', () => {
+  it('derives cost deterministically from canonical usage', () => {
+    const usage: CanonicalAIUsage = {
+      inputTokens: 1_000_000,
+      outputTokens: 500_000,
+      totalTokens: 1_500_000,
+      model: 'openai/gpt-4o',
+      provider: 'openrouter',
+      estimatedCostCents: 999, // should be ignored — recalculated from model pricing
+    };
+    // 1M input at $2.5/M + 500K output at $10/M = 250 + 500 = 750 cents
+    expect(calculateCostFromUsage(usage)).toBe(750);
+  });
+
+  it('returns 0 for unknown model regardless of estimatedCostCents', () => {
+    const usage: CanonicalAIUsage = {
+      inputTokens: 100_000,
+      outputTokens: 50_000,
+      totalTokens: 150_000,
+      model: 'totally-unknown-model',
+      provider: 'openrouter',
+      estimatedCostCents: 500,
+    };
+    expect(calculateCostFromUsage(usage)).toBe(0);
+  });
+
+  it('is deterministic — repeated calls return same value', () => {
+    const usage: CanonicalAIUsage = {
+      inputTokens: 50_000,
+      outputTokens: 25_000,
+      totalTokens: 75_000,
+      model: 'openai/gpt-4o',
+      provider: 'openrouter',
+      estimatedCostCents: 0,
+    };
+    const first = calculateCostFromUsage(usage);
+    const second = calculateCostFromUsage(usage);
+    const third = calculateCostFromUsage(usage);
+    expect(first).toBe(second);
+    expect(second).toBe(third);
+  });
+
+  it('returns 0 for free models', () => {
+    const usage: CanonicalAIUsage = {
+      inputTokens: 500_000,
+      outputTokens: 200_000,
+      totalTokens: 700_000,
+      model: 'google/gemini-2.0-flash-exp:free',
+      provider: 'openrouter',
+      estimatedCostCents: 0,
+    };
+    expect(calculateCostFromUsage(usage)).toBe(0);
+  });
+});
+
+// ─── getOutputTokenCeiling ───────────────────────────────────────
+
+describe('getOutputTokenCeiling', () => {
+  it('returns the model-defined maxOutputTokens when present', () => {
+    // openai/gpt-4o has maxOutputTokens: 64_000
+    expect(getOutputTokenCeiling('openai/gpt-4o')).toBe(64_000);
+  });
+
+  it('returns DEFAULT_OUTPUT_TOKEN_CEILING for models without maxOutputTokens', () => {
+    // openrouter/free has no maxOutputTokens
+    const model = getModelById('openrouter/free');
+    expect(model?.maxOutputTokens).toBeUndefined();
+    expect(getOutputTokenCeiling('openrouter/free')).toBe(
+      DEFAULT_OUTPUT_TOKEN_CEILING
+    );
+  });
+
+  it('returns DEFAULT_OUTPUT_TOKEN_CEILING for unknown models', () => {
+    expect(getOutputTokenCeiling('nonexistent/model')).toBe(
+      DEFAULT_OUTPUT_TOKEN_CEILING
+    );
+  });
+
+  it('returns a ceiling for every model in the registry', () => {
+    for (const model of AVAILABLE_MODELS) {
+      const ceiling = getOutputTokenCeiling(model.id);
+      expect(ceiling).toBeGreaterThan(0);
+      expect(Number.isFinite(ceiling)).toBe(true);
+    }
+  });
+
+  it('respects each model-specific ceiling', () => {
+    const modelsWithCeilings = AVAILABLE_MODELS.filter(
+      (m) => m.maxOutputTokens != null
+    );
+    expect(modelsWithCeilings.length).toBeGreaterThan(0);
+    for (const model of modelsWithCeilings) {
+      expect(getOutputTokenCeiling(model.id)).toBe(model.maxOutputTokens);
+    }
+  });
+});
+
+// ─── Tier consistency ────────────────────────────────────────────
+
+describe('tier consistency', () => {
+  it('enforces the same ceiling for a model regardless of user tier', () => {
+    // For every model that appears in both free and pro tiers,
+    // the ceiling must be identical.
+    const freeTierModels = getModelsForTier('free');
+    const proTierModels = getModelsForTier('pro');
+
+    // Free models are a subset of pro models
+    for (const freeModel of freeTierModels) {
+      const proCounterpart = proTierModels.find((m) => m.id === freeModel.id);
+      expect(proCounterpart).toBeDefined();
+
+      const freeCeiling = getOutputTokenCeiling(freeModel.id);
+      const proCeiling = getOutputTokenCeiling(freeModel.id);
+      expect(freeCeiling).toBe(proCeiling);
+    }
+  });
+
+  it('starter and free tiers get identical ceilings', () => {
+    const freeModels = getModelsForTier('free');
+    const starterModels = getModelsForTier('starter');
+
+    expect(freeModels.length).toBe(starterModels.length);
+    for (let i = 0; i < freeModels.length; i++) {
+      expect(getOutputTokenCeiling(freeModels[i].id)).toBe(
+        getOutputTokenCeiling(starterModels[i].id)
+      );
+    }
+  });
+
+  it('ceilings are tier-independent — defined by model, not by tier', () => {
+    // This test verifies that getOutputTokenCeiling is a pure function
+    // of modelId, with no tier parameter. The function signature itself
+    // guarantees tier independence.
+    const allModels = AVAILABLE_MODELS;
+    for (const model of allModels) {
+      const ceiling1 = getOutputTokenCeiling(model.id);
+      const ceiling2 = getOutputTokenCeiling(model.id);
+      expect(ceiling1).toBe(ceiling2);
+    }
+  });
+});
+
+// ─── DEFAULT_OUTPUT_TOKEN_CEILING ────────────────────────────────
+
+describe('DEFAULT_OUTPUT_TOKEN_CEILING', () => {
+  it('is a positive finite number', () => {
+    expect(DEFAULT_OUTPUT_TOKEN_CEILING).toBeGreaterThan(0);
+    expect(Number.isFinite(DEFAULT_OUTPUT_TOKEN_CEILING)).toBe(true);
+  });
+
+  it('is a reasonable value (between 8K and 256K tokens)', () => {
+    expect(DEFAULT_OUTPUT_TOKEN_CEILING).toBeGreaterThanOrEqual(8_192);
+    expect(DEFAULT_OUTPUT_TOKEN_CEILING).toBeLessThanOrEqual(256_000);
+  });
+});

--- a/tests/unit/ai/providers/openrouter.spec.ts
+++ b/tests/unit/ai/providers/openrouter.spec.ts
@@ -280,10 +280,12 @@ describe('OpenRouterProvider', () => {
       const provider = new OpenRouterProvider({ model: TEST_MODEL }, client);
       const result = await provider.generate(SAMPLE_INPUT);
 
+      // Missing usage data is reported as undefined (not silently defaulted to 0)
+      // so downstream normalization can detect and alert on it.
       expect(result.metadata.usage).toEqual({
-        promptTokens: 0,
-        completionTokens: 0,
-        totalTokens: 0,
+        promptTokens: undefined,
+        completionTokens: undefined,
+        totalTokens: undefined,
       });
     });
 

--- a/tests/unit/ai/providers/openrouter.spec.ts
+++ b/tests/unit/ai/providers/openrouter.spec.ts
@@ -289,7 +289,7 @@ describe('OpenRouterProvider', () => {
       });
     });
 
-    it('calls SDK with correct parameters', async () => {
+    it('calls SDK with correct parameters including maxTokens', async () => {
       const { client, send } = createMockClient();
       send.mockResolvedValueOnce({
         choices: [
@@ -317,6 +317,7 @@ describe('OpenRouterProvider', () => {
           temperature: 0.7,
           stream: true,
           responseFormat: { type: 'json_object' },
+          maxTokens: expect.any(Number),
           messages: expect.arrayContaining([
             expect.objectContaining({ role: 'system' }),
             expect.objectContaining({ role: 'user' }),
@@ -505,6 +506,72 @@ describe('OpenRouterProvider', () => {
         expect(usage.completionTokens).toBe(400);
         expect(usage.totalTokens).toBe(480);
       });
+    });
+  });
+
+  describe('output-token ceiling enforcement', () => {
+    it('sends maxTokens derived from the model ceiling', async () => {
+      const { client, send } = createMockClient();
+      send.mockResolvedValueOnce({
+        choices: [
+          {
+            message: { content: JSON.stringify(VALID_PLAN_RESPONSE) },
+          },
+        ],
+      });
+
+      const provider = new OpenRouterProvider({ model: TEST_MODEL }, client);
+      await provider.generate(SAMPLE_INPUT);
+
+      const requestBody = send.mock.calls[0][0];
+      expect(requestBody).toHaveProperty('maxTokens');
+      expect(typeof requestBody.maxTokens).toBe('number');
+      expect(requestBody.maxTokens).toBeGreaterThan(0);
+    });
+
+    it('uses model-specific ceiling for models with explicit maxOutputTokens', async () => {
+      const { client, send } = createMockClient();
+      send.mockResolvedValueOnce({
+        choices: [
+          {
+            message: { content: JSON.stringify(VALID_PLAN_RESPONSE) },
+          },
+        ],
+      });
+
+      // openai/gpt-4o has maxOutputTokens: 64_000
+      const provider = new OpenRouterProvider(
+        { model: 'openai/gpt-4o' },
+        client
+      );
+      await provider.generate(SAMPLE_INPUT);
+
+      const requestBody = send.mock.calls[0][0];
+      expect(requestBody.maxTokens).toBe(64_000);
+    });
+
+    it('uses default ceiling for unknown models', async () => {
+      const { client, send } = createMockClient();
+      send.mockResolvedValueOnce({
+        choices: [
+          {
+            message: { content: JSON.stringify(VALID_PLAN_RESPONSE) },
+          },
+        ],
+      });
+
+      const { DEFAULT_OUTPUT_TOKEN_CEILING } = await import(
+        '@/features/ai/cost'
+      );
+
+      const provider = new OpenRouterProvider(
+        { model: 'unknown/model-xyz' },
+        client
+      );
+      await provider.generate(SAMPLE_INPUT);
+
+      const requestBody = send.mock.calls[0][0];
+      expect(requestBody.maxTokens).toBe(DEFAULT_OUTPUT_TOKEN_CEILING);
     });
   });
 

--- a/tests/unit/ai/providers/openrouter.spec.ts
+++ b/tests/unit/ai/providers/openrouter.spec.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import {
+  DEFAULT_OUTPUT_TOKEN_CEILING,
+  getOutputTokenCeiling,
+} from '@/features/ai/cost';
 import { ProviderInvalidResponseError } from '@/features/ai/providers/errors';
 import {
   OpenRouterProvider,
@@ -523,7 +527,11 @@ describe('OpenRouterProvider', () => {
       const provider = new OpenRouterProvider({ model: TEST_MODEL }, client);
       await provider.generate(SAMPLE_INPUT);
 
-      const requestBody = send.mock.calls[0][0];
+      const requestBody = send.mock.calls[0][0] as {
+        maxTokens: number;
+        model: string;
+        [key: string]: unknown;
+      };
       expect(requestBody).toHaveProperty('maxTokens');
       expect(typeof requestBody.maxTokens).toBe('number');
       expect(requestBody.maxTokens).toBeGreaterThan(0);
@@ -546,8 +554,13 @@ describe('OpenRouterProvider', () => {
       );
       await provider.generate(SAMPLE_INPUT);
 
-      const requestBody = send.mock.calls[0][0];
-      expect(requestBody.maxTokens).toBe(64_000);
+      const requestBody = send.mock.calls[0][0] as {
+        maxTokens: number;
+        [key: string]: unknown;
+      };
+      expect(requestBody.maxTokens).toBe(
+        getOutputTokenCeiling('openai/gpt-4o')
+      );
     });
 
     it('uses default ceiling for unknown models', async () => {
@@ -560,17 +573,16 @@ describe('OpenRouterProvider', () => {
         ],
       });
 
-      const { DEFAULT_OUTPUT_TOKEN_CEILING } = await import(
-        '@/features/ai/cost'
-      );
-
       const provider = new OpenRouterProvider(
         { model: 'unknown/model-xyz' },
         client
       );
       await provider.generate(SAMPLE_INPUT);
 
-      const requestBody = send.mock.calls[0][0];
+      const requestBody = send.mock.calls[0][0] as {
+        maxTokens: number;
+        [key: string]: unknown;
+      };
       expect(requestBody.maxTokens).toBe(DEFAULT_OUTPUT_TOKEN_CEILING);
     });
   });

--- a/tests/unit/ai/usage.spec.ts
+++ b/tests/unit/ai/usage.spec.ts
@@ -36,8 +36,10 @@ vi.mock('@/features/ai/ai-models', () => ({
 // ─── computeCostCents ────────────────────────────────────────────
 
 describe('computeCostCents', () => {
-  it('returns 0 for unknown model', () => {
-    expect(computeCostCents('unknown-model', 1000, 500)).toBe(0);
+  it('throws for unknown model', () => {
+    expect(() => computeCostCents('unknown-model', 1000, 500)).toThrow(
+      /Unknown model "unknown-model"/
+    );
   });
 
   it('returns 0 when both token counts are 0', () => {

--- a/tests/unit/ai/usage.spec.ts
+++ b/tests/unit/ai/usage.spec.ts
@@ -1,0 +1,375 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  computeCostCents,
+  normalizeToCanonicalUsage,
+  safeNormalizeUsage,
+} from '@/features/ai/usage';
+import type { ProviderMetadata } from '@/shared/types/ai-provider.types';
+import { IncompleteUsageError } from '@/shared/types/ai-usage.types';
+
+// Mock Sentry so safeNormalizeUsage doesn't throw on import
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}));
+
+// Mock getModelById for cost calculation tests
+vi.mock('@/features/ai/ai-models', () => ({
+  getModelById: (id: string) => {
+    const models: Record<
+      string,
+      { inputCostPerMillion: number; outputCostPerMillion: number }
+    > = {
+      'openai/gpt-4o': {
+        inputCostPerMillion: 2.5,
+        outputCostPerMillion: 10,
+      },
+      'google/gemini-2.0-flash-exp:free': {
+        inputCostPerMillion: 0,
+        outputCostPerMillion: 0,
+      },
+    };
+    return models[id] ?? undefined;
+  },
+}));
+
+// ─── computeCostCents ────────────────────────────────────────────
+
+describe('computeCostCents', () => {
+  it('returns 0 for unknown model', () => {
+    expect(computeCostCents('unknown-model', 1000, 500)).toBe(0);
+  });
+
+  it('returns 0 when both token counts are 0', () => {
+    expect(computeCostCents('openai/gpt-4o', 0, 0)).toBe(0);
+  });
+
+  it('returns 0 for free models', () => {
+    expect(
+      computeCostCents('google/gemini-2.0-flash-exp:free', 100_000, 50_000)
+    ).toBe(0);
+  });
+
+  it('computes cost correctly for paid models', () => {
+    // 1M input tokens at $2.5/M = $2.50 = 250 cents
+    // 500K output tokens at $10/M = $5.00 = 500 cents
+    // Total = 750 cents
+    expect(computeCostCents('openai/gpt-4o', 1_000_000, 500_000)).toBe(750);
+  });
+
+  it('rounds to nearest cent', () => {
+    // 100 input tokens at $2.5/M = $0.00025 = 0.025 cents → rounds to 0
+    expect(computeCostCents('openai/gpt-4o', 100, 0)).toBe(0);
+    // 10_000 input tokens at $2.5/M = $0.025 = 2.5 cents → rounds to 3
+    expect(computeCostCents('openai/gpt-4o', 10_000, 0)).toBe(3);
+  });
+});
+
+// ─── normalizeToCanonicalUsage ───────────────────────────────────
+
+describe('normalizeToCanonicalUsage', () => {
+  it('normalizes complete provider metadata into canonical shape', () => {
+    const metadata: ProviderMetadata = {
+      provider: 'openrouter',
+      model: 'openai/gpt-4o',
+      usage: {
+        promptTokens: 500,
+        completionTokens: 1000,
+        totalTokens: 1500,
+      },
+    };
+
+    const result = normalizeToCanonicalUsage(metadata);
+
+    expect(result).toEqual({
+      inputTokens: 500,
+      outputTokens: 1000,
+      totalTokens: 1500,
+      model: 'openai/gpt-4o',
+      provider: 'openrouter',
+      estimatedCostCents: expect.any(Number),
+    });
+  });
+
+  it('computes totalTokens when not provided by the provider', () => {
+    const metadata: ProviderMetadata = {
+      provider: 'openrouter',
+      model: 'openai/gpt-4o',
+      usage: {
+        promptTokens: 200,
+        completionTokens: 300,
+      },
+    };
+
+    const result = normalizeToCanonicalUsage(metadata);
+
+    expect(result.totalTokens).toBe(500);
+  });
+
+  it('throws IncompleteUsageError when provider is missing', () => {
+    const metadata: ProviderMetadata = {
+      model: 'openai/gpt-4o',
+      usage: {
+        promptTokens: 100,
+        completionTokens: 200,
+      },
+    };
+
+    expect(() => normalizeToCanonicalUsage(metadata)).toThrow(
+      IncompleteUsageError
+    );
+
+    try {
+      normalizeToCanonicalUsage(metadata);
+    } catch (error) {
+      expect(error).toBeInstanceOf(IncompleteUsageError);
+      const usageError = error as IncompleteUsageError;
+      expect(usageError.missingFields).toContain('provider');
+      expect(usageError.partialUsage.provider).toBe('unknown');
+      expect(usageError.partialUsage.inputTokens).toBe(100);
+    }
+  });
+
+  it('throws IncompleteUsageError when model is missing', () => {
+    const metadata: ProviderMetadata = {
+      provider: 'openrouter',
+      usage: {
+        promptTokens: 100,
+        completionTokens: 200,
+      },
+    };
+
+    expect(() => normalizeToCanonicalUsage(metadata)).toThrow(
+      IncompleteUsageError
+    );
+
+    try {
+      normalizeToCanonicalUsage(metadata);
+    } catch (error) {
+      const usageError = error as IncompleteUsageError;
+      expect(usageError.missingFields).toContain('model');
+      expect(usageError.partialUsage.model).toBe('unknown');
+    }
+  });
+
+  it('throws IncompleteUsageError when inputTokens is missing', () => {
+    const metadata: ProviderMetadata = {
+      provider: 'openrouter',
+      model: 'openai/gpt-4o',
+      usage: {
+        completionTokens: 200,
+      },
+    };
+
+    expect(() => normalizeToCanonicalUsage(metadata)).toThrow(
+      IncompleteUsageError
+    );
+
+    try {
+      normalizeToCanonicalUsage(metadata);
+    } catch (error) {
+      const usageError = error as IncompleteUsageError;
+      expect(usageError.missingFields).toContain('inputTokens');
+      expect(usageError.partialUsage.inputTokens).toBe(0);
+      expect(usageError.partialUsage.outputTokens).toBe(200);
+    }
+  });
+
+  it('throws IncompleteUsageError when outputTokens is missing', () => {
+    const metadata: ProviderMetadata = {
+      provider: 'openrouter',
+      model: 'openai/gpt-4o',
+      usage: {
+        promptTokens: 100,
+      },
+    };
+
+    expect(() => normalizeToCanonicalUsage(metadata)).toThrow(
+      IncompleteUsageError
+    );
+
+    try {
+      normalizeToCanonicalUsage(metadata);
+    } catch (error) {
+      const usageError = error as IncompleteUsageError;
+      expect(usageError.missingFields).toContain('outputTokens');
+      expect(usageError.partialUsage.outputTokens).toBe(0);
+      expect(usageError.partialUsage.inputTokens).toBe(100);
+    }
+  });
+
+  it('throws IncompleteUsageError when usage object is entirely missing', () => {
+    const metadata: ProviderMetadata = {
+      provider: 'openrouter',
+      model: 'openai/gpt-4o',
+    };
+
+    expect(() => normalizeToCanonicalUsage(metadata)).toThrow(
+      IncompleteUsageError
+    );
+
+    try {
+      normalizeToCanonicalUsage(metadata);
+    } catch (error) {
+      const usageError = error as IncompleteUsageError;
+      expect(usageError.missingFields).toContain('inputTokens');
+      expect(usageError.missingFields).toContain('outputTokens');
+      expect(usageError.partialUsage.inputTokens).toBe(0);
+      expect(usageError.partialUsage.outputTokens).toBe(0);
+    }
+  });
+
+  it('throws IncompleteUsageError when metadata is undefined', () => {
+    expect(() => normalizeToCanonicalUsage(undefined)).toThrow(
+      IncompleteUsageError
+    );
+
+    try {
+      normalizeToCanonicalUsage(undefined);
+    } catch (error) {
+      const usageError = error as IncompleteUsageError;
+      expect(usageError.missingFields).toEqual([
+        'provider',
+        'model',
+        'inputTokens',
+        'outputTokens',
+      ]);
+      expect(usageError.partialUsage).toEqual({
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        model: 'unknown',
+        provider: 'unknown',
+        estimatedCostCents: 0,
+      });
+    }
+  });
+
+  it('reports multiple missing fields at once', () => {
+    const metadata: ProviderMetadata = {
+      usage: {
+        promptTokens: 100,
+      },
+    };
+
+    try {
+      normalizeToCanonicalUsage(metadata);
+    } catch (error) {
+      const usageError = error as IncompleteUsageError;
+      expect(usageError.missingFields).toEqual(
+        expect.arrayContaining(['provider', 'model', 'outputTokens'])
+      );
+      expect(usageError.missingFields).toHaveLength(3);
+    }
+  });
+
+  it('does NOT throw when all fields are present (even if zero)', () => {
+    const metadata: ProviderMetadata = {
+      provider: 'mock',
+      model: 'mock-v1',
+      usage: {
+        promptTokens: 0,
+        completionTokens: 0,
+        totalTokens: 0,
+      },
+    };
+
+    const result = normalizeToCanonicalUsage(metadata);
+
+    expect(result).toEqual({
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      model: 'mock-v1',
+      provider: 'mock',
+      estimatedCostCents: 0,
+    });
+  });
+});
+
+// ─── safeNormalizeUsage ──────────────────────────────────────────
+
+describe('safeNormalizeUsage', () => {
+  it('returns canonical usage for complete metadata', () => {
+    const metadata: ProviderMetadata = {
+      provider: 'openrouter',
+      model: 'openai/gpt-4o',
+      usage: {
+        promptTokens: 500,
+        completionTokens: 1000,
+        totalTokens: 1500,
+      },
+    };
+
+    const result = safeNormalizeUsage(metadata);
+
+    expect(result.inputTokens).toBe(500);
+    expect(result.outputTokens).toBe(1000);
+    expect(result.provider).toBe('openrouter');
+  });
+
+  it('returns partial usage (not throw) for incomplete metadata', () => {
+    const metadata: ProviderMetadata = {};
+
+    const result = safeNormalizeUsage(metadata);
+
+    expect(result.provider).toBe('unknown');
+    expect(result.model).toBe('unknown');
+    expect(result.inputTokens).toBe(0);
+    expect(result.outputTokens).toBe(0);
+  });
+
+  it('returns partial usage for undefined metadata', () => {
+    const result = safeNormalizeUsage(undefined);
+
+    expect(result).toEqual({
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      model: 'unknown',
+      provider: 'unknown',
+      estimatedCostCents: 0,
+    });
+  });
+
+  it('returns partial usage with available fields preserved', () => {
+    const metadata: ProviderMetadata = {
+      provider: 'openrouter',
+      model: 'openai/gpt-4o',
+      // usage is missing entirely
+    };
+
+    const result = safeNormalizeUsage(metadata);
+
+    expect(result.provider).toBe('openrouter');
+    expect(result.model).toBe('openai/gpt-4o');
+    expect(result.inputTokens).toBe(0);
+    expect(result.outputTokens).toBe(0);
+  });
+});
+
+// ─── IncompleteUsageError ────────────────────────────────────────
+
+describe('IncompleteUsageError', () => {
+  it('carries partialUsage and missingFields', () => {
+    const partialUsage = {
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      model: 'unknown',
+      provider: 'unknown',
+      estimatedCostCents: 0,
+    };
+
+    const error = new IncompleteUsageError('test error', partialUsage, [
+      'provider',
+      'model',
+    ]);
+
+    expect(error.name).toBe('IncompleteUsageError');
+    expect(error.message).toBe('test error');
+    expect(error.partialUsage).toBe(partialUsage);
+    expect(error.missingFields).toEqual(['provider', 'model']);
+    expect(error).toBeInstanceOf(Error);
+  });
+});

--- a/tests/unit/features/plans/cleanup.spec.ts
+++ b/tests/unit/features/plans/cleanup.spec.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  cleanupOrphanedAttempts,
+  cleanupStuckPlans,
+  ORPHANED_ATTEMPT_THRESHOLD_MS,
+  STUCK_PLAN_THRESHOLD_MS,
+} from '@/features/plans/cleanup';
+import type { DbClient } from '@/lib/db/types';
+
+// Mock the logger to avoid console noise and allow assertion
+vi.mock('@/lib/logging/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+function createMockDbClient(updateCount: number) {
+  const whereFn = vi.fn().mockResolvedValue({ count: updateCount });
+  const setFn = vi.fn().mockReturnValue({ where: whereFn });
+  const updateFn = vi.fn().mockReturnValue({ set: setFn });
+
+  return {
+    client: { update: updateFn } as unknown as DbClient,
+    spies: { updateFn, setFn, whereFn },
+  };
+}
+
+describe('cleanupStuckPlans', () => {
+  let mockDb: ReturnType<typeof createMockDbClient>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('marks stuck generating plans as failed and returns count', async () => {
+    mockDb = createMockDbClient(3);
+
+    const result = await cleanupStuckPlans(mockDb.client);
+
+    expect(result.cleaned).toBe(3);
+    expect(mockDb.spies.updateFn).toHaveBeenCalledTimes(1);
+    expect(mockDb.spies.setFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        generationStatus: 'failed',
+      })
+    );
+  });
+
+  it('returns 0 when no stuck plans exist', async () => {
+    mockDb = createMockDbClient(0);
+
+    const result = await cleanupStuckPlans(mockDb.client);
+
+    expect(result.cleaned).toBe(0);
+  });
+
+  it('uses default threshold of 15 minutes', () => {
+    expect(STUCK_PLAN_THRESHOLD_MS).toBe(15 * 60 * 1000);
+  });
+
+  it('accepts a custom threshold', async () => {
+    mockDb = createMockDbClient(1);
+    const customThreshold = 5 * 60 * 1000; // 5 minutes
+
+    const result = await cleanupStuckPlans(mockDb.client, customThreshold);
+
+    expect(result.cleaned).toBe(1);
+  });
+});
+
+describe('cleanupOrphanedAttempts', () => {
+  let mockDb: ReturnType<typeof createMockDbClient>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('finalizes orphaned in_progress attempts and returns count', async () => {
+    mockDb = createMockDbClient(5);
+
+    const result = await cleanupOrphanedAttempts(mockDb.client);
+
+    expect(result.cleaned).toBe(5);
+    expect(mockDb.spies.updateFn).toHaveBeenCalledTimes(1);
+    expect(mockDb.spies.setFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        classification: 'timeout',
+      })
+    );
+  });
+
+  it('returns 0 when no orphaned attempts exist', async () => {
+    mockDb = createMockDbClient(0);
+
+    const result = await cleanupOrphanedAttempts(mockDb.client);
+
+    expect(result.cleaned).toBe(0);
+  });
+
+  it('uses default threshold of 15 minutes', () => {
+    expect(ORPHANED_ATTEMPT_THRESHOLD_MS).toBe(15 * 60 * 1000);
+  });
+
+  it('accepts a custom threshold', async () => {
+    mockDb = createMockDbClient(2);
+    const customThreshold = 30 * 60 * 1000; // 30 minutes
+
+    const result = await cleanupOrphanedAttempts(
+      mockDb.client,
+      customThreshold
+    );
+
+    expect(result.cleaned).toBe(2);
+  });
+});

--- a/tests/unit/features/plans/lifecycle/lifecycle-consolidation.spec.ts
+++ b/tests/unit/features/plans/lifecycle/lifecycle-consolidation.spec.ts
@@ -1,0 +1,532 @@
+/**
+ * Lifecycle Consolidation Tests — verifies that PlanLifecycleService is the
+ * single authoritative owner of create, generate, retry, and regenerate
+ * for all entry points with consistent behavior.
+ *
+ * Covers:
+ * - PDF input parity (PDF fields forwarded through the same lifecycle)
+ * - modelOverride forwarding
+ * - One lifecycle record per generation attempt
+ * - Failed generations produce consistent state regardless of entry point
+ * - Retry and regeneration inputs handled identically by processGenerationAttempt
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { PlanLifecycleServicePorts } from '@/features/plans/lifecycle/service';
+import { PlanLifecycleService } from '@/features/plans/lifecycle/service';
+import type { ProcessGenerationInput } from '@/features/plans/lifecycle/types';
+import { makeCanonicalUsage } from '../../../../fixtures/canonical-usage.factory';
+
+// ─── Helpers ─────────────────────────────────────────────────────
+
+function createMockPorts(
+  overrides?: Partial<PlanLifecycleServicePorts>
+): PlanLifecycleServicePorts {
+  return {
+    planPersistence: {
+      atomicInsertPlan: async () => ({
+        success: true as const,
+        id: 'plan-123',
+      }),
+      findCappedPlanWithoutModules: async () => null,
+      findRecentDuplicatePlan: async () => null,
+      markGenerationSuccess: vi.fn().mockResolvedValue(undefined),
+      markGenerationFailure: vi.fn().mockResolvedValue(undefined),
+    },
+    quota: {
+      resolveUserTier: async () => 'free' as const,
+      checkDurationCap: () => ({ allowed: true }),
+      normalizePlanDuration: () => ({
+        startDate: '2025-01-01',
+        deadlineDate: '2025-01-15',
+        totalWeeks: 2,
+      }),
+      reservePdfQuota: async () => ({
+        allowed: true as const,
+        newCount: 1,
+        limit: 3,
+      }),
+      rollbackPdfQuota: async () => {},
+    },
+    pdfOrigin: {
+      preparePlanInput: async () => ({
+        origin: 'pdf' as const,
+        extractedContext: null,
+        topic: 'test',
+        skillLevel: 'beginner',
+        weeklyHours: 5,
+        learningStyle: 'mixed',
+        pdfUsageReserved: false,
+        pdfProvenance: null,
+      }),
+      rollbackPdfUsage: async () => {},
+    },
+    generation: {
+      runGeneration: vi.fn().mockResolvedValue({
+        status: 'success' as const,
+        modules: [{ title: 'Module 1', estimatedMinutes: 60, tasks: [] }],
+        metadata: { provider: 'openai', model: 'gpt-4o' },
+        usage: makeCanonicalUsage(),
+        durationMs: 1500,
+      }),
+    },
+    usageRecording: {
+      recordUsage: vi.fn().mockResolvedValue(undefined),
+    },
+    jobQueue: {
+      enqueueJob: async () => 'job-123',
+      completeJob: async () => {},
+      failJob: async () => {},
+    },
+    ...overrides,
+  };
+}
+
+// ─── Inputs simulating different entry points ────────────────────
+
+/** Simulates stream route building a generation input (initial creation). */
+const streamInput: ProcessGenerationInput = {
+  planId: 'plan-stream-001',
+  userId: 'user-001',
+  tier: 'free',
+  input: {
+    topic: 'Learn TypeScript',
+    skillLevel: 'beginner',
+    weeklyHours: 5,
+    learningStyle: 'mixed',
+    startDate: '2025-01-01',
+    deadlineDate: '2025-03-01',
+    notes: 'Focus on generics',
+  },
+  modelOverride: 'gpt-4o',
+};
+
+/** Simulates retry route building a generation input from existing plan data. */
+const retryInput: ProcessGenerationInput = {
+  planId: 'plan-retry-002',
+  userId: 'user-001',
+  tier: 'free',
+  input: {
+    topic: 'Learn TypeScript',
+    skillLevel: 'beginner',
+    weeklyHours: 5,
+    learningStyle: 'mixed',
+    startDate: '2025-01-01',
+    deadlineDate: '2025-03-01',
+  },
+};
+
+/** Simulates regeneration worker building input with overrides. */
+const regenerationInput: ProcessGenerationInput = {
+  planId: 'plan-regen-003',
+  userId: 'user-001',
+  tier: 'pro',
+  input: {
+    topic: 'Advanced TypeScript',
+    skillLevel: 'intermediate',
+    weeklyHours: 10,
+    learningStyle: 'practice',
+    startDate: '2025-02-01',
+    deadlineDate: '2025-06-01',
+    notes: 'Include design patterns',
+  },
+};
+
+/** Simulates PDF-origin plan generation input. */
+const pdfInput: ProcessGenerationInput = {
+  planId: 'plan-pdf-004',
+  userId: 'user-001',
+  tier: 'free',
+  input: {
+    topic: 'Machine Learning Basics',
+    skillLevel: 'beginner',
+    weeklyHours: 8,
+    learningStyle: 'reading',
+    pdfContext: {
+      mainTopic: 'ML Fundamentals',
+      sections: [
+        {
+          title: 'Introduction',
+          content: 'Overview of machine learning concepts',
+          level: 1,
+        },
+      ],
+    },
+    pdfExtractionHash: 'abc123hash',
+    pdfProofVersion: 1,
+  },
+};
+
+// ─── Tests ───────────────────────────────────────────────────────
+
+describe('Lifecycle Consolidation', () => {
+  let service: PlanLifecycleService;
+  let ports: PlanLifecycleServicePorts;
+
+  beforeEach(() => {
+    ports = createMockPorts();
+    service = new PlanLifecycleService(ports);
+  });
+
+  // ─── PDF input parity ───────────────────────────────────────
+
+  describe('PDF flow uses the same lifecycle boundary as non-PDF flows', () => {
+    it('forwards PDF fields (pdfContext, pdfExtractionHash, pdfProofVersion) to generation port', async () => {
+      await service.processGenerationAttempt(pdfInput);
+      const runGeneration = vi.mocked(ports.generation.runGeneration);
+
+      expect(runGeneration).toHaveBeenCalledWith(
+        expect.objectContaining({
+          planId: 'plan-pdf-004',
+          input: expect.objectContaining({
+            pdfContext: {
+              mainTopic: 'ML Fundamentals',
+              sections: [
+                {
+                  title: 'Introduction',
+                  content: 'Overview of machine learning concepts',
+                  level: 1,
+                },
+              ],
+            },
+            pdfExtractionHash: 'abc123hash',
+            pdfProofVersion: 1,
+          }),
+        })
+      );
+    });
+
+    it('handles PDF generation success identically to non-PDF generation', async () => {
+      const nonPdfResult = await service.processGenerationAttempt(streamInput);
+      const pdfResult = await service.processGenerationAttempt(pdfInput);
+
+      expect(nonPdfResult.status).toBe('generation_success');
+      expect(pdfResult.status).toBe('generation_success');
+    });
+
+    it('handles PDF generation failure identically to non-PDF generation', async () => {
+      ports = createMockPorts({
+        generation: {
+          runGeneration: vi.fn().mockResolvedValue({
+            status: 'failure',
+            classification: 'provider_error',
+            error: new Error('provider down'),
+            durationMs: 500,
+          }),
+        },
+      });
+      service = new PlanLifecycleService(ports);
+
+      const nonPdfResult = await service.processGenerationAttempt(retryInput);
+      const pdfResult = await service.processGenerationAttempt(pdfInput);
+
+      expect(nonPdfResult.status).toBe('retryable_failure');
+      expect(pdfResult.status).toBe('retryable_failure');
+    });
+  });
+
+  // ─── Model override forwarding ──────────────────────────────
+
+  describe('modelOverride forwarding', () => {
+    it('forwards modelOverride to generation port', async () => {
+      await service.processGenerationAttempt(streamInput);
+      const runGeneration = vi.mocked(ports.generation.runGeneration);
+
+      expect(runGeneration).toHaveBeenCalledWith(
+        expect.objectContaining({
+          modelOverride: 'gpt-4o',
+        })
+      );
+    });
+
+    it('omits modelOverride when not provided (retry/regeneration default)', async () => {
+      await service.processGenerationAttempt(retryInput);
+      const runGeneration = vi.mocked(ports.generation.runGeneration);
+
+      expect(runGeneration).toHaveBeenCalledWith(
+        expect.objectContaining({
+          modelOverride: undefined,
+        })
+      );
+    });
+  });
+
+  // ─── One lifecycle record per attempt ───────────────────────
+
+  describe('one lifecycle record per generation attempt', () => {
+    it('calls generation port exactly once per processGenerationAttempt call', async () => {
+      const runGeneration = vi.mocked(ports.generation.runGeneration);
+
+      await service.processGenerationAttempt(streamInput);
+      expect(runGeneration).toHaveBeenCalledTimes(1);
+
+      await service.processGenerationAttempt(retryInput);
+      expect(runGeneration).toHaveBeenCalledTimes(2);
+
+      await service.processGenerationAttempt(regenerationInput);
+      expect(runGeneration).toHaveBeenCalledTimes(3);
+    });
+
+    it('calls markGenerationSuccess exactly once on successful generation', async () => {
+      const markSuccess = vi.mocked(
+        ports.planPersistence.markGenerationSuccess
+      );
+
+      await service.processGenerationAttempt(streamInput);
+      expect(markSuccess).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls markGenerationFailure exactly once on failed generation', async () => {
+      ports = createMockPorts({
+        generation: {
+          runGeneration: vi.fn().mockResolvedValue({
+            status: 'failure',
+            classification: 'timeout',
+            error: new Error('timed out'),
+            durationMs: 30000,
+          }),
+        },
+      });
+      service = new PlanLifecycleService(ports);
+
+      const markFailure = vi.mocked(
+        ports.planPersistence.markGenerationFailure
+      );
+
+      await service.processGenerationAttempt(retryInput);
+      expect(markFailure).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ─── Consistent failed state ────────────────────────────────
+
+  describe('failed generations end in clear, consistent state', () => {
+    it.each([
+      {
+        classification: 'provider_error' as const,
+        expectedStatus: 'retryable_failure',
+      },
+      {
+        classification: 'timeout' as const,
+        expectedStatus: 'retryable_failure',
+      },
+      {
+        classification: 'rate_limit' as const,
+        expectedStatus: 'retryable_failure',
+      },
+      {
+        classification: 'conflict' as const,
+        expectedStatus: 'retryable_failure',
+      },
+      {
+        classification: 'validation' as const,
+        expectedStatus: 'permanent_failure',
+      },
+      {
+        classification: 'capped' as const,
+        expectedStatus: 'permanent_failure',
+      },
+    ])(
+      '$classification → $expectedStatus with plan marked failed',
+      async ({ classification, expectedStatus }) => {
+        ports = createMockPorts({
+          generation: {
+            runGeneration: vi.fn().mockResolvedValue({
+              status: 'failure',
+              classification,
+              error: new Error(`${classification} error`),
+              durationMs: 100,
+              ...(expectedStatus === 'permanent_failure'
+                ? { usage: makeCanonicalUsage() }
+                : {}),
+            }),
+          },
+        });
+        service = new PlanLifecycleService(ports);
+
+        const result = await service.processGenerationAttempt(streamInput);
+        expect(result.status).toBe(expectedStatus);
+
+        const markFailure = vi.mocked(
+          ports.planPersistence.markGenerationFailure
+        );
+        expect(markFailure).toHaveBeenCalledWith(streamInput.planId);
+      }
+    );
+
+    it('always includes classification and error on failure result', async () => {
+      ports = createMockPorts({
+        generation: {
+          runGeneration: vi.fn().mockResolvedValue({
+            status: 'failure',
+            classification: 'provider_error',
+            error: new Error('something went wrong'),
+            durationMs: 200,
+          }),
+        },
+      });
+      service = new PlanLifecycleService(ports);
+
+      const result = await service.processGenerationAttempt(retryInput);
+
+      expect(result.status).toBe('retryable_failure');
+      if (
+        result.status === 'retryable_failure' ||
+        result.status === 'permanent_failure'
+      ) {
+        expect(result.classification).toBe('provider_error');
+        expect(result.error).toBeInstanceOf(Error);
+        expect(result.error.message).toBe('something went wrong');
+      }
+    });
+  });
+
+  // ─── Lifecycle consistency across entry points ──────────────
+
+  describe('lifecycle consistency across stream, retry, and regeneration', () => {
+    it('processes stream, retry, and regeneration inputs identically through the same path', async () => {
+      const runGeneration = vi.mocked(ports.generation.runGeneration);
+
+      const streamResult = await service.processGenerationAttempt(streamInput);
+      const retryResult = await service.processGenerationAttempt(retryInput);
+      const regenResult =
+        await service.processGenerationAttempt(regenerationInput);
+
+      // All three should succeed via the same lifecycle path
+      expect(streamResult.status).toBe('generation_success');
+      expect(retryResult.status).toBe('generation_success');
+      expect(regenResult.status).toBe('generation_success');
+
+      // All three called the same generation port
+      expect(runGeneration).toHaveBeenCalledTimes(3);
+
+      // Each called markGenerationSuccess
+      const markSuccess = vi.mocked(
+        ports.planPersistence.markGenerationSuccess
+      );
+      expect(markSuccess).toHaveBeenCalledTimes(3);
+      expect(markSuccess).toHaveBeenCalledWith('plan-stream-001');
+      expect(markSuccess).toHaveBeenCalledWith('plan-retry-002');
+      expect(markSuccess).toHaveBeenCalledWith('plan-regen-003');
+
+      // Each recorded usage
+      const recordUsage = vi.mocked(ports.usageRecording.recordUsage);
+      expect(recordUsage).toHaveBeenCalledTimes(3);
+    });
+
+    it('handles failure consistently for all entry points', async () => {
+      ports = createMockPorts({
+        generation: {
+          runGeneration: vi.fn().mockResolvedValue({
+            status: 'failure',
+            classification: 'provider_error',
+            error: new Error('service unavailable'),
+            durationMs: 300,
+          }),
+        },
+      });
+      service = new PlanLifecycleService(ports);
+
+      const results = await Promise.all([
+        service.processGenerationAttempt(streamInput),
+        service.processGenerationAttempt(retryInput),
+        service.processGenerationAttempt(regenerationInput),
+      ]);
+
+      // All three should be retryable_failure
+      for (const result of results) {
+        expect(result.status).toBe('retryable_failure');
+        if (result.status === 'retryable_failure') {
+          expect(result.classification).toBe('provider_error');
+        }
+      }
+
+      // All three marked plan as failed
+      const markFailure = vi.mocked(
+        ports.planPersistence.markGenerationFailure
+      );
+      expect(markFailure).toHaveBeenCalledTimes(3);
+
+      // No usage recorded for retryable failures
+      const recordUsage = vi.mocked(ports.usageRecording.recordUsage);
+      expect(recordUsage).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── Plan creation lifecycle consistency ────────────────────
+
+  describe('plan creation lifecycle consistency', () => {
+    it('creates AI-origin plans through the lifecycle service', async () => {
+      const result = await service.createPlan({
+        userId: 'user-001',
+        topic: 'Learn Rust',
+        skillLevel: 'beginner',
+        weeklyHours: 5,
+        learningStyle: 'mixed',
+      });
+
+      expect(result.status).toBe('success');
+      if (result.status === 'success') {
+        expect(result.planId).toBe('plan-123');
+        expect(result.tier).toBe('free');
+      }
+    });
+
+    it('creates PDF-origin plans through the lifecycle service', async () => {
+      const result = await service.createPdfPlan({
+        userId: 'user-001',
+        authUserId: 'auth-001',
+        body: { topic: 'ML', extractedContent: {} },
+        topic: 'ML',
+        skillLevel: 'beginner',
+        weeklyHours: 5,
+        learningStyle: 'mixed',
+        extractedContent: {},
+        pdfProofToken: 'proof-token',
+        pdfExtractionHash: 'hash-abc',
+      });
+
+      expect(result.status).toBe('success');
+      if (result.status === 'success') {
+        expect(result.planId).toBe('plan-123');
+      }
+    });
+
+    it('PDF and AI plan creation both check capped plans', async () => {
+      const findCapped = vi.fn().mockResolvedValue('capped-plan-id');
+      ports = createMockPorts({
+        planPersistence: {
+          ...createMockPorts().planPersistence,
+          findCappedPlanWithoutModules: findCapped,
+        },
+      });
+      service = new PlanLifecycleService(ports);
+
+      const aiResult = await service.createPlan({
+        userId: 'user-001',
+        topic: 'Learn Rust',
+        skillLevel: 'beginner',
+        weeklyHours: 5,
+        learningStyle: 'mixed',
+      });
+
+      const pdfResult = await service.createPdfPlan({
+        userId: 'user-001',
+        authUserId: 'auth-001',
+        body: { topic: 'ML', extractedContent: {} },
+        topic: 'ML',
+        skillLevel: 'beginner',
+        weeklyHours: 5,
+        learningStyle: 'mixed',
+        extractedContent: {},
+        pdfProofToken: 'proof-token',
+        pdfExtractionHash: 'hash-abc',
+      });
+
+      expect(aiResult.status).toBe('quota_rejected');
+      expect(pdfResult.status).toBe('quota_rejected');
+      expect(findCapped).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/tests/unit/features/plans/lifecycle/lifecycle-consolidation.spec.ts
+++ b/tests/unit/features/plans/lifecycle/lifecycle-consolidation.spec.ts
@@ -20,10 +20,14 @@ import { makeCanonicalUsage } from '../../../../fixtures/canonical-usage.factory
 
 // ─── Helpers ─────────────────────────────────────────────────────
 
-function createMockPorts(
-  overrides?: Partial<PlanLifecycleServicePorts>
-): PlanLifecycleServicePorts {
-  return {
+type PortOverrides = {
+  [K in keyof PlanLifecycleServicePorts]?: Partial<
+    PlanLifecycleServicePorts[K]
+  >;
+};
+
+function createMockPorts(overrides?: PortOverrides): PlanLifecycleServicePorts {
+  const defaults = {
     planPersistence: {
       atomicInsertPlan: async () => ({
         success: true as const,
@@ -79,14 +83,28 @@ function createMockPorts(
       completeJob: async () => {},
       failJob: async () => {},
     },
-    ...overrides,
+  };
+
+  return {
+    planPersistence: {
+      ...defaults.planPersistence,
+      ...overrides?.planPersistence,
+    },
+    quota: { ...defaults.quota, ...overrides?.quota },
+    pdfOrigin: { ...defaults.pdfOrigin, ...overrides?.pdfOrigin },
+    generation: { ...defaults.generation, ...overrides?.generation },
+    usageRecording: {
+      ...defaults.usageRecording,
+      ...overrides?.usageRecording,
+    },
+    jobQueue: { ...defaults.jobQueue, ...overrides?.jobQueue },
   };
 }
 
 // ─── Inputs simulating different entry points ────────────────────
 
 /** Simulates stream route building a generation input (initial creation). */
-const streamInput: ProcessGenerationInput = {
+const STREAM_INPUT: ProcessGenerationInput = {
   planId: 'plan-stream-001',
   userId: 'user-001',
   tier: 'free',
@@ -103,7 +121,7 @@ const streamInput: ProcessGenerationInput = {
 };
 
 /** Simulates retry route building a generation input from existing plan data. */
-const retryInput: ProcessGenerationInput = {
+const RETRY_INPUT: ProcessGenerationInput = {
   planId: 'plan-retry-002',
   userId: 'user-001',
   tier: 'free',
@@ -118,7 +136,7 @@ const retryInput: ProcessGenerationInput = {
 };
 
 /** Simulates regeneration worker building input with overrides. */
-const regenerationInput: ProcessGenerationInput = {
+const REGENERATION_INPUT: ProcessGenerationInput = {
   planId: 'plan-regen-003',
   userId: 'user-001',
   tier: 'pro',
@@ -134,7 +152,7 @@ const regenerationInput: ProcessGenerationInput = {
 };
 
 /** Simulates PDF-origin plan generation input. */
-const pdfInput: ProcessGenerationInput = {
+const PDF_INPUT: ProcessGenerationInput = {
   planId: 'plan-pdf-004',
   userId: 'user-001',
   tier: 'free',
@@ -173,7 +191,7 @@ describe('Lifecycle Consolidation', () => {
 
   describe('PDF flow uses the same lifecycle boundary as non-PDF flows', () => {
     it('forwards PDF fields (pdfContext, pdfExtractionHash, pdfProofVersion) to generation port', async () => {
-      await service.processGenerationAttempt(pdfInput);
+      await service.processGenerationAttempt(PDF_INPUT);
       const runGeneration = vi.mocked(ports.generation.runGeneration);
 
       expect(runGeneration).toHaveBeenCalledWith(
@@ -198,8 +216,8 @@ describe('Lifecycle Consolidation', () => {
     });
 
     it('handles PDF generation success identically to non-PDF generation', async () => {
-      const nonPdfResult = await service.processGenerationAttempt(streamInput);
-      const pdfResult = await service.processGenerationAttempt(pdfInput);
+      const nonPdfResult = await service.processGenerationAttempt(STREAM_INPUT);
+      const pdfResult = await service.processGenerationAttempt(PDF_INPUT);
 
       expect(nonPdfResult.status).toBe('generation_success');
       expect(pdfResult.status).toBe('generation_success');
@@ -218,8 +236,8 @@ describe('Lifecycle Consolidation', () => {
       });
       service = new PlanLifecycleService(ports);
 
-      const nonPdfResult = await service.processGenerationAttempt(retryInput);
-      const pdfResult = await service.processGenerationAttempt(pdfInput);
+      const nonPdfResult = await service.processGenerationAttempt(RETRY_INPUT);
+      const pdfResult = await service.processGenerationAttempt(PDF_INPUT);
 
       expect(nonPdfResult.status).toBe('retryable_failure');
       expect(pdfResult.status).toBe('retryable_failure');
@@ -230,7 +248,7 @@ describe('Lifecycle Consolidation', () => {
 
   describe('modelOverride forwarding', () => {
     it('forwards modelOverride to generation port', async () => {
-      await service.processGenerationAttempt(streamInput);
+      await service.processGenerationAttempt(STREAM_INPUT);
       const runGeneration = vi.mocked(ports.generation.runGeneration);
 
       expect(runGeneration).toHaveBeenCalledWith(
@@ -241,7 +259,7 @@ describe('Lifecycle Consolidation', () => {
     });
 
     it('omits modelOverride when not provided (retry/regeneration default)', async () => {
-      await service.processGenerationAttempt(retryInput);
+      await service.processGenerationAttempt(RETRY_INPUT);
       const runGeneration = vi.mocked(ports.generation.runGeneration);
 
       expect(runGeneration).toHaveBeenCalledWith(
@@ -255,17 +273,22 @@ describe('Lifecycle Consolidation', () => {
   // ─── One lifecycle record per attempt ───────────────────────
 
   describe('one lifecycle record per generation attempt', () => {
-    it('calls generation port exactly once per processGenerationAttempt call', async () => {
+    it('calls generation port exactly once for stream input', async () => {
       const runGeneration = vi.mocked(ports.generation.runGeneration);
-
-      await service.processGenerationAttempt(streamInput);
+      await service.processGenerationAttempt(STREAM_INPUT);
       expect(runGeneration).toHaveBeenCalledTimes(1);
+    });
 
-      await service.processGenerationAttempt(retryInput);
-      expect(runGeneration).toHaveBeenCalledTimes(2);
+    it('calls generation port exactly once for retry input', async () => {
+      const runGeneration = vi.mocked(ports.generation.runGeneration);
+      await service.processGenerationAttempt(RETRY_INPUT);
+      expect(runGeneration).toHaveBeenCalledTimes(1);
+    });
 
-      await service.processGenerationAttempt(regenerationInput);
-      expect(runGeneration).toHaveBeenCalledTimes(3);
+    it('calls generation port exactly once for regeneration input', async () => {
+      const runGeneration = vi.mocked(ports.generation.runGeneration);
+      await service.processGenerationAttempt(REGENERATION_INPUT);
+      expect(runGeneration).toHaveBeenCalledTimes(1);
     });
 
     it('calls markGenerationSuccess exactly once on successful generation', async () => {
@@ -273,7 +296,7 @@ describe('Lifecycle Consolidation', () => {
         ports.planPersistence.markGenerationSuccess
       );
 
-      await service.processGenerationAttempt(streamInput);
+      await service.processGenerationAttempt(STREAM_INPUT);
       expect(markSuccess).toHaveBeenCalledTimes(1);
     });
 
@@ -294,7 +317,7 @@ describe('Lifecycle Consolidation', () => {
         ports.planPersistence.markGenerationFailure
       );
 
-      await service.processGenerationAttempt(retryInput);
+      await service.processGenerationAttempt(RETRY_INPUT);
       expect(markFailure).toHaveBeenCalledTimes(1);
     });
   });
@@ -337,6 +360,8 @@ describe('Lifecycle Consolidation', () => {
               classification,
               error: new Error(`${classification} error`),
               durationMs: 100,
+              // Permanent failures (validation, capped) include usage data from
+              // the provider; retryable failures (timeout, rate_limit, etc.) do not.
               ...(expectedStatus === 'permanent_failure'
                 ? { usage: makeCanonicalUsage() }
                 : {}),
@@ -345,13 +370,13 @@ describe('Lifecycle Consolidation', () => {
         });
         service = new PlanLifecycleService(ports);
 
-        const result = await service.processGenerationAttempt(streamInput);
+        const result = await service.processGenerationAttempt(STREAM_INPUT);
         expect(result.status).toBe(expectedStatus);
 
         const markFailure = vi.mocked(
           ports.planPersistence.markGenerationFailure
         );
-        expect(markFailure).toHaveBeenCalledWith(streamInput.planId);
+        expect(markFailure).toHaveBeenCalledWith(STREAM_INPUT.planId);
       }
     );
 
@@ -368,7 +393,7 @@ describe('Lifecycle Consolidation', () => {
       });
       service = new PlanLifecycleService(ports);
 
-      const result = await service.processGenerationAttempt(retryInput);
+      const result = await service.processGenerationAttempt(RETRY_INPUT);
 
       expect(result.status).toBe('retryable_failure');
       if (
@@ -388,10 +413,10 @@ describe('Lifecycle Consolidation', () => {
     it('processes stream, retry, and regeneration inputs identically through the same path', async () => {
       const runGeneration = vi.mocked(ports.generation.runGeneration);
 
-      const streamResult = await service.processGenerationAttempt(streamInput);
-      const retryResult = await service.processGenerationAttempt(retryInput);
+      const streamResult = await service.processGenerationAttempt(STREAM_INPUT);
+      const retryResult = await service.processGenerationAttempt(RETRY_INPUT);
       const regenResult =
-        await service.processGenerationAttempt(regenerationInput);
+        await service.processGenerationAttempt(REGENERATION_INPUT);
 
       // All three should succeed via the same lifecycle path
       expect(streamResult.status).toBe('generation_success');
@@ -429,9 +454,9 @@ describe('Lifecycle Consolidation', () => {
       service = new PlanLifecycleService(ports);
 
       const results = await Promise.all([
-        service.processGenerationAttempt(streamInput),
-        service.processGenerationAttempt(retryInput),
-        service.processGenerationAttempt(regenerationInput),
+        service.processGenerationAttempt(STREAM_INPUT),
+        service.processGenerationAttempt(RETRY_INPUT),
+        service.processGenerationAttempt(REGENERATION_INPUT),
       ]);
 
       // All three should be retryable_failure
@@ -496,10 +521,7 @@ describe('Lifecycle Consolidation', () => {
     it('PDF and AI plan creation both check capped plans', async () => {
       const findCapped = vi.fn().mockResolvedValue('capped-plan-id');
       ports = createMockPorts({
-        planPersistence: {
-          ...createMockPorts().planPersistence,
-          findCappedPlanWithoutModules: findCapped,
-        },
+        planPersistence: { findCappedPlanWithoutModules: findCapped },
       });
       service = new PlanLifecycleService(ports);
 

--- a/tests/unit/features/plans/lifecycle/plan-operations.spec.ts
+++ b/tests/unit/features/plans/lifecycle/plan-operations.spec.ts
@@ -7,6 +7,11 @@ import { findRecentDuplicatePlan } from '@/features/plans/lifecycle/plan-operati
 /**
  * Build a chainable mock DbClient that resolves with the given rows.
  * Mimics the Drizzle query builder chain: select → from → where → limit.
+ *
+ * Uses `as unknown as` double cast because Drizzle's internal query-builder
+ * types are deeply nested generics that cannot be satisfied with a simple
+ * partial mock. The cast is safe here since we only exercise the fluent
+ * chain methods the function under test actually calls.
  */
 function createMockDbClient(rows: Array<{ id: string }>) {
   const limitFn = vi.fn().mockResolvedValue(rows);
@@ -61,7 +66,7 @@ describe('findRecentDuplicatePlan', () => {
     expect(spies.limitFn).toHaveBeenCalledWith(1);
   });
 
-  it('returns the first match when multiple rows exist', async () => {
+  it('returns id from first element when result array has multiple entries (defensive)', async () => {
     const { client } = createMockDbClient([
       { id: 'first-plan' },
       { id: 'second-plan' },
@@ -74,5 +79,21 @@ describe('findRecentDuplicatePlan', () => {
     );
 
     expect(result).toBe('first-plan');
+  });
+
+  it('propagates database errors to the caller', async () => {
+    const dbError = new Error('DB connection lost');
+    const limitFn = vi.fn().mockRejectedValue(dbError);
+    const whereFn = vi.fn().mockReturnValue({ limit: limitFn });
+    const fromFn = vi.fn().mockReturnValue({ where: whereFn });
+    const selectFn = vi.fn().mockReturnValue({ from: fromFn });
+
+    const client = { select: selectFn } as unknown as Parameters<
+      typeof findRecentDuplicatePlan
+    >[2];
+
+    await expect(
+      findRecentDuplicatePlan('user-abc', 'Learn TypeScript', client)
+    ).rejects.toThrow('DB connection lost');
   });
 });

--- a/tests/unit/features/plans/lifecycle/plan-operations.spec.ts
+++ b/tests/unit/features/plans/lifecycle/plan-operations.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { findRecentDuplicatePlan } from '@/features/plans/lifecycle/plan-operations';
+
+// ─── Helpers ─────────────────────────────────────────────────────
+
+/**
+ * Build a chainable mock DbClient that resolves with the given rows.
+ * Mimics the Drizzle query builder chain: select → from → where → limit.
+ */
+function createMockDbClient(rows: Array<{ id: string }>) {
+  const limitFn = vi.fn().mockResolvedValue(rows);
+  const whereFn = vi.fn().mockReturnValue({ limit: limitFn });
+  const fromFn = vi.fn().mockReturnValue({ where: whereFn });
+  const selectFn = vi.fn().mockReturnValue({ from: fromFn });
+
+  return {
+    client: { select: selectFn } as unknown as Parameters<
+      typeof findRecentDuplicatePlan
+    >[2],
+    spies: { selectFn, fromFn, whereFn, limitFn },
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────
+
+describe('findRecentDuplicatePlan', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns the plan ID when a matching row exists', async () => {
+    const { client } = createMockDbClient([{ id: 'dup-plan-123' }]);
+
+    const result = await findRecentDuplicatePlan(
+      'user-abc',
+      'Learn TypeScript',
+      client
+    );
+
+    expect(result).toBe('dup-plan-123');
+  });
+
+  it('returns null when no matching row exists', async () => {
+    const { client } = createMockDbClient([]);
+
+    const result = await findRecentDuplicatePlan(
+      'user-abc',
+      'Learn TypeScript',
+      client
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('queries with limit(1) to return at most one result', async () => {
+    const { client, spies } = createMockDbClient([]);
+
+    await findRecentDuplicatePlan('user-abc', 'Learn TypeScript', client);
+
+    expect(spies.limitFn).toHaveBeenCalledWith(1);
+  });
+
+  it('returns the first match when multiple rows exist', async () => {
+    const { client } = createMockDbClient([
+      { id: 'first-plan' },
+      { id: 'second-plan' },
+    ]);
+
+    const result = await findRecentDuplicatePlan(
+      'user-abc',
+      'Learn TypeScript',
+      client
+    );
+
+    expect(result).toBe('first-plan');
+  });
+});

--- a/tests/unit/features/plans/lifecycle/process-generation.spec.ts
+++ b/tests/unit/features/plans/lifecycle/process-generation.spec.ts
@@ -4,23 +4,7 @@ import type { PlanLifecycleServicePorts } from '@/features/plans/lifecycle/servi
 import { PlanLifecycleService } from '@/features/plans/lifecycle/service';
 import type { ProcessGenerationInput } from '@/features/plans/lifecycle/types';
 import { isRetryableClassification } from '@/features/plans/lifecycle/types';
-import type { CanonicalAIUsage } from '@/shared/types/ai-usage.types';
-
-// ─── Helpers ─────────────────────────────────────────────────────
-
-function makeCanonicalUsage(
-  overrides?: Partial<CanonicalAIUsage>
-): CanonicalAIUsage {
-  return {
-    inputTokens: 100,
-    outputTokens: 200,
-    totalTokens: 300,
-    model: 'gpt-4o',
-    provider: 'openai',
-    estimatedCostCents: 0,
-    ...overrides,
-  };
-}
+import { makeCanonicalUsage } from '../../../../fixtures/canonical-usage.factory';
 
 function createMockPorts(
   overrides?: Partial<PlanLifecycleServicePorts>
@@ -243,8 +227,6 @@ describe('PlanLifecycleService.processGenerationAttempt', () => {
               inputTokens: 50,
               outputTokens: 0,
               totalTokens: 50,
-              provider: 'openai',
-              model: 'gpt-4o',
             }),
             durationMs: 200,
           }),
@@ -361,7 +343,6 @@ describe('PlanLifecycleService.processGenerationAttempt', () => {
             inputTokens: 0,
             outputTokens: 0,
             totalTokens: 0,
-            estimatedCostCents: 0,
           }),
           durationMs: 800,
         }),

--- a/tests/unit/features/plans/lifecycle/process-generation.spec.ts
+++ b/tests/unit/features/plans/lifecycle/process-generation.spec.ts
@@ -4,8 +4,23 @@ import type { PlanLifecycleServicePorts } from '@/features/plans/lifecycle/servi
 import { PlanLifecycleService } from '@/features/plans/lifecycle/service';
 import type { ProcessGenerationInput } from '@/features/plans/lifecycle/types';
 import { isRetryableClassification } from '@/features/plans/lifecycle/types';
+import type { CanonicalAIUsage } from '@/shared/types/ai-usage.types';
 
 // ─── Helpers ─────────────────────────────────────────────────────
+
+function makeCanonicalUsage(
+  overrides?: Partial<CanonicalAIUsage>
+): CanonicalAIUsage {
+  return {
+    inputTokens: 100,
+    outputTokens: 200,
+    totalTokens: 300,
+    model: 'gpt-4o',
+    provider: 'openai',
+    estimatedCostCents: 0,
+    ...overrides,
+  };
+}
 
 function createMockPorts(
   overrides?: Partial<PlanLifecycleServicePorts>
@@ -17,6 +32,7 @@ function createMockPorts(
         id: 'plan-123',
       }),
       findCappedPlanWithoutModules: async () => null,
+      findRecentDuplicatePlan: async () => null,
       markGenerationSuccess: vi.fn().mockResolvedValue(undefined),
       markGenerationFailure: vi.fn().mockResolvedValue(undefined),
     },
@@ -57,6 +73,7 @@ function createMockPorts(
           model: 'gpt-4o',
           usage: { inputTokens: 100, outputTokens: 200 },
         },
+        usage: makeCanonicalUsage(),
         durationMs: 1500,
       }),
     },
@@ -120,8 +137,10 @@ describe('PlanLifecycleService.processGenerationAttempt', () => {
     expect(recordUsage).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: 'user-abc',
-        provider: 'openai',
-        model: 'gpt-4o',
+        usage: expect.objectContaining({
+          provider: 'openai',
+          model: 'gpt-4o',
+        }),
         kind: 'plan',
       })
     );
@@ -220,6 +239,13 @@ describe('PlanLifecycleService.processGenerationAttempt', () => {
               model: 'gpt-4o',
               usage: { inputTokens: 50, outputTokens: 0 },
             },
+            usage: makeCanonicalUsage({
+              inputTokens: 50,
+              outputTokens: 0,
+              totalTokens: 50,
+              provider: 'openai',
+              model: 'gpt-4o',
+            }),
             durationMs: 200,
           }),
         },
@@ -270,6 +296,13 @@ describe('PlanLifecycleService.processGenerationAttempt', () => {
             model: 'claude-3',
             usage: { inputTokens: 80, outputTokens: 10 },
           },
+          usage: makeCanonicalUsage({
+            inputTokens: 80,
+            outputTokens: 10,
+            totalTokens: 90,
+            provider: 'anthropic',
+            model: 'claude-3',
+          }),
           durationMs: 150,
         }),
       },
@@ -282,8 +315,10 @@ describe('PlanLifecycleService.processGenerationAttempt', () => {
     expect(recordUsage).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: 'user-abc',
-        provider: 'anthropic',
-        model: 'claude-3',
+        usage: expect.objectContaining({
+          provider: 'anthropic',
+          model: 'claude-3',
+        }),
         kind: 'plan',
       })
     );
@@ -320,6 +355,14 @@ describe('PlanLifecycleService.processGenerationAttempt', () => {
           status: 'success',
           modules: [],
           metadata: {},
+          usage: makeCanonicalUsage({
+            provider: 'unknown',
+            model: 'unknown',
+            inputTokens: 0,
+            outputTokens: 0,
+            totalTokens: 0,
+            estimatedCostCents: 0,
+          }),
           durationMs: 800,
         }),
       },
@@ -331,8 +374,10 @@ describe('PlanLifecycleService.processGenerationAttempt', () => {
 
     expect(recordUsage).toHaveBeenCalledWith(
       expect.objectContaining({
-        provider: 'unknown',
-        model: 'unknown',
+        usage: expect.objectContaining({
+          provider: 'unknown',
+          model: 'unknown',
+        }),
       })
     );
   });

--- a/tests/unit/features/plans/lifecycle/service.spec.ts
+++ b/tests/unit/features/plans/lifecycle/service.spec.ts
@@ -537,7 +537,9 @@ describe('PlanLifecycleService', () => {
     });
 
     it('does not reserve PDF quota when duplicate is detected', async () => {
-      const prepareSpy = vi.fn();
+      const prepareSpy = vi
+        .fn()
+        .mockRejectedValue(new Error('preparePlanInput should not be called'));
       ports = createMockPorts({
         planPersistence: {
           ...createMockPorts().planPersistence,

--- a/tests/unit/features/plans/lifecycle/service.spec.ts
+++ b/tests/unit/features/plans/lifecycle/service.spec.ts
@@ -19,6 +19,7 @@ function createMockPorts(
         id: 'plan-123',
       }),
       findCappedPlanWithoutModules: async () => null,
+      findRecentDuplicatePlan: async () => null,
       markGenerationSuccess: async () => {},
       markGenerationFailure: async () => {},
     },
@@ -55,6 +56,14 @@ function createMockPorts(
         status: 'success' as const,
         modules: [],
         metadata: {},
+        usage: {
+          inputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 0,
+          model: 'unknown',
+          provider: 'unknown',
+          estimatedCostCents: 0,
+        },
         durationMs: 1000,
       }),
     },
@@ -230,6 +239,75 @@ describe('PlanLifecycleService', () => {
       await service.createPlan({ ...validInput, topic: '  Learn Rust  ' });
 
       expect(capturedData).toMatchObject({ topic: 'Learn Rust' });
+    });
+
+    it('returns duplicate_detected when a recent duplicate plan exists', async () => {
+      ports = createMockPorts({
+        planPersistence: {
+          ...createMockPorts().planPersistence,
+          findRecentDuplicatePlan: async () => 'existing-plan-id',
+        },
+      });
+      service = new PlanLifecycleService(ports);
+
+      const result = await service.createPlan(validInput);
+
+      expect(result.status).toBe('duplicate_detected');
+      if (result.status === 'duplicate_detected') {
+        expect(result.existingPlanId).toBe('existing-plan-id');
+      }
+    });
+
+    it('does not call atomicInsertPlan when duplicate is detected', async () => {
+      const insertSpy = vi
+        .fn()
+        .mockResolvedValue({ success: true as const, id: 'plan-new' });
+      ports = createMockPorts({
+        planPersistence: {
+          ...createMockPorts().planPersistence,
+          findRecentDuplicatePlan: async () => 'existing-plan-id',
+          atomicInsertPlan: insertSpy,
+        },
+      });
+      service = new PlanLifecycleService(ports);
+
+      await service.createPlan(validInput);
+
+      expect(insertSpy).not.toHaveBeenCalled();
+    });
+
+    it('passes userId and trimmed topic to findRecentDuplicatePlan', async () => {
+      let capturedUserId: string | undefined;
+      let capturedTopic: string | undefined;
+      ports = createMockPorts({
+        planPersistence: {
+          ...createMockPorts().planPersistence,
+          findRecentDuplicatePlan: async (userId, topic) => {
+            capturedUserId = userId;
+            capturedTopic = topic;
+            return null;
+          },
+        },
+      });
+      service = new PlanLifecycleService(ports);
+
+      await service.createPlan({
+        ...validInput,
+        topic: '  Learn TypeScript  ',
+      });
+
+      expect(capturedUserId).toBe('user-abc');
+      expect(capturedTopic).toBe('Learn TypeScript');
+    });
+
+    it('proceeds to create plan when no duplicate exists', async () => {
+      // Default mock returns null for findRecentDuplicatePlan
+      const result = await service.createPlan(validInput);
+
+      expect(result.status).toBe('success');
+      if (result.status === 'success') {
+        expect(result.planId).toBe('plan-123');
+      }
     });
 
     it('resolves tier for the correct userId', async () => {
@@ -439,6 +517,60 @@ describe('PlanLifecycleService', () => {
         internalUserId: 'user-abc',
         reserved: false,
       });
+    });
+
+    it('returns duplicate_detected when a recent duplicate PDF plan exists', async () => {
+      ports = createMockPorts({
+        planPersistence: {
+          ...createMockPorts().planPersistence,
+          findRecentDuplicatePlan: async () => 'existing-pdf-plan-id',
+        },
+      });
+      service = new PlanLifecycleService(ports);
+
+      const result = await service.createPdfPlan(validPdfInput);
+
+      expect(result.status).toBe('duplicate_detected');
+      if (result.status === 'duplicate_detected') {
+        expect(result.existingPlanId).toBe('existing-pdf-plan-id');
+      }
+    });
+
+    it('does not reserve PDF quota when duplicate is detected', async () => {
+      const prepareSpy = vi.fn();
+      ports = createMockPorts({
+        planPersistence: {
+          ...createMockPorts().planPersistence,
+          findRecentDuplicatePlan: async () => 'existing-pdf-plan-id',
+        },
+        pdfOrigin: {
+          preparePlanInput: prepareSpy,
+          rollbackPdfUsage: async () => {},
+        },
+      });
+      service = new PlanLifecycleService(ports);
+
+      await service.createPdfPlan(validPdfInput);
+
+      expect(prepareSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not call atomicInsertPlan when PDF duplicate is detected', async () => {
+      const insertSpy = vi
+        .fn()
+        .mockResolvedValue({ success: true as const, id: 'plan-new' });
+      ports = createMockPorts({
+        planPersistence: {
+          ...createMockPorts().planPersistence,
+          findRecentDuplicatePlan: async () => 'existing-pdf-plan-id',
+          atomicInsertPlan: insertSpy,
+        },
+      });
+      service = new PlanLifecycleService(ports);
+
+      await service.createPdfPlan(validPdfInput);
+
+      expect(insertSpy).not.toHaveBeenCalled();
     });
 
     it('does not call rollback on success', async () => {

--- a/tests/unit/features/plans/retry-policy.spec.ts
+++ b/tests/unit/features/plans/retry-policy.spec.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeEffectiveMaxAttempts,
+  getRetryDelay,
+  JOB_RETRY_BASE_SECONDS,
+  JOB_RETRY_MAX_DELAY_SECONDS,
+  MAX_JOB_RETRIES,
+  MAX_PROVIDER_RETRIES,
+  MAX_TOTAL_AI_CALLS_PER_JOB,
+  shouldRetryJob,
+} from '@/features/plans/retry-policy';
+
+describe('retry-policy', () => {
+  describe('shouldRetryJob', () => {
+    it('returns shouldRetry=true when retryable and under max attempts', () => {
+      const result = shouldRetryJob({
+        attemptNumber: 1,
+        maxAttempts: 3,
+        retryable: true,
+      });
+
+      expect(result.shouldRetry).toBe(true);
+      expect(result.delay).toBeGreaterThan(0);
+      expect(result.reason).toContain('Retryable');
+    });
+
+    it('returns shouldRetry=false when retryable but at max attempts', () => {
+      const result = shouldRetryJob({
+        attemptNumber: 3,
+        maxAttempts: 3,
+        retryable: true,
+      });
+
+      expect(result.shouldRetry).toBe(false);
+      expect(result.reason).toContain('Attempt cap reached');
+    });
+
+    it('returns shouldRetry=false when retryable but past max attempts', () => {
+      const result = shouldRetryJob({
+        attemptNumber: 5,
+        maxAttempts: 3,
+        retryable: true,
+      });
+
+      expect(result.shouldRetry).toBe(false);
+      expect(result.reason).toContain('Attempt cap reached');
+    });
+
+    it('returns shouldRetry=false when not retryable regardless of attempts', () => {
+      const result = shouldRetryJob({
+        attemptNumber: 1,
+        maxAttempts: 10,
+        retryable: false,
+      });
+
+      expect(result.shouldRetry).toBe(false);
+      expect(result.reason).toContain('not retryable');
+    });
+
+    it('includes delay in successful retry decisions', () => {
+      const result = shouldRetryJob({
+        attemptNumber: 2,
+        maxAttempts: 5,
+        retryable: true,
+      });
+
+      expect(result.shouldRetry).toBe(true);
+      expect(result.delay).toBe(getRetryDelay(2));
+    });
+
+    it('does not include delay when shouldRetry is false', () => {
+      const result = shouldRetryJob({
+        attemptNumber: 1,
+        maxAttempts: 3,
+        retryable: false,
+      });
+
+      expect(result.delay).toBeUndefined();
+    });
+  });
+
+  describe('getRetryDelay', () => {
+    it('computes exponential backoff', () => {
+      expect(getRetryDelay(1)).toBe(Math.pow(JOB_RETRY_BASE_SECONDS, 1) * 1000);
+      expect(getRetryDelay(2)).toBe(Math.pow(JOB_RETRY_BASE_SECONDS, 2) * 1000);
+      expect(getRetryDelay(3)).toBe(Math.pow(JOB_RETRY_BASE_SECONDS, 3) * 1000);
+    });
+
+    it('caps delay at JOB_RETRY_MAX_DELAY_SECONDS', () => {
+      const maxDelayMs = JOB_RETRY_MAX_DELAY_SECONDS * 1000;
+
+      // A very high attempt number should be capped
+      expect(getRetryDelay(100)).toBe(maxDelayMs);
+      expect(getRetryDelay(20)).toBe(maxDelayMs);
+    });
+
+    it('does not exceed 300 seconds (5 minutes)', () => {
+      for (let attempt = 1; attempt <= 50; attempt++) {
+        expect(getRetryDelay(attempt)).toBeLessThanOrEqual(300_000);
+      }
+    });
+  });
+
+  describe('computeEffectiveMaxAttempts', () => {
+    it('returns baseMax when retryableOverride is true', () => {
+      expect(computeEffectiveMaxAttempts(3, true)).toBe(3);
+    });
+
+    it('returns baseMax when retryableOverride is undefined', () => {
+      expect(computeEffectiveMaxAttempts(5)).toBe(5);
+    });
+
+    it('returns 0 when retryableOverride is false', () => {
+      expect(computeEffectiveMaxAttempts(10, false)).toBe(0);
+    });
+
+    it('never returns 100 (old ABSOLUTE_MAX_ATTEMPTS)', () => {
+      // This is the critical regression test: retryable=true must NOT escalate to 100
+      expect(computeEffectiveMaxAttempts(3, true)).toBe(3);
+      expect(computeEffectiveMaxAttempts(3, true)).not.toBe(100);
+    });
+  });
+
+  describe('constant invariants', () => {
+    it('MAX_TOTAL_AI_CALLS_PER_JOB = MAX_JOB_RETRIES * (MAX_PROVIDER_RETRIES + 1)', () => {
+      expect(MAX_TOTAL_AI_CALLS_PER_JOB).toBe(
+        MAX_JOB_RETRIES * (MAX_PROVIDER_RETRIES + 1)
+      );
+    });
+
+    it('MAX_TOTAL_AI_CALLS_PER_JOB equals 6', () => {
+      expect(MAX_TOTAL_AI_CALLS_PER_JOB).toBe(6);
+    });
+
+    it('total AI calls per regeneration is bounded by MAX_TOTAL_AI_CALLS_PER_JOB', () => {
+      // Simulate worst case: every job attempt triggers max provider retries
+      const totalProviderCallsPerAttempt = MAX_PROVIDER_RETRIES + 1;
+      const totalCalls = MAX_JOB_RETRIES * totalProviderCallsPerAttempt;
+
+      expect(totalCalls).toBe(MAX_TOTAL_AI_CALLS_PER_JOB);
+      expect(totalCalls).toBeLessThanOrEqual(MAX_TOTAL_AI_CALLS_PER_JOB);
+    });
+
+    it('MAX_JOB_RETRIES is a reasonable bound (not 100)', () => {
+      expect(MAX_JOB_RETRIES).toBeLessThanOrEqual(10);
+      expect(MAX_JOB_RETRIES).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/tests/unit/hooks/usePlanStatus.spec.tsx
+++ b/tests/unit/hooks/usePlanStatus.spec.tsx
@@ -1,5 +1,6 @@
 import { usePlanStatus } from '@/hooks/usePlanStatus';
 import { clientLogger } from '@/lib/logging/client';
+import { INITIAL_POLL_MS } from '@/shared/constants/polling';
 import { PLAN_STATUSES } from '@/shared/types/client';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -9,11 +10,20 @@ import {
   createPlanStatusResponse,
 } from '../../fixtures/plan-status';
 
+/**
+ * With Math.random() mocked to 0.5, jitter factor is exactly 1.0
+ * so delays are deterministic: computeNextDelay(d) = min(d * 1.5, 10000)
+ */
+const FIRST_BACKOFF = 1500; // computeNextDelay(1000) = 1000 * 1.5
+const SECOND_BACKOFF = 2250; // computeNextDelay(1500) = 1500 * 1.5
+
 describe('usePlanStatus', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(clientLogger, 'error').mockImplementation(() => undefined);
     vi.spyOn(clientLogger, 'warn').mockImplementation(() => undefined);
+    // Deterministic jitter: Math.random() = 0.5 → jitter multiplier = 1.0
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
   });
 
   afterEach(() => {
@@ -137,7 +147,7 @@ describe('usePlanStatus', () => {
     });
   });
 
-  it('should poll every 3 seconds when status is pending', async () => {
+  it('should poll with exponential backoff when status is pending', async () => {
     vi.useFakeTimers();
 
     const mockFetch = vi
@@ -152,20 +162,20 @@ describe('usePlanStatus', () => {
     });
     expect(mockFetch).toHaveBeenCalledTimes(1);
 
-    // First poll after 3 seconds
+    // First poll after FIRST_BACKOFF (1500ms with no jitter)
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(3000);
+      await vi.advanceTimersByTimeAsync(FIRST_BACKOFF);
     });
     expect(mockFetch).toHaveBeenCalledTimes(2);
 
-    // Second poll after another 3 seconds
+    // Second poll after SECOND_BACKOFF (2250ms with no jitter)
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(3000);
+      await vi.advanceTimersByTimeAsync(SECOND_BACKOFF);
     });
     expect(mockFetch).toHaveBeenCalledTimes(3);
   });
 
-  it('should poll every 3 seconds when status is processing', async () => {
+  it('should poll with exponential backoff when status is processing', async () => {
     vi.useFakeTimers();
 
     const mockFetch = vi
@@ -184,9 +194,9 @@ describe('usePlanStatus', () => {
     });
     expect(mockFetch).toHaveBeenCalledTimes(1);
 
-    // First poll after 3 seconds
+    // First poll after FIRST_BACKOFF
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(3000);
+      await vi.advanceTimersByTimeAsync(FIRST_BACKOFF);
     });
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
@@ -241,7 +251,7 @@ describe('usePlanStatus', () => {
 
     // Should continue polling despite error — advance to trigger second fetch
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(3000);
+      await vi.advanceTimersByTimeAsync(FIRST_BACKOFF);
     });
     expect(mockFetch).toHaveBeenCalledTimes(2);
 
@@ -281,7 +291,7 @@ describe('usePlanStatus', () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(3000);
+      await vi.advanceTimersByTimeAsync(FIRST_BACKOFF);
     });
     expect(mockFetch).toHaveBeenCalledTimes(2);
 
@@ -315,7 +325,7 @@ describe('usePlanStatus', () => {
 
     // Should continue polling despite error — advance to trigger second fetch
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(3000);
+      await vi.advanceTimersByTimeAsync(FIRST_BACKOFF);
     });
     expect(mockFetch).toHaveBeenCalledTimes(2);
 
@@ -363,7 +373,7 @@ describe('usePlanStatus', () => {
     });
   });
 
-  it('should clean up polling interval on unmount', async () => {
+  it('should clean up polling timeout on unmount', async () => {
     vi.useFakeTimers();
 
     const mockFetch = vi
@@ -420,16 +430,17 @@ describe('usePlanStatus', () => {
     expect(result.current.status).toBe('pending');
     expect(result.current.isPolling).toBe(true);
 
-    // Second fetch - processing
+    // Second fetch - processing (after FIRST_BACKOFF from pending)
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(3000);
+      await vi.advanceTimersByTimeAsync(FIRST_BACKOFF);
     });
     expect(result.current.status).toBe('processing');
     expect(result.current.isPolling).toBe(true);
 
-    // Third fetch - ready (should stop polling)
+    // Status changed: pending → processing, so backoff resets to INITIAL_POLL_MS.
+    // Third fetch after INITIAL_POLL_MS (reset on transition)
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(3000);
+      await vi.advanceTimersByTimeAsync(INITIAL_POLL_MS);
     });
     expect(result.current.status).toBe('ready');
     expect(result.current.isPolling).toBe(false);
@@ -439,6 +450,56 @@ describe('usePlanStatus', () => {
       await vi.advanceTimersByTimeAsync(10000);
     });
     expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('should reset backoff delay on status transitions', async () => {
+    vi.useFakeTimers();
+
+    let callCount = 0;
+    const mockFetch = vi.fn().mockImplementation(async () => {
+      callCount++;
+      // Calls 1-3: pending (build up backoff)
+      // Call 4: processing (trigger reset)
+      if (callCount <= 3) {
+        return createMockFetchResponse(createPlanStatusResponse());
+      }
+      return createMockFetchResponse(
+        createPlanStatusResponse({ status: 'processing' })
+      );
+    });
+
+    renderHook(() => usePlanStatus('plan-123', 'pending', mockFetch));
+
+    // Immediate fetch (call 1)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // After FIRST_BACKOFF=1500 (call 2)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(FIRST_BACKOFF);
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    // After SECOND_BACKOFF=2250 (call 3)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SECOND_BACKOFF);
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+
+    // Next backoff would be 3375ms, but status changes → resets to INITIAL_POLL_MS
+    const THIRD_BACKOFF = 3375; // computeNextDelay(2250) = 2250 * 1.5
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(THIRD_BACKOFF);
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+
+    // After transition, backoff resets: next poll should be at INITIAL_POLL_MS (1000ms)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(INITIAL_POLL_MS);
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(5);
   });
 });
 

--- a/tests/unit/observability/sampling.test.ts
+++ b/tests/unit/observability/sampling.test.ts
@@ -1,0 +1,260 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  getEnvironment,
+  getReplayErrorSampleRate,
+  getReplaySessionSampleRate,
+  shouldEnableLogs,
+  tracesSampler,
+} from '@/lib/observability/sampling';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function withEnv(nodeEnv: string, fn: () => void) {
+  vi.stubEnv('NODE_ENV', nodeEnv);
+  try {
+    fn();
+  } finally {
+    vi.unstubAllEnvs();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// getEnvironment
+// ---------------------------------------------------------------------------
+
+describe('getEnvironment', () => {
+  it('returns "production" when NODE_ENV is production', () => {
+    withEnv('production', () => {
+      expect(getEnvironment()).toBe('production');
+    });
+  });
+
+  it('returns "test" when NODE_ENV is test', () => {
+    withEnv('test', () => {
+      expect(getEnvironment()).toBe('test');
+    });
+  });
+
+  it('returns "development" when NODE_ENV is development', () => {
+    withEnv('development', () => {
+      expect(getEnvironment()).toBe('development');
+    });
+  });
+
+  it('defaults to "development" for unknown NODE_ENV values', () => {
+    withEnv('staging', () => {
+      expect(getEnvironment()).toBe('development');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Replay sample rates
+// ---------------------------------------------------------------------------
+
+describe('getReplaySessionSampleRate', () => {
+  it('returns 0.1 in production (10 % of sessions)', () => {
+    withEnv('production', () => {
+      expect(getReplaySessionSampleRate()).toBe(0.1);
+    });
+  });
+
+  it('returns 1.0 in development (full visibility)', () => {
+    withEnv('development', () => {
+      expect(getReplaySessionSampleRate()).toBe(1.0);
+    });
+  });
+
+  it('returns 0 in test (no replays)', () => {
+    withEnv('test', () => {
+      expect(getReplaySessionSampleRate()).toBe(0);
+    });
+  });
+});
+
+describe('getReplayErrorSampleRate', () => {
+  it('always returns 1.0 regardless of environment', () => {
+    for (const env of ['production', 'development', 'test']) {
+      withEnv(env, () => {
+        expect(getReplayErrorSampleRate()).toBe(1.0);
+      });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tracesSampler
+// ---------------------------------------------------------------------------
+
+describe('tracesSampler', () => {
+  describe('parent sampling inheritance', () => {
+    it('returns 1.0 when parent was sampled', () => {
+      withEnv('production', () => {
+        expect(tracesSampler({ name: '/api/plans', parentSampled: true })).toBe(
+          1.0
+        );
+      });
+    });
+
+    it('returns 0 when parent was NOT sampled', () => {
+      withEnv('production', () => {
+        expect(
+          tracesSampler({ name: '/api/plans', parentSampled: false })
+        ).toBe(0);
+      });
+    });
+  });
+
+  describe('low-value traces (production)', () => {
+    beforeEach(() => {
+      vi.stubEnv('NODE_ENV', 'production');
+    });
+
+    it.each([
+      ['Next.js static assets', 'GET /_next/static/chunk.js'],
+      ['favicon', 'GET /favicon.ico'],
+      ['health check', 'GET /api/health'],
+      ['robots.txt', 'GET /robots.txt'],
+      ['sitemap', 'GET /sitemap.xml'],
+      ['CSS files', 'GET /styles/main.css'],
+      ['image files', 'GET /images/logo.png'],
+      ['font files', 'GET /fonts/inter.woff2'],
+    ])('drops %s (rate = 0)', (_label, name) => {
+      expect(tracesSampler({ name })).toBe(0);
+    });
+  });
+
+  describe('low-value traces (development)', () => {
+    beforeEach(() => {
+      vi.stubEnv('NODE_ENV', 'development');
+    });
+
+    it('samples low-value traces at minimal rate in dev', () => {
+      expect(tracesSampler({ name: 'GET /_next/static/chunk.js' })).toBe(0.01);
+    });
+  });
+
+  describe('high-value traces — API routes (production)', () => {
+    beforeEach(() => {
+      vi.stubEnv('NODE_ENV', 'production');
+    });
+
+    it.each([
+      'GET /api/plans',
+      'POST /api/v1/plans',
+      'GET /api/settings/profile',
+    ])('samples "%s" at 0.2', (name) => {
+      expect(tracesSampler({ name })).toBe(0.2);
+    });
+  });
+
+  describe('high-value traces — API routes (development)', () => {
+    beforeEach(() => {
+      vi.stubEnv('NODE_ENV', 'development');
+    });
+
+    it('samples API routes at 1.0 in dev', () => {
+      expect(tracesSampler({ name: 'GET /api/plans' })).toBe(1.0);
+    });
+  });
+
+  describe('default traces', () => {
+    it('returns 0.05 in production', () => {
+      withEnv('production', () => {
+        expect(tracesSampler({ name: '/dashboard' })).toBe(0.05);
+      });
+    });
+
+    it('returns 0.5 in development', () => {
+      withEnv('development', () => {
+        expect(tracesSampler({ name: '/dashboard' })).toBe(0.5);
+      });
+    });
+
+    it('returns 0 in test', () => {
+      withEnv('test', () => {
+        expect(tracesSampler({ name: '/dashboard' })).toBe(0);
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles missing name gracefully', () => {
+      withEnv('production', () => {
+        expect(tracesSampler({})).toBe(0.05);
+      });
+    });
+
+    it('handles empty name', () => {
+      withEnv('production', () => {
+        expect(tracesSampler({ name: '' })).toBe(0.05);
+      });
+    });
+
+    it('health check is classified as low-value even without HTTP method prefix', () => {
+      withEnv('production', () => {
+        expect(tracesSampler({ name: '/api/health' })).toBe(0);
+      });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shouldEnableLogs
+// ---------------------------------------------------------------------------
+
+describe('shouldEnableLogs', () => {
+  it('returns false in production (reduces ingest volume)', () => {
+    withEnv('production', () => {
+      expect(shouldEnableLogs()).toBe(false);
+    });
+  });
+
+  it('returns true in development', () => {
+    withEnv('development', () => {
+      expect(shouldEnableLogs()).toBe(true);
+    });
+  });
+
+  it('returns true in test', () => {
+    withEnv('test', () => {
+      expect(shouldEnableLogs()).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Contract: high-severity failures are always captured
+// ---------------------------------------------------------------------------
+
+describe('high-severity capture guarantees', () => {
+  it('error replays are always 100 % regardless of environment', () => {
+    for (const env of ['production', 'development', 'test']) {
+      withEnv(env, () => {
+        expect(getReplayErrorSampleRate()).toBe(1.0);
+      });
+    }
+  });
+
+  it('traces with sampled parents are never dropped', () => {
+    for (const env of ['production', 'development', 'test']) {
+      withEnv(env, () => {
+        expect(tracesSampler({ name: 'anything', parentSampled: true })).toBe(
+          1.0
+        );
+      });
+    }
+  });
+
+  it('API routes always have non-zero sample rate', () => {
+    for (const env of ['production', 'development']) {
+      withEnv(env, () => {
+        const rate = tracesSampler({ name: 'POST /api/plans' });
+        expect(rate).toBeGreaterThan(0);
+      });
+    }
+  });
+});

--- a/tests/unit/observability/sampling.test.ts
+++ b/tests/unit/observability/sampling.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   getEnvironment,
@@ -76,12 +76,10 @@ describe('getReplaySessionSampleRate', () => {
 });
 
 describe('getReplayErrorSampleRate', () => {
-  it('always returns 1.0 regardless of environment', () => {
-    for (const env of ['production', 'development', 'test']) {
-      withEnv(env, () => {
-        expect(getReplayErrorSampleRate()).toBe(1.0);
-      });
-    }
+  it.each(['production', 'development', 'test'])('returns 1.0 in %s', (env) => {
+    withEnv(env, () => {
+      expect(getReplayErrorSampleRate()).toBe(1.0);
+    });
   });
 });
 
@@ -113,6 +111,10 @@ describe('tracesSampler', () => {
       vi.stubEnv('NODE_ENV', 'production');
     });
 
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
     it.each([
       ['Next.js static assets', 'GET /_next/static/chunk.js'],
       ['favicon', 'GET /favicon.ico'],
@@ -132,6 +134,10 @@ describe('tracesSampler', () => {
       vi.stubEnv('NODE_ENV', 'development');
     });
 
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
     it('samples low-value traces at minimal rate in dev', () => {
       expect(tracesSampler({ name: 'GET /_next/static/chunk.js' })).toBe(0.01);
     });
@@ -140,6 +146,10 @@ describe('tracesSampler', () => {
   describe('high-value traces — API routes (production)', () => {
     beforeEach(() => {
       vi.stubEnv('NODE_ENV', 'production');
+    });
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
     });
 
     it.each([
@@ -154,6 +164,10 @@ describe('tracesSampler', () => {
   describe('high-value traces — API routes (development)', () => {
     beforeEach(() => {
       vi.stubEnv('NODE_ENV', 'development');
+    });
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
     });
 
     it('samples API routes at 1.0 in dev', () => {
@@ -224,6 +238,56 @@ describe('shouldEnableLogs', () => {
       expect(shouldEnableLogs()).toBe(true);
     });
   });
+
+  it('SENTRY_ENABLE_LOGS=true overrides production default', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('SENTRY_ENABLE_LOGS', 'true');
+    try {
+      expect(shouldEnableLogs()).toBe(true);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('SENTRY_ENABLE_LOGS=1 overrides production default', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('SENTRY_ENABLE_LOGS', '1');
+    try {
+      expect(shouldEnableLogs()).toBe(true);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('SENTRY_ENABLE_LOGS=false overrides development default', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('SENTRY_ENABLE_LOGS', 'false');
+    try {
+      expect(shouldEnableLogs()).toBe(false);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('SENTRY_ENABLE_LOGS=0 overrides development default', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('SENTRY_ENABLE_LOGS', '0');
+    try {
+      expect(shouldEnableLogs()).toBe(false);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('ignores unrecognised SENTRY_ENABLE_LOGS values and falls back to env', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('SENTRY_ENABLE_LOGS', 'yes');
+    try {
+      expect(shouldEnableLogs()).toBe(false);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -231,30 +295,33 @@ describe('shouldEnableLogs', () => {
 // ---------------------------------------------------------------------------
 
 describe('high-severity capture guarantees', () => {
-  it('error replays are always 100 % regardless of environment', () => {
-    for (const env of ['production', 'development', 'test']) {
+  it.each(['production', 'development', 'test'])(
+    'error replays are 100%% in %s',
+    (env) => {
       withEnv(env, () => {
         expect(getReplayErrorSampleRate()).toBe(1.0);
       });
     }
-  });
+  );
 
-  it('traces with sampled parents are never dropped', () => {
-    for (const env of ['production', 'development', 'test']) {
+  it.each(['production', 'development', 'test'])(
+    'traces with sampled parents are never dropped in %s',
+    (env) => {
       withEnv(env, () => {
         expect(tracesSampler({ name: 'anything', parentSampled: true })).toBe(
           1.0
         );
       });
     }
-  });
+  );
 
-  it('API routes always have non-zero sample rate', () => {
-    for (const env of ['production', 'development']) {
+  it.each(['production', 'development'])(
+    'API routes have non-zero sample rate in %s',
+    (env) => {
       withEnv(env, () => {
         const rate = tracesSampler({ name: 'POST /api/plans' });
         expect(rate).toBeGreaterThan(0);
       });
     }
-  });
+  );
 });

--- a/tests/unit/shared/polling.spec.ts
+++ b/tests/unit/shared/polling.spec.ts
@@ -1,0 +1,66 @@
+import {
+  BACKOFF_MULTIPLIER,
+  computeNextDelay,
+  INITIAL_POLL_MS,
+  JITTER_FACTOR,
+  MAX_POLL_MS,
+} from '@/shared/constants/polling';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('computeNextDelay', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('multiplies the current delay by the backoff multiplier', () => {
+    // Remove jitter for deterministic assertion
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    const result = computeNextDelay(INITIAL_POLL_MS);
+    expect(result).toBe(INITIAL_POLL_MS * BACKOFF_MULTIPLIER);
+  });
+
+  it('caps result at MAX_POLL_MS', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    const result = computeNextDelay(MAX_POLL_MS);
+    expect(result).toBe(MAX_POLL_MS);
+  });
+
+  it('never returns below INITIAL_POLL_MS', () => {
+    // Force jitter to produce the lowest possible value
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const result = computeNextDelay(INITIAL_POLL_MS);
+    expect(result).toBeGreaterThanOrEqual(INITIAL_POLL_MS);
+  });
+
+  it('never returns above MAX_POLL_MS', () => {
+    // Force jitter to produce the highest possible value
+    vi.spyOn(Math, 'random').mockReturnValue(1);
+    const result = computeNextDelay(MAX_POLL_MS);
+    expect(result).toBeLessThanOrEqual(MAX_POLL_MS);
+  });
+
+  it('applies jitter within ±JITTER_FACTOR bounds', () => {
+    const base = 2000;
+    const expected = base * BACKOFF_MULTIPLIER;
+
+    // Low jitter
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const low = computeNextDelay(base);
+    expect(low).toBeGreaterThanOrEqual(expected * (1 - JITTER_FACTOR));
+
+    // High jitter
+    vi.spyOn(Math, 'random').mockReturnValue(1);
+    const high = computeNextDelay(base);
+    expect(high).toBeLessThanOrEqual(expected * (1 + JITTER_FACTOR));
+  });
+
+  it('produces different values with different random seeds', () => {
+    const results = new Set<number>();
+    for (const r of [0, 0.25, 0.5, 0.75, 1]) {
+      vi.spyOn(Math, 'random').mockReturnValue(r);
+      results.add(computeNextDelay(2000));
+      vi.restoreAllMocks();
+    }
+    expect(results.size).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION
## Phase 2: Pre-Launch Hardening

Implements three slices from the Launch Readiness Hardening PRD ([#284](https://github.com/saldanaj97/atlaris/issues/284)).

### Slice 5: Status Delivery Cost Reduction (#289)
- Replace fixed 3s `setInterval` polling with `setTimeout`-based exponential backoff (initial=1s, max=10s, multiplier=1.5, jitter=±20%)
- Reset backoff delay on status transitions for fast response to changes
- Skip modules DB query when `generationStatus !== ready` (saves 1 query per poll)
- Add `Cache-Control: max-age=1, stale-while-revalidate=2` to status responses
- Add JSDoc documenting `derivePlanStatus` state machine

### Slice 6: Retry & Idempotency Policy Centralization (#290)
- **Critical bug fix:** `retryable: true` in regeneration worker bypassed `maxAttempts(3)` and used `ABSOLUTE_MAX_ATTEMPTS(100)` — combined with provider p-retry(1), allowed up to 200 AI calls per regeneration
- Create centralized retry policy module (`src/features/plans/retry-policy.ts`) with bounded semantics: `MAX_PROVIDER_RETRIES=1`, `MAX_JOB_RETRIES=3`, `MAX_TOTAL_AI_CALLS_PER_JOB=6`
- Remove `ABSOLUTE_MAX_ATTEMPTS(100)` — `computeShouldRetry` now always respects `maxAttempts`
- Wire provider retry config through centralized constants
- Create cleanup module (`src/features/plans/cleanup.ts`) for stuck plans and orphaned attempts

### Slice 7: Request-Time DB Boundary Cleanup (#291)
- **Critical bug fix:** Stream route opened 2 RLS connections; Connection 1 (request-scoped) was closed when `Response(stream)` returned, but `PlanPersistenceAdapter` and `UsageRecordingAdapter` still used it for `markSuccess/Failure` and `recordUsage` during generation finalization
- Unify to single stream-scoped connection for all lifecycle operations
- Fix `UsageRecordingAdapter` to accept injected `dbClient` instead of `getDb()` fallback
- Remove `attemptsDbClient` split from factory; single `dbClient` for all adapters
- Add `idleTimeout: 180s` option for stream-scoped connections (AI generation holds connection idle 30-120s)

### Validation
- ✅ `pnpm lint` — clean
- ✅ `pnpm type-check` — clean  
- ✅ `pnpm test:changed` — 46 tests passing across 4 test files

### New Files
- `src/shared/constants/polling.ts` — Backoff/jitter config + `computeNextDelay()`
- `src/shared/constants/retry-policy.ts` — Centralized retry constants
- `src/features/plans/retry-policy.ts` — Decision functions: `shouldRetryJob()`, `getRetryDelay()`, `computeEffectiveMaxAttempts()`
- `src/features/plans/cleanup.ts` — `cleanupStuckPlans()`, `cleanupOrphanedAttempts()`
- `tests/unit/shared/polling.spec.ts` — 6 tests for backoff math
- `tests/unit/features/plans/retry-policy.spec.ts` — 17 tests
- `tests/unit/features/plans/cleanup.spec.ts` — 8 tests

Closes #289, closes #290, closes #291

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR implements Phase 2 launch readiness hardening across three core areas: polling cost optimization, centralized retry policy enforcement, and database connection boundary cleanup.

## Key Changes

### 1. Polling Optimization (Slice 5)
- **Dynamic backoff strategy**: Replaced fixed 3-second polling with exponential backoff (1s initial, 10s max, 1.5x multiplier, ±20% jitter) that resets on status transitions
- **Reduced database load**: Skip modules DB query when `generationStatus !== 'ready'`
- **HTTP caching**: Added `Cache-Control: max-age=1, stale-while-revalidate=2` headers to status responses
- **Documentation**: Added JSDoc to `derivePlanStatus` describing the status state machine and priority rules

### 2. Retry & Idempotency Centralization (Slice 6)
- **Critical bug fix**: Fixed bypass of `maxAttempts` when `retryable=true` that allowed excessive AI calls (up to ~200 per regeneration)
- **Centralized retry policy**: New module (`retry-policy.ts`) with bounded constants:
  - `MAX_PROVIDER_RETRIES=1`, `MAX_JOB_RETRIES=3`, `MAX_TOTAL_AI_CALLS_PER_JOB=6`
  - Removed hardcoded `ABSOLUTE_MAX_ATTEMPTS=100`
- **Cleanup utilities**: New module (`cleanup.ts`) for removing stuck plans and orphaned attempts after 15-minute timeout
- **Duplicate detection**: Added early-return duplicate detection in plan creation to prevent wasteful regeneration

### 3. Database Connection Unification (Slice 7)
- **Stream-scoped connections**: Unified lifecycle operations to use single `streamDb` connection per request instead of splitting between request-scoped and attempt-scoped clients
- **Connection pooling**: Added `idleTimeout: 180s` for stream connections to prevent resource exhaustion
- **Adapter injection**: Passed `dbClient` into `UsageRecordingAdapter` and `GenerationAdapter` for consistent connection usage
- **Factory refactoring**: Removed `attemptsDbClient` parameter from `createPlanLifecycleService`

## Implementation Details

**New modules:**
- `src/features/ai/cost.ts`: Centralized cost calculation with output-token ceilings
- `src/features/ai/usage.ts`: Canonical AI usage normalization with graceful error handling
- `src/features/plans/cleanup.ts`: Stuck plan and orphaned attempt cleanup
- `src/features/plans/retry-policy.ts`: Centralized retry decisioning logic
- `src/shared/constants/polling.ts`: Polling backoff configuration and computation
- `src/shared/constants/retry-policy.ts`: Centralized retry bounds
- `src/shared/types/ai-usage.types.ts`: Canonical usage contract (`CanonicalAIUsage`)

**Lifecycle service updates:**
- `processGenerationAttempt` now records usage from normalized `CanonicalAIUsage` instead of extracting fields from metadata
- Refactored retry route to use `PlanLifecycleService` delegation with optional generation overrides
- Stream route now uses single unified DB connection with rate limiting computed before plan creation

**Route changes:**
- Retry route: Removed attempt/model/generation orchestration logic, delegates to lifecycle service
- Stream route: Moved rate limiting earlier, unified DB connection, explicit duplicate detection with 409 response
- Plans creation: Integrated duplicate detection, refactored with lifecycle service delegation

## Validation & Testing
- 46+ unit and integration tests added covering: polling backoff, retry policy, cleanup operations, duplicate detection, cost calculation, usage normalization, and lifecycle consolidation
- All lint/type-check/tests passing
- Explicit tests for DB boundary behavior, retry semantics, and status machine state transitions

## Breaking Changes
- `RecordUsageParams` now requires `inputTokens`, `outputTokens`, `costCents` as non-optional numbers
- `createPlanLifecycleService` no longer accepts `attemptsDbClient` parameter
- Usage recording now receives `CanonicalAIUsage` objects instead of separate field parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->