### PR TITLE
docs: add Cloud Agent VM gotchas to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ We will primarily be utilizing the `.agents/plans/` directory to organize prds, 
 - Integration/security tests need Docker running. Unit tests do not.
 - `pnpm.onlyBuiltDependencies` in `package.json` must include `esbuild`, `@sentry/cli`, `sharp`, etc. for native binaries to build during `pnpm install`.
 - The `env.spec.ts` unit tests may show failures when `AI_PROVIDER` or other env vars are set in `.env.local`; this is expected — those tests validate default parsing behavior and use `vi.stubEnv` internally.
-- Docker daemon needs `sudo` in Cloud Agent VMs: `sudo nohup dockerd > /var/log/dockerd.log 2>&1 &`, then `sudo chmod 666 /var/run/docker.sock` before Supabase CLI can connect.
+- Docker daemon needs `sudo` in Cloud Agent VMs: `sudo nohup dockerd > /var/log/dockerd.log 2>&1 &`. Before Supabase CLI can connect, ensure your user can access the socket without world-writable permissions (e.g. `sudo usermod -aG docker "$USER"` then a new login/shell, or `sudo chgrp docker /var/run/docker.sock && sudo chmod 660 /var/run/docker.sock`). Avoid `chmod 666` on the socket — it is effectively root-equivalent for any local user.
 - `.env.local` requires Supabase keys from `pnpm exec supabase status` (specifically `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` and `SUPABASE_SERVICE_ROLE_KEY`). Run `db:dev:start` first, then extract keys.
 
 ## Learned User Preferences

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,8 @@ We will primarily be utilizing the `.agents/plans/` directory to organize prds, 
 - Integration/security tests need Docker running. Unit tests do not.
 - `pnpm.onlyBuiltDependencies` in `package.json` must include `esbuild`, `@sentry/cli`, `sharp`, etc. for native binaries to build during `pnpm install`.
 - The `env.spec.ts` unit tests may show failures when `AI_PROVIDER` or other env vars are set in `.env.local`; this is expected — those tests validate default parsing behavior and use `vi.stubEnv` internally.
+- Docker daemon needs `sudo` in Cloud Agent VMs: `sudo nohup dockerd > /var/log/dockerd.log 2>&1 &`, then `sudo chmod 666 /var/run/docker.sock` before Supabase CLI can connect.
+- `.env.local` requires Supabase keys from `pnpm exec supabase status` (specifically `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` and `SUPABASE_SERVICE_ROLE_KEY`). Run `db:dev:start` first, then extract keys.
 
 ## Learned User Preferences
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds two non-obvious gotchas discovered during Cloud Agent VM environment setup:

- Docker daemon requires `sudo` and socket permission fix (`chmod 666`) before Supabase CLI can connect
- `.env.local` requires Supabase keys extracted from `pnpm exec supabase status` after starting the local stack

These help future agents avoid the same setup friction.

### Demo

<a href="https://cursor.com/agents/bc-883762c9-ccd2-492d-bd19-ee19cb241d0f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_create_learning_plan.mp4"><img src="https://cursor.com/artifacts/c/art-4627e1ed-e7e1-46e5-95fa-c7da50f52a27" alt="demo_create_learning_plan.mp4" /></a>

Full dev environment running: Supabase local stack + Next.js dev server + mock AI plan generation.

![Dashboard loaded](https://cursor.com/artifacts/c/art-7dcee9d7-1353-4900-9f2b-e3d2b73f7c9e)
![Generated learning plan](https://cursor.com/artifacts/c/art-f0ec2aef-9ef9-47fb-8dc3-999e5122d807)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-883762c9-ccd2-492d-bd19-ee19cb241d0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-883762c9-ccd2-492d-bd19-ee19cb241d0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

