### PR TITLE
feat(metrics): enable sentry metrics

### DIFF
--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -4,13 +4,47 @@ This document defines the logging architecture for Atlaris, ensuring proper sepa
 
 ## Sentry Integration
 
-All logs are sent to Sentry for observability:
+Sentry is the app's error, trace, replay, log, and application-metrics sink:
 
 - **Server**: Pino logs are forwarded via `Sentry.pinoIntegration()` in `sentry.server.config.ts`
 - **Client**: `clientLogger` uses `Sentry.logger` directly
 - **Request context**: `createRequestContext()` sets `request_id` on Sentry's isolation scope for correlation
+- **Metrics**: application metrics go through `@/lib/observability/metrics`, which wraps `Sentry.metrics.count`, `Sentry.metrics.gauge`, and `Sentry.metrics.distribution`
 
-Ensure `enableLogs: true` is set in all Sentry config files (server, edge, client).
+Ensure `enableLogs` is configured in all Sentry config files (server, edge, client).
+Ensure `enableMetrics: true` is set in all Sentry config files (server, edge, client).
+
+## Application Metrics
+
+Use application metrics for numeric health signals that are not naturally errors or logs: business event counts, queue depth, success/failure rates, and operation durations.
+
+```typescript
+import {
+  countMetric,
+  distributionMetric,
+  gaugeMetric,
+} from '@/lib/observability/metrics';
+
+countMetric('atlaris.plan.created', 1, {
+  attributes: { source: 'manual' },
+  unit: 'event',
+});
+
+gaugeMetric('atlaris.queue.depth', pendingJobs, { unit: 'item' });
+
+distributionMetric('atlaris.plan.generate.duration', durationMs, {
+  attributes: { provider: 'openrouter' },
+  unit: 'millisecond',
+});
+```
+
+Rules:
+
+- Metric names must use the `atlaris.` prefix and dot-separated names.
+- Use `countMetric` for event totals, `gaugeMetric` for current values, and `distributionMetric` for latency, size, and other values where percentiles matter.
+- Keep attributes useful and bounded. Do not add raw prompt text, emails, plan titles, or other high-cardinality/PII fields.
+- Always set `unit` when the value has a unit, especially time and size.
+- Do not import `Sentry.metrics` directly in feature code; use the wrapper so Sentry disable flags and value guards stay centralized.
 
 ## Architecture Overview
 

--- a/package.json
+++ b/package.json
@@ -118,7 +118,8 @@
       "tar": "^7.5.8",
       "rollup": ">=4.59.0",
       "serialize-javascript": "^7.0.3",
-      "fast-uri": "^3.1.2"
+      "fast-uri": "^3.1.2",
+      "kysely": "^0.28.17"
     }
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   rollup: '>=4.59.0'
   serialize-javascript: ^7.0.3
   fast-uri: ^3.1.2
+  kysely: ^0.28.17
 
 importers:
   .:
@@ -82,7 +83,7 @@ importers:
         version: 17.4.2
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.16)(postgres@3.4.9)
+        version: 0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)
       flags:
         specifier: ^4.0.6
         version: 4.0.6(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1357,6 +1358,7 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution:
@@ -1365,6 +1367,7 @@ packages:
       }
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution:
@@ -1373,6 +1376,7 @@ packages:
       }
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution:
@@ -1381,6 +1385,7 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution:
@@ -1389,6 +1394,7 @@ packages:
       }
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution:
@@ -1397,6 +1403,7 @@ packages:
       }
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution:
@@ -1405,6 +1412,7 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution:
@@ -1413,6 +1421,7 @@ packages:
       }
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution:
@@ -1422,6 +1431,7 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution:
@@ -1431,6 +1441,7 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution:
@@ -1440,6 +1451,7 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution:
@@ -1449,6 +1461,7 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution:
@@ -1458,6 +1471,7 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution:
@@ -1467,6 +1481,7 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution:
@@ -1476,6 +1491,7 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution:
@@ -1485,6 +1501,7 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution:
@@ -1623,6 +1640,7 @@ packages:
     engines: { node: '>= 10' }
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.6':
     resolution:
@@ -1632,6 +1650,7 @@ packages:
     engines: { node: '>= 10' }
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.6':
     resolution:
@@ -1641,6 +1660,7 @@ packages:
     engines: { node: '>= 10' }
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.6':
     resolution:
@@ -1650,6 +1670,7 @@ packages:
     engines: { node: '>= 10' }
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.6':
     resolution:
@@ -2056,6 +2077,7 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.62.0':
     resolution:
@@ -2065,6 +2087,7 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.62.0':
     resolution:
@@ -2074,6 +2097,7 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.62.0':
     resolution:
@@ -2083,6 +2107,7 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.62.0':
     resolution:
@@ -2092,6 +2117,7 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.62.0':
     resolution:
@@ -2101,6 +2127,7 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.62.0':
     resolution:
@@ -2110,6 +2137,7 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.62.0':
     resolution:
@@ -2119,6 +2147,7 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.62.0':
     resolution:
@@ -3266,6 +3295,7 @@ packages:
       }
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution:
@@ -3274,6 +3304,7 @@ packages:
       }
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution:
@@ -3282,6 +3313,7 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution:
@@ -3290,6 +3322,7 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution:
@@ -3298,6 +3331,7 @@ packages:
       }
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution:
@@ -3306,6 +3340,7 @@ packages:
       }
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution:
@@ -3314,6 +3349,7 @@ packages:
       }
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution:
@@ -3322,6 +3358,7 @@ packages:
       }
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution:
@@ -3330,6 +3367,7 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution:
@@ -3338,6 +3376,7 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution:
@@ -3346,6 +3385,7 @@ packages:
       }
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution:
@@ -3354,6 +3394,7 @@ packages:
       }
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution:
@@ -3362,6 +3403,7 @@ packages:
       }
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution:
@@ -3751,6 +3793,7 @@ packages:
     engines: { node: '>= 20' }
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution:
@@ -3760,6 +3803,7 @@ packages:
     engines: { node: '>= 20' }
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution:
@@ -3769,6 +3813,7 @@ packages:
     engines: { node: '>= 20' }
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution:
@@ -3778,6 +3823,7 @@ packages:
     engines: { node: '>= 20' }
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution:
@@ -5061,7 +5107,7 @@ packages:
       expo-sqlite: '>=14.0.0'
       gel: '>=2'
       knex: '*'
-      kysely: '*'
+      kysely: ^0.28.17
       mysql2: '>=2'
       pg: '>=8'
       postgres: '>=3'
@@ -5750,13 +5796,6 @@ packages:
     engines: { node: '>=6' }
     hasBin: true
 
-  kysely@0.28.16:
-    resolution:
-      {
-        integrity: sha512-3i5pmOiZvMDj00qhrIVbH0AnioVTx22DMP7Vn5At4yJO46iy+FM8Y/g61ltenLVSo3fiO8h8Q3QOFgf/gQ72ww==,
-      }
-    engines: { node: '>=20.0.0' }
-
   lazystream@1.0.1:
     resolution:
       {
@@ -5817,6 +5856,7 @@ packages:
     engines: { node: '>= 12.0.0' }
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution:
@@ -5826,6 +5866,7 @@ packages:
     engines: { node: '>= 12.0.0' }
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution:
@@ -5835,6 +5876,7 @@ packages:
     engines: { node: '>= 12.0.0' }
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution:
@@ -5844,6 +5886,7 @@ packages:
     engines: { node: '>= 12.0.0' }
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution:
@@ -10648,12 +10691,11 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.16)(postgres@3.4.9):
+  drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9):
     optionalDependencies:
       '@neondatabase/serverless': 1.1.0
       '@opentelemetry/api': 1.9.1
       '@types/pg': 8.15.6
-      kysely: 0.28.16
       postgres: 3.4.9
 
   eastasianwidth@0.2.0: {}
@@ -11041,9 +11083,6 @@ snapshots:
   json-schema-traverse@1.0.0: {}
 
   json5@2.2.3: {}
-
-  kysely@0.28.16:
-    optional: true
 
   lazystream@1.0.1:
     dependencies:

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -24,6 +24,10 @@ Sentry.init({
   // Errors are still captured via captureException.
   enableLogs: shouldEnableLogs(),
 
+  // Application Metrics are enabled explicitly so repo instrumentation can use
+  // Sentry.metrics.count/gauge/distribution consistently across SDK upgrades.
+  enableMetrics: true,
+
   // Enable sending user PII (Personally Identifiable Information)
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
   sendDefaultPii: true,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -17,6 +17,10 @@ Sentry.init({
   // Errors are still captured via captureException.
   enableLogs: shouldEnableLogs(),
 
+  // Application Metrics are enabled explicitly so repo instrumentation can use
+  // Sentry.metrics.count/gauge/distribution consistently across SDK upgrades.
+  enableMetrics: true,
+
   // Forward Pino logs to Sentry (pino is used in @/lib/logging/logger).
   // Volume is controlled by pino's logger level (info in prod, debug in dev).
   // Vercel AI integration for micro-explanations (generateObject) + force for Vercel builds

--- a/src/features/billing/stripe-commerce/boundary-impl.ts
+++ b/src/features/billing/stripe-commerce/boundary-impl.ts
@@ -18,6 +18,7 @@ import { createCustomer } from '@/features/billing/subscriptions';
 import { AppError, extractErrorCode, ValidationError } from '@/lib/api/errors';
 import type { users } from '@supabase/schema';
 import type { DbClient } from '@/lib/db/types';
+import { countMetric } from '@/lib/observability/metrics';
 import Stripe from 'stripe';
 import { z } from 'zod';
 import type { db as serviceRoleDb } from '@supabase/service-role';
@@ -135,6 +136,12 @@ export class DefaultStripeCommerceBoundary implements StripeCommerceBoundary {
       });
     }
 
+    countMetric('atlaris.billing.checkout_session.created', 1, {
+      attributes: {
+        mode: this.deps.localMode ? 'local' : 'stripe',
+      },
+    });
+
     return { sessionUrl };
   }
 
@@ -207,6 +214,12 @@ export class DefaultStripeCommerceBoundary implements StripeCommerceBoundary {
         },
       });
     }
+
+    countMetric('atlaris.billing.portal_session.created', 1, {
+      attributes: {
+        subscription_status: actor.subscriptionStatus ?? 'none',
+      },
+    });
 
     return { portalUrl };
   }

--- a/src/features/plans/lifecycle/creation-pipeline.ts
+++ b/src/features/plans/lifecycle/creation-pipeline.ts
@@ -1,5 +1,6 @@
 import { calculateTotalWeeks } from '@/features/plans/policy/duration';
 import { logger } from '@/lib/logging/logger';
+import { countMetric } from '@/lib/observability/metrics';
 import type { SubscriptionTier } from '@/shared/types/billing.types';
 
 import type { PlanPersistencePort, QuotaPort } from './ports';
@@ -160,6 +161,12 @@ export async function insertCreatedPlan(params: {
     { userId, planId: insertResult.id, tier, origin: planData.origin },
     `${getCreateLogBase(lifecycleLabel)}: plan created`,
   );
+  countMetric('atlaris.plan.created', 1, {
+    attributes: {
+      origin: planData.origin,
+      tier,
+    },
+  });
   return {
     status: 'success',
     planId: insertResult.id,

--- a/src/features/plans/lifecycle/service.ts
+++ b/src/features/plans/lifecycle/service.ts
@@ -1,4 +1,5 @@
 import { logger } from '@/lib/logging/logger';
+import { countMetric, distributionMetric } from '@/lib/observability/metrics';
 import { isRetryableClassification } from '@/shared/types/failure-classification';
 import { checkCreationGate } from './creation-pipeline';
 import { createAiPlanWithStrategy } from './origin-strategies/create-ai-plan';
@@ -135,6 +136,20 @@ export class PlanLifecycleService {
       });
 
       logger.info({ planId, durationMs }, 'plan.lifecycle.generation: success');
+      countMetric('atlaris.plan.generation.success', 1, {
+        attributes: {
+          tier,
+          extended_timeout: extendedTimeout,
+        },
+      });
+      distributionMetric('atlaris.plan.generation.duration_ms', durationMs, {
+        unit: 'millisecond',
+        attributes: {
+          status: 'success',
+          tier,
+          extended_timeout: extendedTimeout,
+        },
+      });
       return {
         status: 'generation_success',
         data: {
@@ -195,6 +210,26 @@ export class PlanLifecycleService {
         { planId, classification },
         'plan.lifecycle.generation: retryable failure',
       );
+      countMetric('atlaris.plan.generation.failure', 1, {
+        attributes: {
+          classification,
+          retryable: true,
+          tier,
+        },
+      });
+      distributionMetric(
+        'atlaris.plan.generation.duration_ms',
+        generationResult.durationMs,
+        {
+          unit: 'millisecond',
+          attributes: {
+            status: 'failure',
+            classification,
+            retryable: true,
+            tier,
+          },
+        },
+      );
       return {
         status: 'retryable_failure',
         classification,
@@ -205,6 +240,26 @@ export class PlanLifecycleService {
     logger.warn(
       { planId, classification },
       'plan.lifecycle.generation: permanent failure',
+    );
+    countMetric('atlaris.plan.generation.failure', 1, {
+      attributes: {
+        classification,
+        retryable: false,
+        tier,
+      },
+    });
+    distributionMetric(
+      'atlaris.plan.generation.duration_ms',
+      generationResult.durationMs,
+      {
+        unit: 'millisecond',
+        attributes: {
+          status: 'failure',
+          classification,
+          retryable: false,
+          tier,
+        },
+      },
     );
     return {
       status: 'permanent_failure',

--- a/src/features/plans/task-progress/boundary.ts
+++ b/src/features/plans/task-progress/boundary.ts
@@ -1,4 +1,5 @@
 import { setTaskProgressBatch } from '@/lib/db/queries/tasks';
+import { countMetric } from '@/lib/observability/metrics';
 import { PROGRESS_STATUSES } from '@/shared/types/db';
 import type { ProgressStatus } from '@/shared/types/db.types';
 
@@ -96,6 +97,16 @@ export async function applyTaskProgressUpdates(
       ...(input.now === undefined ? {} : { now: input.now }),
     },
   );
+  const completedCount = progress.filter(
+    (row) => row.status === 'completed',
+  ).length;
+  if (completedCount > 0) {
+    countMetric('atlaris.learning.task_completed', completedCount, {
+      attributes: {
+        scope: input.moduleId === undefined ? 'plan' : 'module',
+      },
+    });
+  }
 
   const appliedByTaskId: Record<string, ProgressStatus> = {};
   for (const row of progress) {

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -34,6 +34,10 @@ if (isSentryEnabled) {
     // SDK log shipping — disabled in production to reduce ingest volume.
     enableLogs: shouldEnableLogs(),
 
+    // Application Metrics are enabled explicitly so browser instrumentation can
+    // use Sentry.metrics.count/gauge/distribution consistently across SDK upgrades.
+    enableMetrics: true,
+
     // Replay: 10 % sessions in prod (cost control), 100 % error replays (always).
     // See src/lib/observability/sampling.ts for full rationale.
     replaysSessionSampleRate: getReplaySessionSampleRate(),

--- a/src/lib/observability/metrics.ts
+++ b/src/lib/observability/metrics.ts
@@ -1,0 +1,76 @@
+import * as Sentry from '@sentry/nextjs';
+
+type MetricOptions = Parameters<typeof Sentry.metrics.count>[2];
+
+export type AtlarisMetricName = `atlaris.${string}`;
+export type MetricAttributes = NonNullable<MetricOptions>['attributes'];
+
+export type ApplicationMetricOptions = {
+  attributes?: MetricAttributes;
+  unit?: string;
+};
+
+function isSentryMetricsEnabled(): boolean {
+  const serverFlag =
+    typeof process !== 'undefined' ? process.env.ENABLE_SENTRY : undefined;
+  const publicFlag =
+    typeof process !== 'undefined'
+      ? process.env.NEXT_PUBLIC_ENABLE_SENTRY
+      : undefined;
+  const flag = serverFlag ?? publicFlag;
+
+  return flag?.trim().toLowerCase() !== 'false';
+}
+
+function toMetricOptions(
+  options: ApplicationMetricOptions | undefined,
+): MetricOptions | undefined {
+  if (!options) {
+    return undefined;
+  }
+
+  return {
+    attributes: options.attributes,
+    unit: options.unit,
+  };
+}
+
+function shouldCaptureMetric(value: number): boolean {
+  return isSentryMetricsEnabled() && Number.isFinite(value);
+}
+
+export function countMetric(
+  name: AtlarisMetricName,
+  value = 1,
+  options?: ApplicationMetricOptions,
+): void {
+  if (!shouldCaptureMetric(value)) {
+    return;
+  }
+
+  Sentry.metrics.count(name, value, toMetricOptions(options));
+}
+
+export function gaugeMetric(
+  name: AtlarisMetricName,
+  value: number,
+  options?: ApplicationMetricOptions,
+): void {
+  if (!shouldCaptureMetric(value)) {
+    return;
+  }
+
+  Sentry.metrics.gauge(name, value, toMetricOptions(options));
+}
+
+export function distributionMetric(
+  name: AtlarisMetricName,
+  value: number,
+  options?: ApplicationMetricOptions,
+): void {
+  if (!shouldCaptureMetric(value)) {
+    return;
+  }
+
+  Sentry.metrics.distribution(name, value, toMetricOptions(options));
+}

--- a/tests/unit/features/billing/stripe-commerce-boundary-metrics.spec.ts
+++ b/tests/unit/features/billing/stripe-commerce-boundary-metrics.spec.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/features/billing/subscriptions', () => ({
+  createCustomer: vi.fn().mockResolvedValue('cus_123'),
+}));
+
+vi.mock('@/lib/observability/metrics', () => ({
+  countMetric: vi.fn(),
+}));
+
+import { DefaultStripeCommerceBoundary } from '@/features/billing/stripe-commerce/boundary-impl';
+import type { StripeGateway } from '@/features/billing/stripe-commerce/gateway';
+import { LOCAL_PRICE_IDS } from '@/features/billing/local-catalog';
+import { countMetric } from '@/lib/observability/metrics';
+
+function createGateway(): StripeGateway {
+  return {
+    createCheckoutSession: vi.fn().mockResolvedValue({
+      url: 'https://checkout.stripe.com/c/session',
+    }),
+    createBillingPortalSession: vi.fn().mockResolvedValue({
+      url: 'https://billing.stripe.com/session',
+    }),
+    constructWebhookEvent: vi.fn(),
+    retrieveSubscription: vi.fn(),
+    getStripeClient: vi.fn(),
+  } as unknown as StripeGateway;
+}
+
+function createBoundary(params: { localMode?: boolean } = {}) {
+  return new DefaultStripeCommerceBoundary({
+    gateway: createGateway(),
+    localMode: params.localMode ?? false,
+    getDb: vi.fn() as never,
+    privilegedDb: {
+      customerProvisioningDb: {} as never,
+      webhookEventDb: {} as never,
+    },
+    users: {} as never,
+    webhookSecret: 'whsec_test',
+    webhookDevMode: false,
+    isProduction: false,
+    isDevOrTest: true,
+  });
+}
+
+describe('Stripe commerce metrics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('emits a checkout-session metric after Stripe returns a session URL', async () => {
+    const boundary = createBoundary({ localMode: true });
+
+    await boundary.beginCheckout({
+      actor: { userId: 'user-1', email: 'user@example.com' },
+      priceId: LOCAL_PRICE_IDS.starterMonthly,
+    });
+
+    expect(countMetric).toHaveBeenCalledWith(
+      'atlaris.billing.checkout_session.created',
+      1,
+      {
+        attributes: {
+          mode: 'local',
+        },
+      },
+    );
+  });
+
+  it('emits a portal-session metric after Stripe returns a portal URL', async () => {
+    const boundary = createBoundary();
+
+    await boundary.openPortal({
+      actor: {
+        userId: 'user-1',
+        stripeCustomerId: 'cus_123',
+        subscriptionStatus: 'active',
+      },
+    });
+
+    expect(countMetric).toHaveBeenCalledWith(
+      'atlaris.billing.portal_session.created',
+      1,
+      {
+        attributes: {
+          subscription_status: 'active',
+        },
+      },
+    );
+  });
+});

--- a/tests/unit/features/plans/lifecycle/lifecycle-consolidation.spec.ts
+++ b/tests/unit/features/plans/lifecycle/lifecycle-consolidation.spec.ts
@@ -13,9 +13,15 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('@/lib/observability/metrics', () => ({
+  countMetric: vi.fn(),
+  distributionMetric: vi.fn(),
+}));
+
 import type { PlanLifecycleServicePorts } from '@/features/plans/lifecycle/service';
 import { PlanLifecycleService } from '@/features/plans/lifecycle/service';
 import type { ProcessGenerationInput } from '@/features/plans/lifecycle/types';
+import { countMetric, distributionMetric } from '@/lib/observability/metrics';
 import { makeAttemptReservation } from '@tests/fixtures/attempts';
 
 import { makeCanonicalUsage } from '../../../../fixtures/canonical-usage.factory';
@@ -166,6 +172,7 @@ describe('Lifecycle Consolidation', () => {
   let ports: PlanLifecycleServicePorts;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     ports = createMockPorts();
     service = new PlanLifecycleService(ports);
   });
@@ -224,6 +231,33 @@ describe('Lifecycle Consolidation', () => {
       expect(finalizeSuccess).toHaveBeenCalledTimes(1);
     });
 
+    it('emits success and duration metrics after successful generation', async () => {
+      await service.processGenerationAttempt(STREAM_INPUT);
+
+      expect(countMetric).toHaveBeenCalledWith(
+        'atlaris.plan.generation.success',
+        1,
+        {
+          attributes: {
+            tier: STREAM_INPUT.tier,
+            extended_timeout: false,
+          },
+        },
+      );
+      expect(distributionMetric).toHaveBeenCalledWith(
+        'atlaris.plan.generation.duration_ms',
+        1500,
+        {
+          unit: 'millisecond',
+          attributes: {
+            status: 'success',
+            tier: STREAM_INPUT.tier,
+            extended_timeout: false,
+          },
+        },
+      );
+    });
+
     it('calls generationFinalization.finalizeFailure exactly once on failed generation', async () => {
       const resv = makeAttemptReservation({ attemptId: 'fail-1' });
       ports = createMockPorts({
@@ -247,6 +281,51 @@ describe('Lifecycle Consolidation', () => {
 
       await service.processGenerationAttempt(RETRY_INPUT);
       expect(finalizeFailure).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits failure and duration metrics after failed generation', async () => {
+      const resv = makeAttemptReservation({ attemptId: 'metric-fail-1' });
+      ports = createMockPorts({
+        generation: {
+          runGeneration: vi.fn().mockResolvedValue({
+            status: 'failure',
+            classification: 'timeout',
+            error: new Error('timed out'),
+            durationMs: 30000,
+            reservation: resv,
+            timedOut: true,
+            extendedTimeout: false,
+          }),
+        },
+      });
+      service = new PlanLifecycleService(ports);
+
+      await service.processGenerationAttempt(RETRY_INPUT);
+
+      expect(countMetric).toHaveBeenCalledWith(
+        'atlaris.plan.generation.failure',
+        1,
+        {
+          attributes: {
+            classification: 'timeout',
+            retryable: true,
+            tier: RETRY_INPUT.tier,
+          },
+        },
+      );
+      expect(distributionMetric).toHaveBeenCalledWith(
+        'atlaris.plan.generation.duration_ms',
+        30000,
+        {
+          unit: 'millisecond',
+          attributes: {
+            status: 'failure',
+            classification: 'timeout',
+            retryable: true,
+            tier: RETRY_INPUT.tier,
+          },
+        },
+      );
     });
   });
 
@@ -442,6 +521,12 @@ describe('Lifecycle Consolidation', () => {
         expect(result.planId).toBe('plan-123');
         expect(result.tier).toBe('free');
       }
+      expect(countMetric).toHaveBeenCalledWith('atlaris.plan.created', 1, {
+        attributes: {
+          origin: 'ai',
+          tier: 'free',
+        },
+      });
     });
 
     it('AI plan creation checks capped plans', async () => {

--- a/tests/unit/features/plans/task-progress-boundary-metrics.spec.ts
+++ b/tests/unit/features/plans/task-progress-boundary-metrics.spec.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/db/queries/tasks', () => ({
+  setTaskProgressBatch: vi.fn(),
+}));
+
+vi.mock('@/lib/observability/metrics', () => ({
+  countMetric: vi.fn(),
+}));
+
+import { applyTaskProgressUpdates } from '@/features/plans/task-progress/boundary';
+import { setTaskProgressBatch } from '@/lib/db/queries/tasks';
+import { countMetric } from '@/lib/observability/metrics';
+
+describe('task progress metrics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('counts completed task writes after progress is persisted', async () => {
+    vi.mocked(setTaskProgressBatch).mockResolvedValue([
+      {
+        id: 'progress-1',
+        taskId: 'task-1',
+        userId: 'user-1',
+        status: 'completed',
+        completedAt: new Date('2026-05-11T00:00:00.000Z'),
+        updatedAt: new Date('2026-05-11T00:00:00.000Z'),
+        createdAt: new Date('2026-05-11T00:00:00.000Z'),
+      },
+      {
+        id: 'progress-2',
+        taskId: 'task-2',
+        userId: 'user-1',
+        status: 'not_started',
+        completedAt: null,
+        updatedAt: new Date('2026-05-11T00:00:00.000Z'),
+        createdAt: new Date('2026-05-11T00:00:00.000Z'),
+      },
+    ]);
+
+    await applyTaskProgressUpdates({
+      userId: 'user-1',
+      planId: 'plan-1',
+      moduleId: 'module-1',
+      updates: [
+        { taskId: 'task-1', status: 'completed' },
+        { taskId: 'task-2', status: 'not_started' },
+      ],
+      dbClient: {} as never,
+    });
+
+    expect(countMetric).toHaveBeenCalledWith(
+      'atlaris.learning.task_completed',
+      1,
+      {
+        attributes: {
+          scope: 'module',
+        },
+      },
+    );
+  });
+
+  it('does not emit completion metrics when no task is completed', async () => {
+    vi.mocked(setTaskProgressBatch).mockResolvedValue([
+      {
+        id: 'progress-1',
+        taskId: 'task-1',
+        userId: 'user-1',
+        status: 'in_progress',
+        completedAt: null,
+        updatedAt: new Date('2026-05-11T00:00:00.000Z'),
+        createdAt: new Date('2026-05-11T00:00:00.000Z'),
+      },
+    ]);
+
+    await applyTaskProgressUpdates({
+      userId: 'user-1',
+      planId: 'plan-1',
+      updates: [{ taskId: 'task-1', status: 'in_progress' }],
+      dbClient: {} as never,
+    });
+
+    expect(countMetric).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/observability/metrics.spec.ts
+++ b/tests/unit/observability/metrics.spec.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as Sentry from '@sentry/nextjs';
+
+import {
+  countMetric,
+  distributionMetric,
+  gaugeMetric,
+} from '@/lib/observability/metrics';
+
+vi.mock('@sentry/nextjs', () => ({
+  metrics: {
+    count: vi.fn(),
+    distribution: vi.fn(),
+    gauge: vi.fn(),
+  },
+}));
+
+describe('application metrics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it('captures counters with attributes and units', () => {
+    countMetric('atlaris.plan.created', 1, {
+      attributes: { source: 'manual' },
+      unit: 'event',
+    });
+
+    expect(Sentry.metrics.count).toHaveBeenCalledWith(
+      'atlaris.plan.created',
+      1,
+      {
+        attributes: { source: 'manual' },
+        unit: 'event',
+      },
+    );
+  });
+
+  it('captures gauges and distributions', () => {
+    gaugeMetric('atlaris.queue.depth', 12, { unit: 'item' });
+    distributionMetric('atlaris.plan.generate.duration', 532, {
+      unit: 'millisecond',
+    });
+
+    expect(Sentry.metrics.gauge).toHaveBeenCalledWith(
+      'atlaris.queue.depth',
+      12,
+      {
+        attributes: undefined,
+        unit: 'item',
+      },
+    );
+    expect(Sentry.metrics.distribution).toHaveBeenCalledWith(
+      'atlaris.plan.generate.duration',
+      532,
+      {
+        attributes: undefined,
+        unit: 'millisecond',
+      },
+    );
+  });
+
+  it('does not capture metrics when Sentry is disabled', () => {
+    vi.stubEnv('ENABLE_SENTRY', 'false');
+
+    countMetric('atlaris.plan.created');
+
+    expect(Sentry.metrics.count).not.toHaveBeenCalled();
+  });
+
+  it('drops invalid metric values before they reach Sentry', () => {
+    countMetric('atlaris.plan.created', Number.NaN);
+    gaugeMetric('atlaris.queue.depth', Number.POSITIVE_INFINITY);
+    distributionMetric(
+      'atlaris.plan.generate.duration',
+      Number.NEGATIVE_INFINITY,
+    );
+
+    expect(Sentry.metrics.count).not.toHaveBeenCalled();
+    expect(Sentry.metrics.gauge).not.toHaveBeenCalled();
+    expect(Sentry.metrics.distribution).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
- Added `enableMetrics: true` to Sentry configurations in server, edge, and client setups to support consistent metric instrumentation.
- Introduced a new metrics utility in `lib/observability/metrics.ts` for counting, gauging, and distributing application metrics.
- Updated various components to emit metrics for significant events, including plan creation, billing sessions, and task completions.
- Enhanced documentation to reflect the new metrics capabilities and usage guidelines.