### PR TITLE
fix(security): reconcile server-owned write boundary contracts

### DIFF
--- a/.agents/plans/lessons.md
+++ b/.agents/plans/lessons.md
@@ -120,6 +120,14 @@
 
 **Impact:** Security-sensitive privilege changes stay enforced at the database layer while plan generation, regeneration, lesson generation, billing meters, and observability still validate through the intended server-owned paths.
 
+## 2026-05-21: Server-owned write contracts drift from privilege hardening
+
+**Context:** After revoking authenticated writes on billing/generation tables, stale comments still told agents to pass request-scoped `getDb()` for generation persistence, and helpers like `recordUsage` / `deletePlan` defaulted to `getDb()`.
+
+**Rule:** Keep reads and ownership checks on request-scoped RLS; default server-owned mutations to `serviceRoleDb` only inside feature-owned write boundaries. Re-export `AUTHENTICATED_SERVER_OWNED_WRITE_TABLES` in security tests and add bootstrap drift checks instead of duplicating table lists.
+
+**Impact:** Prevents accidental reintroduction of authenticated writes and keeps docs aligned with the privilege-first boundary.
+
 ## 2026-05-20: Vitest `vi.hoisted` cannot call imported factories
 
 **Context:** Shared `mockServerSession` helper worked, but `vi.hoisted(createServerAuthMockHandle)` failed at collection time with `Cannot access '__vi_import_*' before initialization`.

--- a/src/app/api/v1/plans/[planId]/attempts/route.ts
+++ b/src/app/api/v1/plans/[planId]/attempts/route.ts
@@ -1,4 +1,4 @@
-import { requirePlanIdFromRequest } from '@/features/plans/api/route-context';
+import { requireUuidRouteParam } from '@/features/plans/api/route-context';
 import { getPlanGenerationAttemptsForRead } from '@/features/plans/read-projection/service';
 import { NotFoundError } from '@/lib/api/errors';
 import { requestBoundary } from '@/lib/api/request-boundary';
@@ -6,8 +6,8 @@ import { json } from '@/lib/api/response';
 
 export const GET = requestBoundary.route(
   { rateLimit: 'read' },
-  async ({ req, actor }) => {
-    const planId = requirePlanIdFromRequest(req, 'second-to-last');
+  async ({ params, actor }) => {
+    const planId = requireUuidRouteParam(params, 'planId');
 
     const attempts = await getPlanGenerationAttemptsForRead({
       planId,

--- a/src/app/api/v1/plans/[planId]/regenerate/route.ts
+++ b/src/app/api/v1/plans/[planId]/regenerate/route.ts
@@ -1,4 +1,4 @@
-import { requirePlanIdFromRequest } from '@/features/plans/api/route-context';
+import { requireUuidRouteParam } from '@/features/plans/api/route-context';
 import { requestPlanRegeneration } from '@/features/plans/regeneration-orchestration/request';
 import { planRegenerationRequestSchema } from '@/features/plans/validation/learningPlans';
 import type { PlanRegenerationOverridesInput } from '@/features/plans/validation/learningPlans.types';
@@ -22,8 +22,8 @@ import { ZodError } from 'zod';
  */
 export const POST: PlainHandler = requestBoundary.route(
   { rateLimit: 'aiGeneration' },
-  async ({ req, actor }) => {
-    const planId = requirePlanIdFromRequest(req, 'second-to-last');
+  async ({ req, params, actor }) => {
+    const planId = requireUuidRouteParam(params, 'planId');
 
     const body = await parseJsonBody(req, {
       mode: 'required',

--- a/src/app/api/v1/plans/[planId]/retry/route.ts
+++ b/src/app/api/v1/plans/[planId]/retry/route.ts
@@ -1,6 +1,6 @@
 import {
   requireOwnedPlanById,
-  requirePlanIdFromRequest,
+  requireUuidRouteParam,
 } from '@/features/plans/api/route-context';
 import {
   createPlanGenerationSessionBoundary,
@@ -43,10 +43,10 @@ function createRetryHandler(deps?: {
 
   return requestBoundary.route(
     { rateLimit: 'aiGeneration' },
-    async ({ req, actor, db, correlationId }): Promise<Response> => {
+    async ({ req, params, actor, db, correlationId }): Promise<Response> => {
       const authUserId = actor.authUserId;
       const internalUserId = actor.id;
-      const planId = requirePlanIdFromRequest(req, 'second-to-last');
+      const planId = requireUuidRouteParam(params, 'planId');
 
       const rateLimit = await checkPlanGenerationRateLimit(internalUserId, db);
       const generationRateLimitHeaders =

--- a/src/app/api/v1/plans/[planId]/route.ts
+++ b/src/app/api/v1/plans/[planId]/route.ts
@@ -1,4 +1,4 @@
-import { requirePlanIdFromRequest } from '@/features/plans/api/route-context';
+import { requireUuidRouteParam } from '@/features/plans/api/route-context';
 import { getPlanDetailForRead } from '@/features/plans/read-projection/service';
 import { removePlanForWrite } from '@/features/plans/write-service';
 import { NotFoundError } from '@/lib/api/errors';
@@ -20,8 +20,8 @@ import { logger } from '@/lib/logging/logger';
 
 export const GET = requestBoundary.route(
   { rateLimit: 'read' },
-  async ({ req, actor, db }) => {
-    const planId = requirePlanIdFromRequest(req, 'last');
+  async ({ params, actor, db }) => {
+    const planId = requireUuidRouteParam(params, 'planId');
 
     logger.info({ planId, userId: actor.id }, 'Fetching learning plan detail');
 
@@ -46,8 +46,8 @@ export const GET = requestBoundary.route(
 
 export const DELETE = requestBoundary.route(
   { rateLimit: 'mutation' },
-  async ({ req, actor, db }) => {
-    const planId = requirePlanIdFromRequest(req, 'last');
+  async ({ params, actor, db }) => {
+    const planId = requireUuidRouteParam(params, 'planId');
 
     logger.info({ planId, userId: actor.id }, 'Deleting learning plan');
 

--- a/src/app/api/v1/plans/[planId]/status/route.ts
+++ b/src/app/api/v1/plans/[planId]/status/route.ts
@@ -1,5 +1,5 @@
 import { classificationToUserMessage } from '@/features/ai/failure-presentation';
-import { requirePlanIdFromRequest } from '@/features/plans/api/route-context';
+import { requireUuidRouteParam } from '@/features/plans/api/route-context';
 import { getPlanGenerationStatusSnapshot } from '@/features/plans/read-projection/service';
 import { NotFoundError } from '@/lib/api/errors';
 import { requestBoundary } from '@/lib/api/request-boundary';
@@ -17,8 +17,8 @@ import { PlanStatusResponseSchema } from '@/shared/schemas/plan-status';
 
 export const GET = requestBoundary.route(
   { rateLimit: 'read' },
-  async ({ req, actor, db, correlationId }): Promise<Response> => {
-    const planId = requirePlanIdFromRequest(req, 'second-to-last');
+  async ({ params, actor, db, correlationId }): Promise<Response> => {
+    const planId = requireUuidRouteParam(params, 'planId');
 
     logger.debug(
       { planId, userId: actor.id, correlationId },

--- a/src/app/api/v1/plans/[planId]/tasks/route.ts
+++ b/src/app/api/v1/plans/[planId]/tasks/route.ts
@@ -1,6 +1,6 @@
 import {
   requireOwnedPlanById,
-  requirePlanIdFromRequest,
+  requireUuidRouteParam,
 } from '@/features/plans/api/route-context';
 import { requestBoundary } from '@/lib/api/request-boundary';
 import { json } from '@/lib/api/response';
@@ -8,8 +8,8 @@ import { getAllTasksInPlan } from '@/lib/db/queries/tasks';
 
 export const GET = requestBoundary.route(
   { rateLimit: 'read' },
-  async ({ req, actor, db }) => {
-    const planId = requirePlanIdFromRequest(req, 'second-to-last');
+  async ({ params, actor, db }) => {
+    const planId = requireUuidRouteParam(params, 'planId');
     await requireOwnedPlanById({
       planId,
       ownerUserId: actor.id,

--- a/src/app/api/v1/plans/route.ts
+++ b/src/app/api/v1/plans/route.ts
@@ -4,6 +4,7 @@ import {
 } from '@/features/plans/read-projection/service';
 import type { PlainHandler } from '@/lib/api/auth';
 import { parseListPaginationParams } from '@/lib/api/pagination';
+import { getRequestSearchParams } from '@/lib/api/request-url';
 import { requestBoundary } from '@/lib/api/request-boundary';
 import { json } from '@/lib/api/response';
 import { logger } from '@/lib/logging/logger';
@@ -15,12 +16,13 @@ import {
 export const GET: PlainHandler = requestBoundary.route(
   { rateLimit: 'read' },
   async ({ req, actor, db }) => {
-    const url = new URL(req.url);
-
-    const { limit, offset } = parseListPaginationParams(url.searchParams, {
-      defaultLimit: getPaginationDefault('limit'),
-      maxLimit: PAGINATION_MAX_LIMIT,
-    });
+    const { limit, offset } = parseListPaginationParams(
+      getRequestSearchParams(req),
+      {
+        defaultLimit: getPaginationDefault('limit'),
+        maxLimit: PAGINATION_MAX_LIMIT,
+      },
+    );
 
     logger.info(
       {

--- a/src/app/api/v1/resources/route.ts
+++ b/src/app/api/v1/resources/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import { ValidationError } from '@/lib/api/errors';
 import { parseListPaginationParams } from '@/lib/api/pagination';
+import { getRequestSearchParams } from '@/lib/api/request-url';
 import { requestBoundary } from '@/lib/api/request-boundary';
 import { json } from '@/lib/api/response';
 import { resources } from '@supabase/schema';
@@ -19,10 +20,10 @@ const resourcesTypeQuerySchema = z.object({
 export const GET = requestBoundary.route(
   { rateLimit: 'read' },
   async ({ req, db }) => {
-    const url = new URL(req.url);
+    const searchParams = getRequestSearchParams(req);
 
     const parsedTypeQuery = resourcesTypeQuerySchema.safeParse({
-      type: url.searchParams.get('type') ?? undefined,
+      type: searchParams.get('type') ?? undefined,
     });
     if (!parsedTypeQuery.success) {
       throw new ValidationError(
@@ -31,7 +32,7 @@ export const GET = requestBoundary.route(
       );
     }
 
-    const { limit, offset } = parseListPaginationParams(url.searchParams, {
+    const { limit, offset } = parseListPaginationParams(searchParams, {
       defaultLimit: DEFAULT_RESOURCES_LIMIT,
       maxLimit: PAGINATION_MAX_LIMIT,
     });

--- a/src/features/ai/orchestrator.ts
+++ b/src/features/ai/orchestrator.ts
@@ -58,7 +58,7 @@ export async function runGenerationExecution(
 
   if (!isAttemptsDbClient(dbClient)) {
     throw new Error(
-      'runGenerationExecution requires dbClient (pass request-scoped getDb() from API routes)',
+      'runGenerationExecution requires dbClient (pass serviceRoleDb from server-owned generation boundaries, or an explicit test client)',
     );
   }
 

--- a/src/features/plans/api/route-context.ts
+++ b/src/features/plans/api/route-context.ts
@@ -9,36 +9,10 @@ export type PlansDbClient = DbClient;
 
 type LearningPlanRecord = OwnedPlanRecord;
 
-function getPlanIdFromUrl(
-  req: Request,
-  position: 'last' | 'second-to-last' = 'last',
-): string | undefined {
-  const url = new URL(req.url);
-  const segments = url.pathname.split('/').filter(Boolean);
-
-  return position === 'last'
-    ? segments[segments.length - 1]
-    : segments[segments.length - 2];
-}
-
 function isUuid(value: string): boolean {
   return /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(
     value,
   );
-}
-
-export function requirePlanIdFromRequest(
-  req: Request,
-  position: 'last' | 'second-to-last' = 'second-to-last',
-): string {
-  const planId = getPlanIdFromUrl(req, position);
-  if (!planId) {
-    throw new ValidationError('Plan id is required in the request path.');
-  }
-  if (!isUuid(planId)) {
-    throw new ValidationError('Invalid plan id format.');
-  }
-  return planId;
 }
 
 export function requireUuidRouteParam(

--- a/src/features/plans/lifecycle/factory.ts
+++ b/src/features/plans/lifecycle/factory.ts
@@ -8,10 +8,11 @@
  * Connection 1 (request-scoped) was used for lifecycle operations after withAuth's
  * finally block closed it.
  *
- * Connection scoping:
- *   - Stream route: stream-scoped RLS connection (survives entire generation)
- *   - Retry route: request-scoped RLS connection (synchronous with request)
- *   - Workers: service-role connection (no RLS needed)
+ * DB client scoping (server-owned writes):
+ *   - Plan stream/retry sessions: service-role client for generation persistence
+ *     after request auth and ownership checks at the route boundary
+ *   - Workers: service-role client (same server-owned write boundary)
+ *   - Reads and pre-write access checks: request-scoped RLS via getDb()
  */
 
 import { GenerationAdapter } from './adapters/generation-adapter';

--- a/src/features/plans/session/session-command.ts
+++ b/src/features/plans/session/session-command.ts
@@ -1,4 +1,5 @@
 import { resolveUserTier } from '@/features/billing/tier';
+import { getRequestSearchParams } from '@/lib/api/request-url';
 import { logger } from '@/lib/logging/logger';
 
 import type { PlansDbClient } from '@/features/plans/api/route-context';
@@ -218,7 +219,7 @@ function resolveCreateStreamModel({
 }): string | undefined {
   const { modelOverride, resolutionSource, suppliedModel } =
     resolveStreamModelResolution({
-      searchParams: new URL(req.url).searchParams,
+      searchParams: getRequestSearchParams(req),
       tier: createResult.tier,
       savedPreferredAiModel,
     });

--- a/src/features/plans/session/stream-cleanup.ts
+++ b/src/features/plans/session/stream-cleanup.ts
@@ -66,9 +66,9 @@ export async function safeMarkPlanFailed(
 
 /**
  * `safeMarkPlanFailedWithDbClient` builds the `PlanPersistenceAdapter` used by
- * `safeMarkPlanFailed`. Request handlers should pass the RLS-enforced
- * `DbClient` returned by `getDb()`, while workers/tests may pass a service-role
- * or test client matching their execution context.
+ * `safeMarkPlanFailed`. Plan failure marking mutates server-owned plan state;
+ * pass serviceRoleDb from feature-owned generation boundaries. Workers/tests
+ * may pass service-role or other privileged clients matching their context.
  */
 export async function safeMarkPlanFailedWithDbClient(
   planId: string,

--- a/src/lib/api/request-url.ts
+++ b/src/lib/api/request-url.ts
@@ -1,0 +1,7 @@
+/**
+ * Returns query-string parameters from a request URL.
+ * Use when only search params are needed (not path or origin).
+ */
+export function getRequestSearchParams(req: Request): URLSearchParams {
+  return new URL(req.url).searchParams;
+}

--- a/src/lib/db/queries/attempts.ts
+++ b/src/lib/db/queries/attempts.ts
@@ -40,10 +40,13 @@ import {
 import { count, eq, sql } from 'drizzle-orm';
 
 /**
- * RLS-sensitive query module: approved exception to the default "optional dbClient = getDb()" pattern.
- * This file requires explicit dbClient (AttemptsDbClient) in all params;
- * do not add default getDb() or make dbClient optional — callers must pass request-scoped getDb()
- * so RLS claims are preserved. See src/lib/db/AGENTS.md § "RLS-sensitive query modules".
+ * Server-owned generation persistence: requires explicit dbClient (AttemptsDbClient)
+ * in all params. Do not add default getDb() or make dbClient optional.
+ *
+ * Production callers pass serviceRoleDb from feature-owned generation boundaries
+ * after request auth and ownership checks. JWT claim replay in transactions is a
+ * no-op for service-role; it remains for any legacy RLS-scoped callers/tests.
+ * See src/lib/db/AGENTS.md § "RLS-sensitive query modules".
  */
 
 /**

--- a/src/lib/db/queries/helpers/attempts-persistence-success.ts
+++ b/src/lib/db/queries/helpers/attempts-persistence-success.ts
@@ -42,9 +42,10 @@ export function whereInProgressGenerationAttemptForPlan(params: {
 }
 
 /**
- * Persists success inside an existing transaction whose RLS/JWT claims have
- * already been applied. Callers that need claim setup should use
- * persistSuccessfulAttempt instead.
+ * Persists server-owned generation content inside an existing transaction.
+ * Callers that open their own transaction should use persistSuccessfulAttempt,
+ * which replays JWT claims only when the dbClient is request-scoped RLS
+ * (service-role skips replay).
  */
 export async function persistSuccessfulAttemptInTx(
   tx: DbTransaction,

--- a/src/lib/db/queries/plans.ts
+++ b/src/lib/db/queries/plans.ts
@@ -37,6 +37,7 @@ import type {
 } from '@/shared/types/db.types';
 import { and, asc, count, desc, eq, inArray, sql } from 'drizzle-orm';
 import { getDb } from '@supabase/runtime';
+import { db as serviceRoleDb } from '@supabase/service-role';
 
 type DeletePlanDbClient = Pick<DbClient, 'delete' | 'select'>;
 
@@ -468,7 +469,8 @@ type DeletePlanResult =
  *
  * @param planId - Plan ID to delete
  * @param userId - Authenticated user ID (ownership enforced via WHERE + RLS)
- * @param dbClient - Optional client; defaults to getDb()
+ * @param dbClient - Optional client; defaults to serviceRoleDb (learning_plans
+ *   DELETE is server-owned; ownership is enforced via explicit userId filters)
  * @returns DeletePlanResult indicating success or failure reason
  */
 export async function deletePlan(
@@ -477,7 +479,7 @@ export async function deletePlan(
   dbClient?: DeletePlanDbClient,
   deps: DeletePlanDeps = defaultDeletePlanDeps,
 ): Promise<DeletePlanResult> {
-  const client = dbClient ?? getDb();
+  const client = dbClient ?? serviceRoleDb;
 
   const plan = await deps.selectOwnedPlanById({
     planId,

--- a/supabase/service-role.ts
+++ b/supabase/service-role.ts
@@ -5,26 +5,32 @@
  * Using this in the wrong context creates critical security vulnerabilities.
  *
  * ═══════════════════════════════════════════════════════════════════════
- * ONLY USE FOR:
+ * USE FOR (trusted server-owned writes):
  * ═══════════════════════════════════════════════════════════════════════
  * ✅ Workers and background jobs (src/workers/...)
  * ✅ Database migrations and schema changes
  * ✅ Test setup and seeding (tests/helpers/db/, tests/.../setup.ts)
  * ✅ Administrative scripts (scripts/...)
+ * ✅ Feature-owned server write boundaries after request auth + ownership
+ *    checks (billing meters, generation/cache persistence, plan deletion)
  *
  * ═══════════════════════════════════════════════════════════════════════
- * NEVER USE IN:
+ * DO NOT USE DIRECTLY IN:
  * ═══════════════════════════════════════════════════════════════════════
- * ❌ API routes (src/app/api/...)
+ * ❌ Raw API route handlers (src/app/api/...)
  * ❌ Server actions (src/app/.../actions.ts)
- * ❌ Request handlers (src/lib/api/...)
- * ❌ Any code that handles user requests
+ * ❌ Request-handler glue (src/lib/api/...)
+ * ❌ Arbitrary user-request code paths without a narrow write boundary
+ *
+ * Route/action layers should use getDb() for reads and access checks, then
+ * delegate server-owned mutations to a feature service that receives this
+ * client only after verifying the actor and row ownership.
  *
  * ═══════════════════════════════════════════════════════════════════════
- * FOR REQUEST HANDLERS:
+ * FOR REQUEST-SCOPED READS AND ACCESS CHECKS:
  * ═══════════════════════════════════════════════════════════════════════
- * Use getDb() from @supabase/runtime instead - it automatically returns
- * the correct RLS-enforced client based on request context.
+ * Use getDb() from @supabase/runtime — it returns the RLS-enforced client
+ * for the active request context.
  *
  * Or import RLS clients directly from @/lib/db:
  * import { createAuthenticatedRlsClient } from '@/lib/db';
@@ -113,7 +119,8 @@ export function isServiceRoleDbClient(client: unknown): boolean {
 
 /**
  * Service role database client - BYPASSES RLS (lazily initialized).
- * Use getDb() from @supabase/runtime in request handlers instead.
+ * Prefer getDb() in route/action layers; pass this client only through
+ * feature-owned server write boundaries for server-owned tables.
  */
 export const db: ServiceRoleDb = new Proxy(
   serviceRoleProxyTarget,

--- a/supabase/usage.ts
+++ b/supabase/usage.ts
@@ -1,6 +1,6 @@
 import { buildModelPricingSnapshot } from '@/features/ai/model-pricing-snapshot';
 import { microusdIntegerToBigint } from '@/features/ai/provider-cost-microusd';
-import { getDb } from './runtime';
+import { db as serviceRoleDb } from './service-role';
 import { aiUsageEvents } from './schema';
 
 import type { DbClient, DbTransaction } from '@/lib/db/types';
@@ -50,9 +50,14 @@ export function canonicalUsageToRecordParams(
   };
 }
 
+/**
+ * Inserts an AI usage audit row. Defaults to service-role because
+ * `ai_usage_events` is server-owned; prefer recordUsageInTx inside generation
+ * transactions. Pass an explicit client only from trusted server boundaries.
+ */
 export async function recordUsage(
   params: RecordUsageParams,
-  dbClient: DbClient = getDb(),
+  dbClient: DbClient = serviceRoleDb,
 ): Promise<void> {
   await recordUsageInTx(dbClient, params);
 }

--- a/tests/helpers/route-handler-context.ts
+++ b/tests/helpers/route-handler-context.ts
@@ -1,0 +1,8 @@
+import type { RouteHandlerContext } from '@/lib/api/types/auth.types';
+
+/** Next.js route handler context for direct handler invocation in tests. */
+export function buildRouteHandlerContext(
+  params: Record<string, string>,
+): RouteHandlerContext {
+  return { params: Promise.resolve(params) };
+}

--- a/tests/helpers/streaming.ts
+++ b/tests/helpers/streaming.ts
@@ -5,6 +5,8 @@
  * streaming responses in integration tests.
  */
 
+import { expect } from 'vitest';
+
 /**
  * Type for parsed streaming events
  */
@@ -116,4 +118,57 @@ export async function readStreamingResponse(
 
   const buffer = await readStreamBodyIntoBuffer(reader);
   return parseSseBufferToEvents(buffer);
+}
+
+export function expectStreamingJsonObject(
+  value: unknown,
+): Record<string, unknown> {
+  expect(value).toBeTypeOf('object');
+  expect(value).not.toBeNull();
+  return value as Record<string, unknown>;
+}
+
+export function expectPlanStartEvent(
+  events: StreamingEvent[],
+  expectedAttemptNumber: number,
+): { planId: string } {
+  const startEvent = events.find((event) => event.type === 'plan_start');
+  if (!startEvent) {
+    throw new Error('Expected plan_start event');
+  }
+
+  const startData = expectStreamingJsonObject(startEvent.data);
+  expect(startData.planId).toEqual(expect.any(String));
+  expect(startData.attemptNumber).toBe(expectedAttemptNumber);
+
+  const planId = startData.planId;
+  if (typeof planId !== 'string' || planId.length === 0) {
+    throw new Error('Expected plan_start event to include a planId');
+  }
+
+  return { planId };
+}
+
+export function expectTerminalEventAfterStart(
+  events: StreamingEvent[],
+  terminalType: 'complete' | 'error' | 'cancelled',
+): StreamingEvent {
+  const eventTypes = events.map((event) => event.type);
+  const startIndex = eventTypes.indexOf('plan_start');
+  const terminalIndex = eventTypes.indexOf(terminalType);
+
+  expect(startIndex).toBeGreaterThanOrEqual(0);
+  expect(terminalIndex).toBeGreaterThan(startIndex);
+  expect(
+    eventTypes
+      .slice(0, terminalIndex)
+      .filter((type) => ['complete', 'error', 'cancelled'].includes(type)),
+  ).toEqual([]);
+
+  const terminalEvent = events[terminalIndex];
+  if (!terminalEvent) {
+    throw new Error(`Expected ${terminalType} event`);
+  }
+
+  return terminalEvent;
 }

--- a/tests/integration/api/plan-tasks.spec.ts
+++ b/tests/integration/api/plan-tasks.spec.ts
@@ -3,6 +3,7 @@ import { NextRequest } from 'next/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { db } from '@supabase/service-role';
 import { mockServerSession } from '@tests/helpers/mock-server-auth';
+import { buildRouteHandlerContext } from '@tests/helpers/route-handler-context';
 import { clearTestUser, setTestUser } from '../../helpers/auth';
 import { ensureUser } from '../../helpers/db/users';
 
@@ -94,7 +95,7 @@ describe('GET /api/v1/plans/:planId/tasks', () => {
       { method: 'GET' },
     );
 
-    const response = await GET(request);
+    const response = await GET(request, buildRouteHandlerContext({ planId }));
 
     expect(response.status).toBe(200);
     const body = await response.json();
@@ -107,13 +108,17 @@ describe('GET /api/v1/plans/:planId/tasks', () => {
   });
 
   it('should return 404 for non-existent plan', async () => {
+    const missingPlanId = '00000000-0000-0000-0000-000000000000';
     const { GET } = await import('@/app/api/v1/plans/[planId]/tasks/route');
     const request = new NextRequest(
-      'http://localhost:3000/api/v1/plans/00000000-0000-0000-0000-000000000000/tasks',
+      `http://localhost:3000/api/v1/plans/${missingPlanId}/tasks`,
       { method: 'GET' },
     );
 
-    const response = await GET(request);
+    const response = await GET(
+      request,
+      buildRouteHandlerContext({ planId: missingPlanId }),
+    );
 
     expect(response.status).toBe(404);
     const body = await response.json();
@@ -133,7 +138,7 @@ describe('GET /api/v1/plans/:planId/tasks', () => {
       { method: 'GET' },
     );
 
-    const response = await GET(request);
+    const response = await GET(request, buildRouteHandlerContext({ planId }));
 
     expect(response.status).toBe(401);
   });
@@ -151,7 +156,7 @@ describe('GET /api/v1/plans/:planId/tasks', () => {
       { method: 'GET' },
     );
 
-    const response = await GET(request);
+    const response = await GET(request, buildRouteHandlerContext({ planId }));
 
     expect(response.status).toBe(401);
   });
@@ -168,7 +173,7 @@ describe('GET /api/v1/plans/:planId/tasks', () => {
       { method: 'GET' },
     );
 
-    const response = await GET(request);
+    const response = await GET(request, buildRouteHandlerContext({ planId }));
 
     expect(response.status).toBe(404);
   });
@@ -194,7 +199,10 @@ describe('GET /api/v1/plans/:planId/tasks', () => {
       { method: 'GET' },
     );
 
-    const response = await GET(request);
+    const response = await GET(
+      request,
+      buildRouteHandlerContext({ planId: emptyPlan.id }),
+    );
 
     expect(response.status).toBe(200);
     const body = await response.json();
@@ -237,7 +245,7 @@ describe('GET /api/v1/plans/:planId/tasks', () => {
       { method: 'GET' },
     );
 
-    const response = await GET(request);
+    const response = await GET(request, buildRouteHandlerContext({ planId }));
 
     expect(response.status).toBe(200);
     const body = await response.json();

--- a/tests/integration/api/plans-retry.spec.ts
+++ b/tests/integration/api/plans-retry.spec.ts
@@ -9,7 +9,6 @@ import { seedFailedAttemptsForDurableWindow } from '../../fixtures/attempts';
 import { createPlanForRetryTest } from '../../fixtures/plans';
 import { setTestUser } from '../../helpers/auth';
 import { ensureUser } from '../../helpers/db/users';
-import { buildRouteHandlerContext } from '@tests/helpers/route-handler-context';
 import {
   expectPlanStartEvent,
   expectStreamingJsonObject,
@@ -67,7 +66,7 @@ function createRetryInvocation(planId: string) {
     request: new Request(`http://localhost/api/v1/plans/${planId}/retry`, {
       method: 'POST',
     }),
-    context: buildRouteHandlerContext({ planId }),
+    context: { params: Promise.resolve({ planId }) },
   };
 }
 
@@ -158,10 +157,11 @@ describe('POST /api/v1/plans/:planId/retry — HTTP preflight + default boundary
       },
     });
 
-    const invocation = createRetryInvocation(plan.id);
+    const invocationA = createRetryInvocation(plan.id);
+    const invocationB = createRetryInvocation(plan.id);
     const [resA, resB] = await Promise.all([
-      POST(invocation.request, invocation.context),
-      POST(invocation.request, invocation.context),
+      POST(invocationA.request, invocationA.context),
+      POST(invocationB.request, invocationB.context),
     ]);
 
     if (resA.status === 200 && resB.status === 200) {

--- a/tests/integration/api/plans-retry.spec.ts
+++ b/tests/integration/api/plans-retry.spec.ts
@@ -204,10 +204,11 @@ describe('POST /api/v1/plans/:planId/retry — HTTP preflight + default boundary
       },
     });
 
-    const invocation = createRetryInvocation(plan.id);
+    const invocationA = createRetryInvocation(plan.id);
+    const invocationB = createRetryInvocation(plan.id);
     const [resA, resB] = await Promise.all([
-      POST(invocation.request, invocation.context),
-      POST(invocation.request, invocation.context),
+      POST(invocationA.request, invocationA.context),
+      POST(invocationB.request, invocationB.context),
     ]);
 
     if (resA.status === 200 && resB.status === 200) {

--- a/tests/integration/api/plans-retry.spec.ts
+++ b/tests/integration/api/plans-retry.spec.ts
@@ -9,7 +9,13 @@ import { seedFailedAttemptsForDurableWindow } from '../../fixtures/attempts';
 import { createPlanForRetryTest } from '../../fixtures/plans';
 import { setTestUser } from '../../helpers/auth';
 import { ensureUser } from '../../helpers/db/users';
-import { readStreamingResponse } from '../../helpers/streaming';
+import { buildRouteHandlerContext } from '@tests/helpers/route-handler-context';
+import {
+  expectPlanStartEvent,
+  expectStreamingJsonObject,
+  expectTerminalEventAfterStart,
+  readStreamingResponse,
+} from '../../helpers/streaming';
 
 type RetryAttemptOverrides = Partial<
   Omit<typeof generationAttempts.$inferInsert, 'planId'>
@@ -56,61 +62,13 @@ async function withRunGenerationAttemptSpy<T>(
   }
 }
 
-function createRetryRequest(planId: string): Request {
-  return new Request(`http://localhost/api/v1/plans/${planId}/retry`, {
-    method: 'POST',
-  });
-}
-
-function expectJsonObject(value: unknown): Record<string, unknown> {
-  expect(value).toBeTypeOf('object');
-  expect(value).not.toBeNull();
-  return value as Record<string, unknown>;
-}
-
-function expectPlanStartEvent(
-  events: Awaited<ReturnType<typeof readStreamingResponse>>,
-  expectedAttemptNumber: number,
-): { planId: string } {
-  const startEvent = events.find((event) => event.type === 'plan_start');
-  if (!startEvent) {
-    throw new Error('Expected plan_start event');
-  }
-
-  const startData = expectJsonObject(startEvent.data);
-  expect(startData.planId).toEqual(expect.any(String));
-  expect(startData.attemptNumber).toBe(expectedAttemptNumber);
-
-  const planId = startData.planId;
-  if (typeof planId !== 'string' || planId.length === 0) {
-    throw new Error('Expected plan_start event to include a planId');
-  }
-
-  return { planId };
-}
-
-function expectTerminalEventAfterStart(
-  events: Awaited<ReturnType<typeof readStreamingResponse>>,
-  terminalType: 'complete' | 'error' | 'cancelled',
-) {
-  const eventTypes = events.map((event) => event.type);
-  const startIndex = eventTypes.indexOf('plan_start');
-  const terminalIndex = eventTypes.indexOf(terminalType);
-
-  expect(startIndex).toBeGreaterThanOrEqual(0);
-  expect(terminalIndex).toBeGreaterThan(startIndex);
-  expect(
-    eventTypes
-      .slice(0, terminalIndex)
-      .filter((type) => ['complete', 'error', 'cancelled'].includes(type)),
-  ).toEqual([]);
-
-  const terminalEvent = events[terminalIndex];
-  if (!terminalEvent) {
-    throw new Error(`Expected ${terminalType} event`);
-  }
-
-  return terminalEvent;
+function createRetryInvocation(planId: string) {
+  return {
+    request: new Request(`http://localhost/api/v1/plans/${planId}/retry`, {
+      method: 'POST',
+    }),
+    context: buildRouteHandlerContext({ planId }),
+  };
 }
 
 async function listAttempts(planId: string) {
@@ -153,13 +111,14 @@ describe('POST /api/v1/plans/:planId/retry — HTTP preflight + default boundary
       },
     });
 
-    const response = await POST(createRetryRequest(plan.id));
+    const { request, context } = createRetryInvocation(plan.id);
+    const response = await POST(request, context);
     expect(response.status).toBe(200);
 
     const events = await readStreamingResponse(response);
     const { planId } = expectPlanStartEvent(events, 2);
     const completeEvent = expectTerminalEventAfterStart(events, 'complete');
-    expect(expectJsonObject(completeEvent.data).planId).toBe(planId);
+    expect(expectStreamingJsonObject(completeEvent.data).planId).toBe(planId);
 
     const attempts = await listAttempts(plan.id);
     const [persistedPlan] = await db
@@ -199,9 +158,10 @@ describe('POST /api/v1/plans/:planId/retry — HTTP preflight + default boundary
       },
     });
 
+    const invocation = createRetryInvocation(plan.id);
     const [resA, resB] = await Promise.all([
-      POST(createRetryRequest(plan.id)),
-      POST(createRetryRequest(plan.id)),
+      POST(invocation.request, invocation.context),
+      POST(invocation.request, invocation.context),
     ]);
 
     if (resA.status === 200 && resB.status === 200) {
@@ -254,8 +214,8 @@ describe('POST /api/v1/plans/:planId/retry — HTTP preflight + default boundary
     await seedFailedAttemptsForDurableWindow(plan.id);
 
     await withRunGenerationAttemptSpy(async (runSpy) => {
-      const request = createRetryRequest(plan.id);
-      const response = await POST(request);
+      const { request, context } = createRetryInvocation(plan.id);
+      const response = await POST(request, context);
       expect(response.status).toBe(429);
       expect(response.headers.get('X-RateLimit-Remaining')).toBe('0');
 
@@ -286,7 +246,8 @@ describe('POST /api/v1/plans/:planId/retry — HTTP preflight + default boundary
     });
 
     await withRunGenerationAttemptSpy(async (runSpy) => {
-      const response = await POST(createRetryRequest(plan.id));
+      const { request, context } = createRetryInvocation(plan.id);
+      const response = await POST(request, context);
       expect(response.status).toBe(400);
       const body = (await response.json()) as { error?: string; code?: string };
       expect(body.code).toBe('VALIDATION_ERROR');

--- a/tests/integration/api/plans-retry.spec.ts
+++ b/tests/integration/api/plans-retry.spec.ts
@@ -9,6 +9,7 @@ import { seedFailedAttemptsForDurableWindow } from '../../fixtures/attempts';
 import { createPlanForRetryTest } from '../../fixtures/plans';
 import { setTestUser } from '../../helpers/auth';
 import { ensureUser } from '../../helpers/db/users';
+import { buildRouteHandlerContext } from '@tests/helpers/route-handler-context';
 import { readStreamingResponse } from '../../helpers/streaming';
 
 type RetryAttemptOverrides = Partial<
@@ -56,10 +57,13 @@ async function withRunGenerationAttemptSpy<T>(
   }
 }
 
-function createRetryRequest(planId: string): Request {
-  return new Request(`http://localhost/api/v1/plans/${planId}/retry`, {
-    method: 'POST',
-  });
+function createRetryInvocation(planId: string) {
+  return {
+    request: new Request(`http://localhost/api/v1/plans/${planId}/retry`, {
+      method: 'POST',
+    }),
+    context: buildRouteHandlerContext({ planId }),
+  };
 }
 
 function expectJsonObject(value: unknown): Record<string, unknown> {
@@ -153,7 +157,8 @@ describe('POST /api/v1/plans/:planId/retry — HTTP preflight + default boundary
       },
     });
 
-    const response = await POST(createRetryRequest(plan.id));
+    const { request, context } = createRetryInvocation(plan.id);
+    const response = await POST(request, context);
     expect(response.status).toBe(200);
 
     const events = await readStreamingResponse(response);
@@ -199,9 +204,10 @@ describe('POST /api/v1/plans/:planId/retry — HTTP preflight + default boundary
       },
     });
 
+    const invocation = createRetryInvocation(plan.id);
     const [resA, resB] = await Promise.all([
-      POST(createRetryRequest(plan.id)),
-      POST(createRetryRequest(plan.id)),
+      POST(invocation.request, invocation.context),
+      POST(invocation.request, invocation.context),
     ]);
 
     if (resA.status === 200 && resB.status === 200) {
@@ -254,8 +260,8 @@ describe('POST /api/v1/plans/:planId/retry — HTTP preflight + default boundary
     await seedFailedAttemptsForDurableWindow(plan.id);
 
     await withRunGenerationAttemptSpy(async (runSpy) => {
-      const request = createRetryRequest(plan.id);
-      const response = await POST(request);
+      const { request, context } = createRetryInvocation(plan.id);
+      const response = await POST(request, context);
       expect(response.status).toBe(429);
       expect(response.headers.get('X-RateLimit-Remaining')).toBe('0');
 
@@ -286,7 +292,8 @@ describe('POST /api/v1/plans/:planId/retry — HTTP preflight + default boundary
     });
 
     await withRunGenerationAttemptSpy(async (runSpy) => {
-      const response = await POST(createRetryRequest(plan.id));
+      const { request, context } = createRetryInvocation(plan.id);
+      const response = await POST(request, context);
       expect(response.status).toBe(400);
       const body = (await response.json()) as { error?: string; code?: string };
       expect(body.code).toBe('VALIDATION_ERROR');

--- a/tests/integration/api/plans-stream.spec.ts
+++ b/tests/integration/api/plans-stream.spec.ts
@@ -8,6 +8,9 @@ import { db } from '@supabase/service-role';
 import { setTestUser } from '../../helpers/auth';
 import { ensureUser } from '../../helpers/db/users';
 import {
+  expectPlanStartEvent,
+  expectStreamingJsonObject,
+  expectTerminalEventAfterStart,
   readStreamingResponse,
   type StreamingEvent,
 } from '../../helpers/streaming';
@@ -30,18 +33,12 @@ function assertNumericHeader(response: Response, name: string): void {
   );
 }
 
-function expectJsonObject(value: unknown): Record<string, unknown> {
-  expect(value).toBeTypeOf('object');
-  expect(value).not.toBeNull();
-  return value as Record<string, unknown>;
-}
-
 async function expectCompletedPlanId(
   events: StreamingEvent[],
 ): Promise<string> {
   const start = expectPlanStartEvent(events, 1);
   const completeEvent = expectTerminalEventAfterStart(events, 'complete');
-  const completeData = expectJsonObject(completeEvent.data);
+  const completeData = expectStreamingJsonObject(completeEvent.data);
   expect(completeData.planId).toBe(start.planId);
   await expect(getPlanGenerationStatus(start.planId)).resolves.toBe('ready');
   await expect(listAttempts(start.planId)).resolves.toMatchObject([
@@ -51,51 +48,6 @@ async function expectCompletedPlanId(
     },
   ]);
   return start.planId;
-}
-
-function expectPlanStartEvent(
-  events: StreamingEvent[],
-  expectedAttemptNumber: number,
-): { planId: string } {
-  const startEvent = events.find((event) => event.type === 'plan_start');
-  if (!startEvent) {
-    throw new Error('Expected plan_start event');
-  }
-
-  const startData = expectJsonObject(startEvent.data);
-  expect(startData.planId).toEqual(expect.any(String));
-  expect(startData.attemptNumber).toBe(expectedAttemptNumber);
-
-  const planId = startData.planId;
-  if (typeof planId !== 'string' || planId.length === 0) {
-    throw new Error('Expected plan_start event to include a planId');
-  }
-
-  return { planId };
-}
-
-function expectTerminalEventAfterStart(
-  events: StreamingEvent[],
-  terminalType: 'complete' | 'error' | 'cancelled',
-): StreamingEvent {
-  const eventTypes = events.map((event) => event.type);
-  const startIndex = eventTypes.indexOf('plan_start');
-  const terminalIndex = eventTypes.indexOf(terminalType);
-
-  expect(startIndex).toBeGreaterThanOrEqual(0);
-  expect(terminalIndex).toBeGreaterThan(startIndex);
-  expect(
-    eventTypes
-      .slice(0, terminalIndex)
-      .filter((type) => ['complete', 'error', 'cancelled'].includes(type)),
-  ).toEqual([]);
-
-  const terminalEvent = events[terminalIndex];
-  if (!terminalEvent) {
-    throw new Error(`Expected ${terminalType} event`);
-  }
-
-  return terminalEvent;
 }
 
 async function listAttempts(planId: string) {
@@ -151,7 +103,7 @@ describe('POST /api/v1/plans/stream — HTTP preflight + default boundary smoke'
 
     const response = await POST(request);
     expect(response.status).toBe(400);
-    const body = expectJsonObject(await response.json());
+    const body = expectStreamingJsonObject(await response.json());
     expect(body.error).toBe('Invalid request body.');
     expect(body.details).toEqual({
       reason: 'Malformed or invalid JSON payload.',

--- a/tests/integration/api/plans.status.rls.spec.ts
+++ b/tests/integration/api/plans.status.rls.spec.ts
@@ -3,6 +3,7 @@ import { NextRequest } from 'next/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { db } from '@supabase/service-role';
 import { mockServerSession } from '@tests/helpers/mock-server-auth';
+import { buildRouteHandlerContext } from '@tests/helpers/route-handler-context';
 import { setTestUser } from '../../helpers/auth';
 import { ensureUser } from '../../helpers/db/users';
 
@@ -65,7 +66,10 @@ describe('GET /api/v1/plans/:planId/status - access control', () => {
       `http://localhost:3000/api/v1/plans/${ownerPlanId}/status`,
       { method: 'GET' },
     );
-    const response = await GET(request);
+    const response = await GET(
+      request,
+      buildRouteHandlerContext({ planId: ownerPlanId }),
+    );
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.planId).toBe(ownerPlanId);
@@ -92,7 +96,10 @@ describe('GET /api/v1/plans/:planId/status - access control', () => {
       `http://localhost:3000/api/v1/plans/${otherPlan.id}/status`,
       { method: 'GET' },
     );
-    const response = await GET(request);
+    const response = await GET(
+      request,
+      buildRouteHandlerContext({ planId: otherPlan.id }),
+    );
     expect(response.status).toBe(404);
   });
 });

--- a/tests/integration/api/plans/plans-read.contract.spec.ts
+++ b/tests/integration/api/plans/plans-read.contract.spec.ts
@@ -14,6 +14,7 @@ import { buildTestPlanInsert } from '@tests/fixtures/plans';
 import { clearTestUser, setTestUser } from '@tests/helpers/auth';
 import { ensureUser } from '@tests/helpers/db/users';
 import { mockServerSession } from '@tests/helpers/mock-server-auth';
+import { buildRouteHandlerContext } from '@tests/helpers/route-handler-context';
 import { NextRequest } from 'next/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
@@ -219,6 +220,7 @@ describe('Plan read API response contracts', () => {
       new NextRequest(`http://localhost:3000/api/v1/plans/${plan.id}`, {
         method: 'GET',
       }),
+      buildRouteHandlerContext({ planId: plan.id }),
     );
     expect(detailRes.status).toBe(200);
     const detailJson: unknown = await detailRes.json();
@@ -232,6 +234,7 @@ describe('Plan read API response contracts', () => {
       new NextRequest(`http://localhost:3000/api/v1/plans/${plan.id}/status`, {
         method: 'GET',
       }),
+      buildRouteHandlerContext({ planId: plan.id }),
     );
     expect(statusRes.status).toBe(200);
     const statusJson: unknown = await statusRes.json();
@@ -246,6 +249,7 @@ describe('Plan read API response contracts', () => {
         `http://localhost:3000/api/v1/plans/${plan.id}/attempts`,
         { method: 'GET' },
       ),
+      buildRouteHandlerContext({ planId: plan.id }),
     );
     expect(attemptsRes.status).toBe(200);
     const attemptsJson: unknown = await attemptsRes.json();

--- a/tests/integration/contract/plans.api-integration.spec.ts
+++ b/tests/integration/contract/plans.api-integration.spec.ts
@@ -6,6 +6,7 @@ import { generationAttempts, learningPlans, modules } from '@supabase/schema';
 import { db } from '@supabase/service-role';
 import { setTestUser } from '../../helpers/auth';
 import { ensureUser } from '../../helpers/db/users';
+import { buildRouteHandlerContext } from '@tests/helpers/route-handler-context';
 import { buildTestAuthUserId, buildTestEmail } from '../../helpers/testIds';
 
 const BASE_URL = 'http://localhost/api/v1/plans';
@@ -41,7 +42,10 @@ describe('Phase 4: API Integration', () => {
         .returning();
 
       let statusRequest = await createStatusRequest(plan.id);
-      let statusResponse = await GET_STATUS(statusRequest);
+      let statusResponse = await GET_STATUS(
+        statusRequest,
+        buildRouteHandlerContext({ planId: plan.id }),
+      );
       expect(statusResponse.status).toBe(200);
       let statusPayload = await statusResponse.json();
       expect(statusPayload.status).toBe('processing');
@@ -61,7 +65,10 @@ describe('Phase 4: API Integration', () => {
       });
 
       statusRequest = await createStatusRequest(plan.id);
-      statusResponse = await GET_STATUS(statusRequest);
+      statusResponse = await GET_STATUS(
+        statusRequest,
+        buildRouteHandlerContext({ planId: plan.id }),
+      );
       statusPayload = await statusResponse.json();
       expect(statusPayload.status).toBe('ready');
     });
@@ -94,7 +101,10 @@ describe('Phase 4: API Integration', () => {
       });
 
       const statusRequest = await createStatusRequest(plan.id);
-      const statusResponse = await GET_STATUS(statusRequest);
+      const statusResponse = await GET_STATUS(
+        statusRequest,
+        buildRouteHandlerContext({ planId: plan.id }),
+      );
       const statusPayload = await statusResponse.json();
       expect(statusPayload.status).toBe('failed');
       expect(statusPayload.latestError).toBe(

--- a/tests/integration/contract/plans.attempts.get.spec.ts
+++ b/tests/integration/contract/plans.attempts.get.spec.ts
@@ -5,12 +5,16 @@ import { generationAttempts, learningPlans } from '@supabase/schema';
 import { db } from '@supabase/service-role';
 import { setTestUser } from '../../helpers/auth';
 import { ensureUser } from '../../helpers/db/users';
+import { buildRouteHandlerContext } from '@tests/helpers/route-handler-context';
 import { buildTestAuthUserId, buildTestEmail } from '../../helpers/testIds';
 
 function buildRequest(planId: string) {
-  return new Request(`http://localhost/api/v1/plans/${planId}/attempts`, {
-    method: 'GET',
-  });
+  return {
+    request: new Request(`http://localhost/api/v1/plans/${planId}/attempts`, {
+      method: 'GET',
+    }),
+    context: buildRouteHandlerContext({ planId }),
+  };
 }
 
 describe('GET /api/v1/plans/:planId/attempts', () => {
@@ -65,7 +69,8 @@ describe('GET /api/v1/plans/:planId/attempts', () => {
       },
     ]);
 
-    const response = await GET(buildRequest(plan.id));
+    const { request, context } = buildRequest(plan.id);
+    const response = await GET(request, context);
     expect(response.status).toBe(200);
 
     const attempts = await response.json();
@@ -83,9 +88,10 @@ describe('GET /api/v1/plans/:planId/attempts', () => {
       email: buildTestEmail(otherOwnerAuthId),
     });
 
-    const response = await GET(
-      buildRequest('00000000-0000-0000-0000-000000000000'),
+    const { request, context } = buildRequest(
+      '00000000-0000-0000-0000-000000000000',
     );
+    const response = await GET(request, context);
     expect(response.status).toBe(404);
   });
 });

--- a/tests/integration/contract/plans.get.spec.ts
+++ b/tests/integration/contract/plans.get.spec.ts
@@ -5,12 +5,16 @@ import { learningPlans, modules, tasks } from '@supabase/schema';
 import { db } from '@supabase/service-role';
 import { setTestUser } from '../../helpers/auth';
 import { ensureUser } from '../../helpers/db/users';
+import { buildRouteHandlerContext } from '@tests/helpers/route-handler-context';
 import { buildTestAuthUserId, buildTestEmail } from '../../helpers/testIds';
 
 function buildRequest(planId: string) {
-  return new Request(`http://localhost/api/v1/plans/${planId}`, {
-    method: 'GET',
-  });
+  return {
+    request: new Request(`http://localhost/api/v1/plans/${planId}`, {
+      method: 'GET',
+    }),
+    context: buildRouteHandlerContext({ planId }),
+  };
 }
 
 describe('GET /api/v1/plans/:planId', () => {
@@ -81,7 +85,8 @@ describe('GET /api/v1/plans/:planId', () => {
       },
     ]);
 
-    const response = await GET(buildRequest(plan.id));
+    const { request, context } = buildRequest(plan.id);
+    const response = await GET(request, context);
     expect(response.status).toBe(200);
 
     const detail = await response.json();
@@ -102,9 +107,10 @@ describe('GET /api/v1/plans/:planId', () => {
       email: buildTestEmail(nonOwnerAuthId),
     });
 
-    const response = await GET(
-      buildRequest('00000000-0000-0000-0000-000000000000'),
+    const { request, context } = buildRequest(
+      '00000000-0000-0000-0000-000000000000',
     );
+    const response = await GET(request, context);
     expect(response.status).toBe(404);
   });
 
@@ -138,7 +144,8 @@ describe('GET /api/v1/plans/:planId', () => {
       email: attackerEmail,
     });
 
-    const response = await GET(buildRequest(ownerPlan.id));
+    const { request, context } = buildRequest(ownerPlan.id);
+    const response = await GET(request, context);
     expect(response.status).toBe(404);
 
     const error = await response.json();

--- a/tests/integration/contract/plans.status-parity.spec.ts
+++ b/tests/integration/contract/plans.status-parity.spec.ts
@@ -1,3 +1,4 @@
+import { buildRouteHandlerContext } from '@tests/helpers/route-handler-context';
 import { GET as GET_PLAN_DETAIL } from '@/app/api/v1/plans/[planId]/route';
 import { GET as GET_PLAN_STATUS } from '@/app/api/v1/plans/[planId]/status/route';
 import { getGenerationAttemptCap } from '@/features/ai/generation-policy';
@@ -127,15 +128,18 @@ describe('Plan status parity contract', () => {
     for (const fixture of fixtures) {
       const planId = await createPlanFixture(userId, fixture);
 
+      const routeContext = buildRouteHandlerContext({ planId });
       const detailResponse = await GET_PLAN_DETAIL(
         new Request(`http://localhost/api/v1/plans/${planId}`, {
           method: 'GET',
         }),
+        routeContext,
       );
       const statusResponse = await GET_PLAN_STATUS(
         new Request(`http://localhost/api/v1/plans/${planId}/status`, {
           method: 'GET',
         }),
+        routeContext,
       );
 
       expect(detailResponse.status).toBe(200);

--- a/tests/integration/features/plans/session/respond-create-stream.spec.ts
+++ b/tests/integration/features/plans/session/respond-create-stream.spec.ts
@@ -9,15 +9,16 @@ import { buildTestAuthUserId } from '@tests/helpers/testIds';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { PlanLifecycleService } from '@/features/plans/lifecycle/service';
-import type {
-  CreatePlanResult,
-  GenerationAttemptResult,
-  ProcessGenerationInput,
-} from '@/features/plans/lifecycle/types';
-import type { RespondCreateStreamArgs } from '@/features/plans/session/plan-generation-session';
-import type { CreateLearningPlanInput } from '@/features/plans/validation/learningPlans.types';
+import type { ProcessGenerationInput } from '@/features/plans/lifecycle/types';
 import type { AttemptsDbClient } from '@/lib/db/queries/types/attempts.types';
-import { buildMockCreateLifecycle } from './stream-session-test-helpers';
+import {
+  BASE_CREATE_BODY,
+  buildCreateStreamArgs,
+  buildCreateStreamRequest,
+  buildMockCreateLifecycle,
+  SUCCESS_CREATE_ATTEMPT_RESULT,
+  SUCCESS_CREATE_RESULT,
+} from './stream-session-test-helpers';
 
 const VALID_PRO_MODEL = AVAILABLE_MODELS.find(({ tier }) => tier === 'pro')?.id;
 
@@ -25,78 +26,11 @@ if (!VALID_PRO_MODEL) {
   throw new Error('Expected at least one pro-tier model fixture');
 }
 
-const SUCCESS_CREATE_RESULT: CreatePlanResult = {
-  status: 'success',
-  planId: 'plan_boundary_create_success',
-  tier: 'pro',
-  normalizedInput: {
-    topic: 'Boundary Topic',
-    skillLevel: 'beginner',
-    weeklyHours: 5,
-    learningStyle: 'mixed',
-    startDate: null,
-    deadlineDate: '2030-01-01',
-  },
-};
-
-const SUCCESS_ATTEMPT_RESULT: GenerationAttemptResult = {
-  status: 'generation_success',
-  data: {
-    modules: [
-      {
-        title: 'Boundary Module',
-        estimatedMinutes: 60,
-        tasks: [{ title: 'Boundary Task', estimatedMinutes: 30 }],
-      },
-    ],
-    metadata: {
-      provider: 'mock',
-      model: 'mock-model',
-      usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
-    },
-    durationMs: 5,
-  },
-};
-
-const BASE_BODY: CreateLearningPlanInput = {
-  topic: 'Boundary Topic',
-  skillLevel: 'beginner',
-  weeklyHours: 5,
-  learningStyle: 'mixed',
-  notes: undefined,
-  startDate: undefined,
-  deadlineDate: '2030-01-01',
-  visibility: 'private',
-  origin: 'ai',
-};
-
-function buildCreateRequest(
-  overrides: { signal?: AbortSignal; url?: string } = {},
-): Request {
-  return new Request(overrides.url ?? 'http://localhost/api/v1/plans/stream', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(BASE_BODY),
-    ...(overrides.signal ? { signal: overrides.signal } : {}),
-  });
-}
-
-function buildArgs(
-  args: Partial<RespondCreateStreamArgs> & { req: Request; authUserId: string },
-): RespondCreateStreamArgs {
-  return {
-    internalUserId: 'internal-user-id',
-    body: { ...BASE_BODY },
-    savedPreferredAiModel: null,
-    ...args,
-  };
-}
-
 describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
   it('emits plan_start, module_summary, progress, then complete on success', async () => {
     const fake = buildMockCreateLifecycle({
       createResult: SUCCESS_CREATE_RESULT,
-      process: async () => SUCCESS_ATTEMPT_RESULT,
+      process: async () => SUCCESS_CREATE_ATTEMPT_RESULT,
     });
     const createLifecycleService = vi.fn(() => fake.service);
     const boundary = createPlanGenerationSessionBoundary({
@@ -104,10 +38,10 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
     });
 
     const authUserId = buildTestAuthUserId('boundary-create-success');
-    const req = buildCreateRequest();
+    const req = buildCreateStreamRequest();
 
     const response = await boundary.respondCreateStream(
-      buildArgs({ req, authUserId }),
+      buildCreateStreamArgs({ req, authUserId }),
     );
 
     expect(response.status).toBe(200);
@@ -128,7 +62,7 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
     expect(planStart?.data).toMatchObject({
       planId: SUCCESS_CREATE_RESULT.planId,
       attemptNumber: 1,
-      topic: 'Boundary Topic',
+      topic: BASE_CREATE_BODY.topic,
     });
 
     const complete = findStreamingEvent(events, 'complete');
@@ -156,10 +90,10 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
     });
 
     const authUserId = buildTestAuthUserId('boundary-create-retryable');
-    const req = buildCreateRequest();
+    const req = buildCreateStreamRequest();
 
     const response = await boundary.respondCreateStream(
-      buildArgs({ req, authUserId }),
+      buildCreateStreamArgs({ req, authUserId }),
     );
 
     expect(response.status).toBe(200);
@@ -197,10 +131,10 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
     });
 
     const authUserId = buildTestAuthUserId('boundary-create-reqid');
-    const req = buildCreateRequest();
+    const req = buildCreateStreamRequest();
 
     const response = await boundary.respondCreateStream(
-      buildArgs({
+      buildCreateStreamArgs({
         req,
         authUserId,
         requestId: 'corr-boundary-create-1',
@@ -229,10 +163,10 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
     });
 
     const authUserId = buildTestAuthUserId('boundary-create-permanent');
-    const req = buildCreateRequest();
+    const req = buildCreateStreamRequest();
 
     const response = await boundary.respondCreateStream(
-      buildArgs({ req, authUserId }),
+      buildCreateStreamArgs({ req, authUserId }),
     );
 
     const events = await readStreamingResponse(response);
@@ -260,10 +194,10 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
     });
 
     const authUserId = buildTestAuthUserId('boundary-create-unhandled');
-    const req = buildCreateRequest();
+    const req = buildCreateStreamRequest();
 
     const response = await boundary.respondCreateStream(
-      buildArgs({
+      buildCreateStreamArgs({
         req,
         authUserId,
         requestId: 'corr-boundary-create-unhandled',
@@ -302,10 +236,10 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
     });
 
     const authUserId = buildTestAuthUserId('boundary-create-disconnect');
-    const req = buildCreateRequest({ signal: controller.signal });
+    const req = buildCreateStreamRequest({ signal: controller.signal });
 
     const response = await boundary.respondCreateStream(
-      buildArgs({ req, authUserId }),
+      buildCreateStreamArgs({ req, authUserId }),
     );
 
     expect(response.status).toBe(200);
@@ -319,17 +253,17 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
   it('passes responseHeaders through to the streaming Response', async () => {
     const fake = buildMockCreateLifecycle({
       createResult: SUCCESS_CREATE_RESULT,
-      process: async () => SUCCESS_ATTEMPT_RESULT,
+      process: async () => SUCCESS_CREATE_ATTEMPT_RESULT,
     });
     const boundary = createPlanGenerationSessionBoundary({
       createLifecycleService: () => fake.service,
     });
 
     const authUserId = buildTestAuthUserId('boundary-create-headers');
-    const req = buildCreateRequest();
+    const req = buildCreateStreamRequest();
 
     const response = await boundary.respondCreateStream(
-      buildArgs({
+      buildCreateStreamArgs({
         req,
         authUserId,
         responseHeaders: {
@@ -352,7 +286,7 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
       createResult: SUCCESS_CREATE_RESULT,
       process: async (input) => {
         captured.push(input);
-        return SUCCESS_ATTEMPT_RESULT;
+        return SUCCESS_CREATE_ATTEMPT_RESULT;
       },
     });
     const boundary = createPlanGenerationSessionBoundary({
@@ -360,12 +294,12 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
     });
 
     const authUserId = buildTestAuthUserId('boundary-create-model-invalid');
-    const req = buildCreateRequest({
+    const req = buildCreateStreamRequest({
       url: 'http://localhost/api/v1/plans/stream?model=invalid/model-id',
     });
 
     const response = await boundary.respondCreateStream(
-      buildArgs({
+      buildCreateStreamArgs({
         req,
         authUserId,
         savedPreferredAiModel: null,
@@ -385,7 +319,7 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
       createResult: SUCCESS_CREATE_RESULT,
       process: async (input) => {
         captured.push(input);
-        return SUCCESS_ATTEMPT_RESULT;
+        return SUCCESS_CREATE_ATTEMPT_RESULT;
       },
     });
     const boundary = createPlanGenerationSessionBoundary({
@@ -393,12 +327,12 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
     });
 
     const authUserId = buildTestAuthUserId('boundary-create-model-valid');
-    const req = buildCreateRequest({
+    const req = buildCreateStreamRequest({
       url: `http://localhost/api/v1/plans/stream?model=${encodeURIComponent(VALID_PRO_MODEL)}`,
     });
 
     const response = await boundary.respondCreateStream(
-      buildArgs({
+      buildCreateStreamArgs({
         req,
         authUserId,
         savedPreferredAiModel: null,
@@ -417,7 +351,7 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
       createResult: SUCCESS_CREATE_RESULT,
       process: async (input) => {
         captured.push(input);
-        return SUCCESS_ATTEMPT_RESULT;
+        return SUCCESS_CREATE_ATTEMPT_RESULT;
       },
     });
     const boundary = createPlanGenerationSessionBoundary({
@@ -425,10 +359,10 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
     });
 
     const authUserId = buildTestAuthUserId('boundary-create-saved-pref');
-    const req = buildCreateRequest();
+    const req = buildCreateStreamRequest();
 
     const response = await boundary.respondCreateStream(
-      buildArgs({
+      buildCreateStreamArgs({
         req,
         authUserId,
         savedPreferredAiModel: VALID_PRO_MODEL,
@@ -444,7 +378,7 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
   it('builds a fresh lifecycle service per request via the injected factory', async () => {
     const fake = buildMockCreateLifecycle({
       createResult: SUCCESS_CREATE_RESULT,
-      process: async () => SUCCESS_ATTEMPT_RESULT,
+      process: async () => SUCCESS_CREATE_ATTEMPT_RESULT,
     });
     const createLifecycleService = vi.fn<
       (db: AttemptsDbClient) => PlanLifecycleService
@@ -457,10 +391,10 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
 
     const responses = await Promise.all([
       boundary.respondCreateStream(
-        buildArgs({ req: buildCreateRequest(), authUserId }),
+        buildCreateStreamArgs({ req: buildCreateStreamRequest(), authUserId }),
       ),
       boundary.respondCreateStream(
-        buildArgs({ req: buildCreateRequest(), authUserId }),
+        buildCreateStreamArgs({ req: buildCreateStreamRequest(), authUserId }),
       ),
     ]);
 

--- a/tests/integration/features/plans/session/respond-retry-stream.spec.ts
+++ b/tests/integration/features/plans/session/respond-retry-stream.spec.ts
@@ -1,121 +1,44 @@
-import type {
-  GenerationAttemptResult,
-  ProcessGenerationInput,
-} from '@/features/plans/lifecycle/types';
+import type { ProcessGenerationInput } from '@/features/plans/lifecycle/types';
 import {
   createPlanGenerationSessionBoundary,
   PLAN_RETRY_RESERVATION_ALLOWED_STATUSES,
-  type RespondRetryStreamArgs,
-  type RetryPlanGenerationPlanSnapshot,
 } from '@/features/plans/session/plan-generation-session';
 import * as streamCleanup from '@/features/plans/session/stream-cleanup';
-import { ensureUser } from '@tests/helpers/db/users';
-import {
-  buildMockProcessLifecycle,
-  type MockProcessLifecycleHandle,
-} from './stream-session-test-helpers';
 import {
   findStreamingEvent,
   readStreamingResponse,
 } from '@tests/helpers/streaming';
-import { buildTestAuthUserId, buildTestEmail } from '@tests/helpers/testIds';
 import { describe, expect, it, vi } from 'vitest';
-import { db } from '@supabase/service-role';
-
-const SUCCESS_ATTEMPT_RESULT: GenerationAttemptResult = {
-  status: 'generation_success',
-  data: {
-    modules: [
-      {
-        title: 'Retry Module',
-        estimatedMinutes: 90,
-        tasks: [
-          { title: 'Retry Task A', estimatedMinutes: 30 },
-          { title: 'Retry Task B', estimatedMinutes: 60 },
-        ],
-      },
-    ],
-    metadata: {
-      provider: 'mock',
-      model: 'mock-model',
-      usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
-    },
-    durationMs: 5,
-  },
-};
-
-const BASE_PLAN_SNAPSHOT: RetryPlanGenerationPlanSnapshot = {
-  topic: 'Retry Topic',
-  skillLevel: 'intermediate',
-  weeklyHours: 6,
-  learningStyle: 'mixed',
-  startDate: '2030-01-01',
-  deadlineDate: '2030-06-01',
-  origin: 'ai',
-};
-
-function buildRetryRequest(planId: string, signal?: AbortSignal): Request {
-  return new Request(`http://localhost/api/v1/plans/${planId}/retry`, {
-    method: 'POST',
-    ...(signal ? { signal } : {}),
-  });
-}
-
-interface BuildArgsInput {
-  req: Request;
-  authUserId: string;
-  internalUserId: string;
-  planId?: string;
-  plan?: RetryPlanGenerationPlanSnapshot;
-  responseHeaders?: HeadersInit;
-  requestId?: string;
-}
-
-function buildArgs(input: BuildArgsInput): RespondRetryStreamArgs {
-  return {
-    req: input.req,
-    authUserId: input.authUserId,
-    internalUserId: input.internalUserId,
-    planId: input.planId ?? 'plan_boundary_retry',
-    plan: input.plan ?? { ...BASE_PLAN_SNAPSHOT },
-    tierDb: db,
-    ...(input.responseHeaders
-      ? { responseHeaders: input.responseHeaders }
-      : {}),
-    ...(input.requestId !== undefined ? { requestId: input.requestId } : {}),
-  };
-}
-
-async function setupUser(scenario: string): Promise<{
-  authUserId: string;
-  internalUserId: string;
-}> {
-  const authUserId = buildTestAuthUserId(scenario);
-  const internalUserId = await ensureUser({
-    authUserId,
-    email: buildTestEmail(authUserId),
-    subscriptionTier: 'pro',
-  });
-  return { authUserId, internalUserId };
-}
+import {
+  BASE_RETRY_PLAN_SNAPSHOT,
+  buildMockProcessLifecycle,
+  buildRetryStreamArgs,
+  buildRetryStreamRequest,
+  setupPlanSessionUser,
+  SUCCESS_RETRY_ATTEMPT_RESULT,
+  type MockProcessLifecycleHandle,
+} from './stream-session-test-helpers';
 
 describe('PlanGenerationSessionBoundary.respondRetryStream', () => {
   it('emits plan_start with retry attempt number then complete on success', async () => {
-    const fake = buildMockProcessLifecycle(async () => SUCCESS_ATTEMPT_RESULT, {
-      topic: BASE_PLAN_SNAPSHOT.topic,
-    });
+    const fake = buildMockProcessLifecycle(
+      async () => SUCCESS_RETRY_ATTEMPT_RESULT,
+      {
+        topic: BASE_RETRY_PLAN_SNAPSHOT.topic,
+      },
+    );
     const createLifecycleService = vi.fn(() => fake.service);
     const boundary = createPlanGenerationSessionBoundary({
       createLifecycleService,
     });
 
-    const { authUserId, internalUserId } = await setupUser(
+    const { authUserId, internalUserId } = await setupPlanSessionUser(
       'boundary-retry-success',
     );
-    const req = buildRetryRequest('plan_retry_success');
+    const req = buildRetryStreamRequest('plan_retry_success');
 
     const response = await boundary.respondRetryStream(
-      buildArgs({
+      buildRetryStreamArgs({
         req,
         authUserId,
         internalUserId,
@@ -134,7 +57,7 @@ describe('PlanGenerationSessionBoundary.respondRetryStream', () => {
     expect(planStart?.data).toMatchObject({
       planId: 'plan_retry_success',
       attemptNumber: 2,
-      topic: BASE_PLAN_SNAPSHOT.topic,
+      topic: BASE_RETRY_PLAN_SNAPSHOT.topic,
     });
     expect(complete?.data).toMatchObject({
       planId: 'plan_retry_success',
@@ -156,13 +79,13 @@ describe('PlanGenerationSessionBoundary.respondRetryStream', () => {
       createLifecycleService: () => fake.service,
     });
 
-    const { authUserId, internalUserId } = await setupUser(
+    const { authUserId, internalUserId } = await setupPlanSessionUser(
       'boundary-retry-retryable',
     );
 
     const response = await boundary.respondRetryStream(
-      buildArgs({
-        req: buildRetryRequest('plan_retry_retryable'),
+      buildRetryStreamArgs({
+        req: buildRetryStreamRequest('plan_retry_retryable'),
         authUserId,
         internalUserId,
         planId: 'plan_retry_retryable',
@@ -192,13 +115,13 @@ describe('PlanGenerationSessionBoundary.respondRetryStream', () => {
       createLifecycleService: () => fake.service,
     });
 
-    const { authUserId, internalUserId } = await setupUser(
+    const { authUserId, internalUserId } = await setupPlanSessionUser(
       'boundary-retry-reqid',
     );
 
     const response = await boundary.respondRetryStream(
-      buildArgs({
-        req: buildRetryRequest('plan_retry_reqid'),
+      buildRetryStreamArgs({
+        req: buildRetryStreamRequest('plan_retry_reqid'),
         authUserId,
         internalUserId,
         planId: 'plan_retry_reqid',
@@ -224,13 +147,13 @@ describe('PlanGenerationSessionBoundary.respondRetryStream', () => {
       createLifecycleService: () => fake.service,
     });
 
-    const { authUserId, internalUserId } = await setupUser(
+    const { authUserId, internalUserId } = await setupPlanSessionUser(
       'boundary-retry-permanent',
     );
 
     const response = await boundary.respondRetryStream(
-      buildArgs({
-        req: buildRetryRequest('plan_retry_permanent'),
+      buildRetryStreamArgs({
+        req: buildRetryStreamRequest('plan_retry_permanent'),
         authUserId,
         internalUserId,
         planId: 'plan_retry_permanent',
@@ -255,19 +178,19 @@ describe('PlanGenerationSessionBoundary.respondRetryStream', () => {
       async () => {
         throw new Error('retry boom');
       },
-      { topic: BASE_PLAN_SNAPSHOT.topic },
+      { topic: BASE_RETRY_PLAN_SNAPSHOT.topic },
     );
     const boundary = createPlanGenerationSessionBoundary({
       createLifecycleService: () => fake.service,
     });
 
-    const { authUserId, internalUserId } = await setupUser(
+    const { authUserId, internalUserId } = await setupPlanSessionUser(
       'boundary-retry-unhandled',
     );
 
     const response = await boundary.respondRetryStream(
-      buildArgs({
-        req: buildRetryRequest('plan_retry_unhandled'),
+      buildRetryStreamArgs({
+        req: buildRetryStreamRequest('plan_retry_unhandled'),
         authUserId,
         internalUserId,
         planId: 'plan_retry_unhandled',
@@ -298,19 +221,22 @@ describe('PlanGenerationSessionBoundary.respondRetryStream', () => {
         controller.abort();
         throw new DOMException('Client disconnected', 'AbortError');
       },
-      { topic: BASE_PLAN_SNAPSHOT.topic },
+      { topic: BASE_RETRY_PLAN_SNAPSHOT.topic },
     );
     const boundary = createPlanGenerationSessionBoundary({
       createLifecycleService: () => fake.service,
     });
 
-    const { authUserId, internalUserId } = await setupUser(
+    const { authUserId, internalUserId } = await setupPlanSessionUser(
       'boundary-retry-disconnect',
     );
 
     const response = await boundary.respondRetryStream(
-      buildArgs({
-        req: buildRetryRequest('plan_retry_disconnect', controller.signal),
+      buildRetryStreamArgs({
+        req: buildRetryStreamRequest(
+          'plan_retry_disconnect',
+          controller.signal,
+        ),
         authUserId,
         internalUserId,
         planId: 'plan_retry_disconnect',
@@ -325,20 +251,23 @@ describe('PlanGenerationSessionBoundary.respondRetryStream', () => {
   });
 
   it('passes responseHeaders through to the streaming Response', async () => {
-    const fake = buildMockProcessLifecycle(async () => SUCCESS_ATTEMPT_RESULT, {
-      topic: BASE_PLAN_SNAPSHOT.topic,
-    });
+    const fake = buildMockProcessLifecycle(
+      async () => SUCCESS_RETRY_ATTEMPT_RESULT,
+      {
+        topic: BASE_RETRY_PLAN_SNAPSHOT.topic,
+      },
+    );
     const boundary = createPlanGenerationSessionBoundary({
       createLifecycleService: () => fake.service,
     });
 
-    const { authUserId, internalUserId } = await setupUser(
+    const { authUserId, internalUserId } = await setupPlanSessionUser(
       'boundary-retry-headers',
     );
 
     const response = await boundary.respondRetryStream(
-      buildArgs({
-        req: buildRetryRequest('plan_retry_headers'),
+      buildRetryStreamArgs({
+        req: buildRetryStreamRequest('plan_retry_headers'),
         authUserId,
         internalUserId,
         planId: 'plan_retry_headers',
@@ -361,21 +290,21 @@ describe('PlanGenerationSessionBoundary.respondRetryStream', () => {
     const fake = buildMockProcessLifecycle(
       async (input) => {
         captured.push(input);
-        return SUCCESS_ATTEMPT_RESULT;
+        return SUCCESS_RETRY_ATTEMPT_RESULT;
       },
-      { topic: BASE_PLAN_SNAPSHOT.topic },
+      { topic: BASE_RETRY_PLAN_SNAPSHOT.topic },
     );
     const boundary = createPlanGenerationSessionBoundary({
       createLifecycleService: () => fake.service,
     });
 
-    const { authUserId, internalUserId } = await setupUser(
+    const { authUserId, internalUserId } = await setupPlanSessionUser(
       'boundary-retry-allowed-statuses',
     );
 
     const response = await boundary.respondRetryStream(
-      buildArgs({
-        req: buildRetryRequest('plan_retry_allowed'),
+      buildRetryStreamArgs({
+        req: buildRetryStreamRequest('plan_retry_allowed'),
         authUserId,
         internalUserId,
         planId: 'plan_retry_allowed',
@@ -394,9 +323,9 @@ describe('PlanGenerationSessionBoundary.respondRetryStream', () => {
     const builtFakes: MockProcessLifecycleHandle[] = [];
     const createLifecycleService = vi.fn(() => {
       const next = buildMockProcessLifecycle(
-        async () => SUCCESS_ATTEMPT_RESULT,
+        async () => SUCCESS_RETRY_ATTEMPT_RESULT,
         {
-          topic: BASE_PLAN_SNAPSHOT.topic,
+          topic: BASE_RETRY_PLAN_SNAPSHOT.topic,
         },
       );
       builtFakes.push(next);
@@ -406,22 +335,22 @@ describe('PlanGenerationSessionBoundary.respondRetryStream', () => {
       createLifecycleService,
     });
 
-    const { authUserId, internalUserId } = await setupUser(
+    const { authUserId, internalUserId } = await setupPlanSessionUser(
       'boundary-retry-factory',
     );
 
     const responses = await Promise.all([
       boundary.respondRetryStream(
-        buildArgs({
-          req: buildRetryRequest('plan_retry_factory_a'),
+        buildRetryStreamArgs({
+          req: buildRetryStreamRequest('plan_retry_factory_a'),
           authUserId,
           internalUserId,
           planId: 'plan_retry_factory_a',
         }),
       ),
       boundary.respondRetryStream(
-        buildArgs({
-          req: buildRetryRequest('plan_retry_factory_b'),
+        buildRetryStreamArgs({
+          req: buildRetryStreamRequest('plan_retry_factory_b'),
           authUserId,
           internalUserId,
           planId: 'plan_retry_factory_b',

--- a/tests/integration/features/plans/session/stream-session-test-helpers.ts
+++ b/tests/integration/features/plans/session/stream-session-test-helpers.ts
@@ -1,10 +1,19 @@
 import type { PlanLifecycleService } from '@/features/plans/lifecycle/service';
 import type {
-  CreatePlanResult,
+  CreatePlanSuccess,
   GenerationAttemptResult,
   ProcessGenerationInput,
 } from '@/features/plans/lifecycle/types';
+import type {
+  RespondCreateStreamArgs,
+  RespondRetryStreamArgs,
+  RetryPlanGenerationPlanSnapshot,
+} from '@/features/plans/session/plan-generation-session';
+import type { CreateLearningPlanInput } from '@/features/plans/validation/learningPlans.types';
 import type { AttemptReservation } from '@/lib/db/queries/types/attempts.types';
+import { ensureUser } from '@tests/helpers/db/users';
+import { buildTestAuthUserId, buildTestEmail } from '@tests/helpers/testIds';
+import { db } from '@supabase/service-role';
 import { vi } from 'vitest';
 
 export interface MockProcessLifecycleHandle {
@@ -14,6 +23,158 @@ export interface MockProcessLifecycleHandle {
 
 export interface MockCreateLifecycleHandle extends MockProcessLifecycleHandle {
   createPlan: ReturnType<typeof vi.fn>;
+}
+
+export const SUCCESS_CREATE_RESULT: CreatePlanSuccess = {
+  status: 'success',
+  planId: 'plan_boundary_create_success',
+  tier: 'pro',
+  normalizedInput: {
+    topic: 'Boundary Topic',
+    skillLevel: 'beginner',
+    weeklyHours: 5,
+    learningStyle: 'mixed',
+    startDate: null,
+    deadlineDate: '2030-01-01',
+  },
+};
+
+export const SUCCESS_CREATE_ATTEMPT_RESULT: GenerationAttemptResult = {
+  status: 'generation_success',
+  data: {
+    modules: [
+      {
+        title: 'Boundary Module',
+        estimatedMinutes: 60,
+        tasks: [{ title: 'Boundary Task', estimatedMinutes: 30 }],
+      },
+    ],
+    metadata: {
+      provider: 'mock',
+      model: 'mock-model',
+      usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+    },
+    durationMs: 5,
+  },
+};
+
+export const SUCCESS_RETRY_ATTEMPT_RESULT: GenerationAttemptResult = {
+  status: 'generation_success',
+  data: {
+    modules: [
+      {
+        title: 'Retry Module',
+        estimatedMinutes: 90,
+        tasks: [
+          { title: 'Retry Task A', estimatedMinutes: 30 },
+          { title: 'Retry Task B', estimatedMinutes: 60 },
+        ],
+      },
+    ],
+    metadata: {
+      provider: 'mock',
+      model: 'mock-model',
+      usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+    },
+    durationMs: 5,
+  },
+};
+
+export const BASE_CREATE_BODY: CreateLearningPlanInput = {
+  topic: 'Boundary Topic',
+  skillLevel: 'beginner',
+  weeklyHours: 5,
+  learningStyle: 'mixed',
+  notes: undefined,
+  startDate: undefined,
+  deadlineDate: '2030-01-01',
+  visibility: 'private',
+  origin: 'ai',
+};
+
+export const BASE_RETRY_PLAN_SNAPSHOT: RetryPlanGenerationPlanSnapshot = {
+  topic: 'Retry Topic',
+  skillLevel: 'intermediate',
+  weeklyHours: 6,
+  learningStyle: 'mixed',
+  startDate: '2030-01-01',
+  deadlineDate: '2030-06-01',
+  origin: 'ai',
+};
+
+export function buildCreateStreamRequest(
+  overrides: { signal?: AbortSignal; url?: string } = {},
+): Request {
+  return new Request(overrides.url ?? 'http://localhost/api/v1/plans/stream', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(BASE_CREATE_BODY),
+    ...(overrides.signal ? { signal: overrides.signal } : {}),
+  });
+}
+
+export function buildRetryStreamRequest(
+  planId: string,
+  signal?: AbortSignal,
+): Request {
+  return new Request(`http://localhost/api/v1/plans/${planId}/retry`, {
+    method: 'POST',
+    ...(signal ? { signal } : {}),
+  });
+}
+
+export function buildCreateStreamArgs(
+  args: Partial<RespondCreateStreamArgs> & {
+    req: Request;
+    authUserId: string;
+  },
+): RespondCreateStreamArgs {
+  return {
+    internalUserId: 'internal-user-id',
+    body: { ...BASE_CREATE_BODY },
+    savedPreferredAiModel: null,
+    ...args,
+  };
+}
+
+export interface BuildRetryStreamArgsInput {
+  req: Request;
+  authUserId: string;
+  internalUserId: string;
+  planId?: string;
+  plan?: RetryPlanGenerationPlanSnapshot;
+  responseHeaders?: HeadersInit;
+  requestId?: string;
+}
+
+export function buildRetryStreamArgs(
+  input: BuildRetryStreamArgsInput,
+): RespondRetryStreamArgs {
+  return {
+    req: input.req,
+    authUserId: input.authUserId,
+    internalUserId: input.internalUserId,
+    planId: input.planId ?? 'plan_boundary_retry',
+    plan: input.plan ?? { ...BASE_RETRY_PLAN_SNAPSHOT },
+    tierDb: db,
+    ...(input.responseHeaders
+      ? { responseHeaders: input.responseHeaders }
+      : {}),
+    ...(input.requestId !== undefined ? { requestId: input.requestId } : {}),
+  };
+}
+
+export async function setupPlanSessionUser(scenario: string): Promise<{
+  authUserId: string;
+  internalUserId: string;
+}> {
+  const authUserId = buildTestAuthUserId(scenario);
+  const internalUserId = await ensureUser({
+    authUserId,
+    email: buildTestEmail(authUserId),
+    subscriptionTier: 'pro',
+  });
+  return { authUserId, internalUserId };
 }
 
 export function fakeAttemptReservation(
@@ -67,7 +228,7 @@ export function buildMockCreateLifecycle({
   reserveAttemptNumber = 1,
   topic = 'Boundary Topic',
 }: {
-  createResult: CreatePlanResult;
+  createResult: CreatePlanSuccess;
   process: (input: ProcessGenerationInput) => Promise<GenerationAttemptResult>;
   reserveAttemptNumber?: number;
   topic?: string;

--- a/tests/integration/rls/attempts-visibility.spec.ts
+++ b/tests/integration/rls/attempts-visibility.spec.ts
@@ -2,6 +2,7 @@ import { GET as GET_ATTEMPTS } from '@/app/api/v1/plans/[planId]/attempts/route'
 import { generationAttempts, learningPlans } from '@supabase/schema';
 import { describe, expect, it } from 'vitest';
 import { db } from '@supabase/service-role';
+import { buildRouteHandlerContext } from '@tests/helpers/route-handler-context';
 import { setTestUser } from '../../helpers/auth';
 import { ensureUser } from '../../helpers/db/users';
 
@@ -58,6 +59,7 @@ describe('RLS attempt visibility', () => {
     setTestUser(owner.authUserId);
     const ownerResp = await GET_ATTEMPTS(
       new Request(`http://localhost/api/v1/plans/${owner.planId}/attempts`),
+      buildRouteHandlerContext({ planId: owner.planId }),
     );
     expect(ownerResp.status).toBe(200);
     const ownerPayload = await ownerResp.json();
@@ -73,6 +75,7 @@ describe('RLS attempt visibility', () => {
 
     const otherResp = await GET_ATTEMPTS(
       new Request(`http://localhost/api/v1/plans/${owner.planId}/attempts`),
+      buildRouteHandlerContext({ planId: owner.planId }),
     );
     // RLS should cause 404 (plan not found in authorized scope)
     expect(otherResp.status).toBe(404);

--- a/tests/security/rls-test-helpers.ts
+++ b/tests/security/rls-test-helpers.ts
@@ -1,3 +1,4 @@
+import { AUTHENTICATED_SERVER_OWNED_WRITE_TABLES } from '@supabase/privileges/authenticated-table-privileges';
 import { z } from 'zod';
 
 export const policyRowSchema = z.object({
@@ -21,17 +22,8 @@ export const expectedPolicyTables = [
   'ai_usage_events',
 ] as const;
 
-export const serverOwnedWriteTables = [
-  'ai_usage_events',
-  'generation_attempts',
-  'learning_plans',
-  'modules',
-  'plan_schedules',
-  'resources',
-  'task_resources',
-  'tasks',
-  'usage_metrics',
-] as const;
+/** Re-exported from supabase/privileges — keep in sync via drift unit test. */
+export const serverOwnedWriteTables = AUTHENTICATED_SERVER_OWNED_WRITE_TABLES;
 
 export async function expectRlsViolation(operation: () => Promise<unknown>) {
   try {

--- a/tests/security/rls.policies.spec.ts
+++ b/tests/security/rls.policies.spec.ts
@@ -21,9 +21,11 @@ import {
   generationAttempts,
   learningPlans,
   modules,
+  planSchedules,
   resources,
   usageMetrics,
   taskProgress,
+  taskResources,
   tasks,
   users,
 } from '@supabase/schema';
@@ -46,7 +48,7 @@ import {
 } from './rls-test-helpers';
 
 // Coverage gap (not functionally exercised in this suite yet):
-// plan_schedules, plan_generations, task_resources, oauth_state_tokens.
+// plan_generations, oauth_state_tokens.
 
 describe('RLS Policy Verification', () => {
   beforeEach(async () => {
@@ -636,6 +638,102 @@ describe('RLS Policy Verification', () => {
         regenerationsUsed: 3,
         lessonModulesGenerated: 4,
       });
+    });
+
+    it('authenticated users cannot directly write plan schedule cache rows', async () => {
+      const [user] = await db
+        .insert(users)
+        .values({
+          authUserId: 'plan_schedules_guard',
+          email: 'plan-schedules-guard@test.com',
+        })
+        .returning();
+
+      const [plan] = await db
+        .insert(learningPlans)
+        .values({
+          userId: user.id,
+          topic: 'Schedule Plan',
+          skillLevel: 'beginner',
+          weeklyHours: 5,
+          learningStyle: 'practice',
+          visibility: 'private',
+        })
+        .returning();
+
+      const authDb = await createRlsDbForUser('plan_schedules_guard');
+
+      await expectRlsViolation(() =>
+        authDb.insert(planSchedules).values({
+          planId: plan.id,
+          scheduleJson: { weeks: [] },
+          inputsHash: 'forged-hash',
+          timezone: 'UTC',
+          weeklyHours: 5,
+          startDate: '2026-05-01',
+        }),
+      );
+    });
+
+    it('authenticated users cannot directly write task resource links', async () => {
+      const [user] = await db
+        .insert(users)
+        .values({
+          authUserId: 'task_resources_guard',
+          email: 'task-resources-guard@test.com',
+        })
+        .returning();
+
+      const [plan] = await db
+        .insert(learningPlans)
+        .values({
+          userId: user.id,
+          topic: 'Task Resources Plan',
+          skillLevel: 'beginner',
+          weeklyHours: 5,
+          learningStyle: 'practice',
+          visibility: 'private',
+        })
+        .returning();
+
+      const [module] = await db
+        .insert(modules)
+        .values({
+          planId: plan.id,
+          order: 1,
+          title: 'Module 1',
+          estimatedMinutes: 60,
+        })
+        .returning();
+
+      const [task] = await db
+        .insert(tasks)
+        .values({
+          moduleId: module.id,
+          order: 1,
+          title: 'Task 1',
+          estimatedMinutes: 30,
+        })
+        .returning();
+
+      const [resource] = await db
+        .insert(resources)
+        .values({
+          type: 'article',
+          title: 'Linked Resource',
+          url: `https://example.com/article-${Date.now()}`,
+        })
+        .returning();
+
+      const authDb = await createRlsDbForUser('task_resources_guard');
+
+      await expectRlsViolation(() =>
+        authDb.insert(taskResources).values({
+          taskId: task.id,
+          resourceId: resource.id,
+          order: 1,
+        }),
+      );
     });
 
     it('authenticated users cannot directly write AI usage event audit rows', async () => {

--- a/tests/unit/helpers/db/server-owned-write-privilege-bootstrap-sync.spec.ts
+++ b/tests/unit/helpers/db/server-owned-write-privilege-bootstrap-sync.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Intentional readFileSync: ensure bootstrap, RLS bootstrap, migration, and
+ * security helpers all reference the same server-owned write revoke list.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { AUTHENTICATED_SERVER_OWNED_WRITE_TABLES } from '@supabase/privileges/authenticated-table-privileges';
+import { describe, expect, it } from 'vitest';
+
+import { serverOwnedWriteTables } from '../../../security/rls-test-helpers';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(TEST_DIR, '../../../../');
+
+describe('server-owned write privilege bootstrap sync', () => {
+  it('security helpers re-export AUTHENTICATED_SERVER_OWNED_WRITE_TABLES', () => {
+    expect([...serverOwnedWriteTables]).toEqual([
+      ...AUTHENTICATED_SERVER_OWNED_WRITE_TABLES,
+    ]);
+  });
+
+  it('migration, bootstrap, and rls-bootstrap revoke every server-owned table', () => {
+    const migration = readFileSync(
+      resolve(
+        REPO_ROOT,
+        'supabase/migrations/20260520194501_harden_authenticated_server_owned_writes.sql',
+      ),
+      'utf8',
+    );
+    const bootstrap = readFileSync(
+      resolve(TEST_DIR, '../../../helpers/db/bootstrap.ts'),
+      'utf8',
+    );
+    const rlsBootstrap = readFileSync(
+      resolve(TEST_DIR, '../../../helpers/db/rls-bootstrap.ts'),
+      'utf8',
+    );
+
+    const migrationRevokeBlock =
+      /REVOKE INSERT, UPDATE, DELETE ON[\s\S]+FROM authenticated;/;
+    expect(migration).toMatch(migrationRevokeBlock);
+
+    for (const table of AUTHENTICATED_SERVER_OWNED_WRITE_TABLES) {
+      expect(migration).toContain(`"${table}"`);
+    }
+
+    expect(bootstrap).toContain('AUTHENTICATED_SERVER_OWNED_WRITE_TABLES');
+    expect(bootstrap).toMatch(
+      /REVOKE INSERT, UPDATE, DELETE ON \$\{serverOwnedTablesSql\} FROM authenticated/,
+    );
+    expect(rlsBootstrap).toContain(
+      'AUTHENTICATED_SERVER_OWNED_WRITE_TABLES_SQL',
+    );
+    expect(rlsBootstrap).toMatch(
+      /REVOKE INSERT, UPDATE, DELETE ON[\s\S]*AUTHENTICATED_SERVER_OWNED_WRITE_TABLES_SQL[\s\S]*FROM authenticated/,
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reconciles stale comments and helper defaults with the privilege-first server-owned write boundary introduced in `20260520194501_harden_authenticated_server_owned_writes.sql`.

## Changes

- **Contract docs:** `supabase/service-role.ts`, plan lifecycle factory, orchestrator error text, attempts persistence comments, and stream cleanup guidance now describe reads via request-scoped RLS and server-owned mutations via feature-owned `serviceRoleDb` boundaries—not direct route-level service role or authenticated writes to generation tables.
- **Safer defaults:** `recordUsage()` and `deletePlan()` default to `serviceRoleDb` so standalone callers cannot accidentally use revoked authenticated write privileges.
- **Tests:** Security helpers re-export `AUTHENTICATED_SERVER_OWNED_WRITE_TABLES`; added negative authenticated-write tests for `plan_schedules` and `task_resources`; added bootstrap/migration drift unit spec.

## Validation

- `pnpm vitest run tests/unit/helpers/db/server-owned-write-privilege-bootstrap-sync.spec.ts`
- `pnpm vitest run --project security tests/security/rls.policies.spec.ts` (30 passed)
- `pnpm vitest run --project integration tests/integration/db/usage.spec.ts` (5 passed)
- `pnpm check:full`
- `git diff --check`

## Notes

- `createStreamDbClient` is already absent from the tree; no deletion needed.
- Production write paths audited: plan generation, regeneration, lesson generation, billing meters, schedule cache, and plan deletion already route server-owned writes through `serviceRoleDb`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8dc1f79-47f8-46e4-8db6-6b0f73282fd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8dc1f79-47f8-46e4-8db6-6b0f73282fd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

