### PR TITLE
test: extract shared plan/session streaming helpers

### DIFF
--- a/tests/helpers/streaming.ts
+++ b/tests/helpers/streaming.ts
@@ -5,6 +5,8 @@
  * streaming responses in integration tests.
  */
 
+import { expect } from 'vitest';
+
 /**
  * Type for parsed streaming events
  */
@@ -116,4 +118,57 @@ export async function readStreamingResponse(
 
   const buffer = await readStreamBodyIntoBuffer(reader);
   return parseSseBufferToEvents(buffer);
+}
+
+export function expectStreamingJsonObject(
+  value: unknown,
+): Record<string, unknown> {
+  expect(value).toBeTypeOf('object');
+  expect(value).not.toBeNull();
+  return value as Record<string, unknown>;
+}
+
+export function expectPlanStartEvent(
+  events: StreamingEvent[],
+  expectedAttemptNumber: number,
+): { planId: string } {
+  const startEvent = events.find((event) => event.type === 'plan_start');
+  if (!startEvent) {
+    throw new Error('Expected plan_start event');
+  }
+
+  const startData = expectStreamingJsonObject(startEvent.data);
+  expect(startData.planId).toEqual(expect.any(String));
+  expect(startData.attemptNumber).toBe(expectedAttemptNumber);
+
+  const planId = startData.planId;
+  if (typeof planId !== 'string' || planId.length === 0) {
+    throw new Error('Expected plan_start event to include a planId');
+  }
+
+  return { planId };
+}
+
+export function expectTerminalEventAfterStart(
+  events: StreamingEvent[],
+  terminalType: 'complete' | 'error' | 'cancelled',
+): StreamingEvent {
+  const eventTypes = events.map((event) => event.type);
+  const startIndex = eventTypes.indexOf('plan_start');
+  const terminalIndex = eventTypes.indexOf(terminalType);
+
+  expect(startIndex).toBeGreaterThanOrEqual(0);
+  expect(terminalIndex).toBeGreaterThan(startIndex);
+  expect(
+    eventTypes
+      .slice(0, terminalIndex)
+      .filter((type) => ['complete', 'error', 'cancelled'].includes(type)),
+  ).toEqual([]);
+
+  const terminalEvent = events[terminalIndex];
+  if (!terminalEvent) {
+    throw new Error(`Expected ${terminalType} event`);
+  }
+
+  return terminalEvent;
 }

--- a/tests/integration/api/plans-retry.spec.ts
+++ b/tests/integration/api/plans-retry.spec.ts
@@ -9,7 +9,6 @@ import { seedFailedAttemptsForDurableWindow } from '../../fixtures/attempts';
 import { createPlanForRetryTest } from '../../fixtures/plans';
 import { setTestUser } from '../../helpers/auth';
 import { ensureUser } from '../../helpers/db/users';
-import { buildRouteHandlerContext } from '@tests/helpers/route-handler-context';
 import {
   expectPlanStartEvent,
   expectStreamingJsonObject,
@@ -67,7 +66,7 @@ function createRetryInvocation(planId: string) {
     request: new Request(`http://localhost/api/v1/plans/${planId}/retry`, {
       method: 'POST',
     }),
-    context: buildRouteHandlerContext({ planId }),
+    context: { params: Promise.resolve({ planId }) },
   };
 }
 
@@ -158,10 +157,11 @@ describe('POST /api/v1/plans/:planId/retry — HTTP preflight + default boundary
       },
     });
 
-    const invocation = createRetryInvocation(plan.id);
+    const invocationA = createRetryInvocation(plan.id);
+    const invocationB = createRetryInvocation(plan.id);
     const [resA, resB] = await Promise.all([
-      POST(invocation.request, invocation.context),
-      POST(invocation.request, invocation.context),
+      POST(invocationA.request, invocationA.context),
+      POST(invocationB.request, invocationB.context),
     ]);
 
     if (resA.status === 200 && resB.status === 200) {

--- a/tests/integration/api/plans-retry.spec.ts
+++ b/tests/integration/api/plans-retry.spec.ts
@@ -9,7 +9,13 @@ import { seedFailedAttemptsForDurableWindow } from '../../fixtures/attempts';
 import { createPlanForRetryTest } from '../../fixtures/plans';
 import { setTestUser } from '../../helpers/auth';
 import { ensureUser } from '../../helpers/db/users';
-import { readStreamingResponse } from '../../helpers/streaming';
+import { buildRouteHandlerContext } from '@tests/helpers/route-handler-context';
+import {
+  expectPlanStartEvent,
+  expectStreamingJsonObject,
+  expectTerminalEventAfterStart,
+  readStreamingResponse,
+} from '../../helpers/streaming';
 
 type RetryAttemptOverrides = Partial<
   Omit<typeof generationAttempts.$inferInsert, 'planId'>
@@ -56,61 +62,13 @@ async function withRunGenerationAttemptSpy<T>(
   }
 }
 
-function createRetryRequest(planId: string): Request {
-  return new Request(`http://localhost/api/v1/plans/${planId}/retry`, {
-    method: 'POST',
-  });
-}
-
-function expectJsonObject(value: unknown): Record<string, unknown> {
-  expect(value).toBeTypeOf('object');
-  expect(value).not.toBeNull();
-  return value as Record<string, unknown>;
-}
-
-function expectPlanStartEvent(
-  events: Awaited<ReturnType<typeof readStreamingResponse>>,
-  expectedAttemptNumber: number,
-): { planId: string } {
-  const startEvent = events.find((event) => event.type === 'plan_start');
-  if (!startEvent) {
-    throw new Error('Expected plan_start event');
-  }
-
-  const startData = expectJsonObject(startEvent.data);
-  expect(startData.planId).toEqual(expect.any(String));
-  expect(startData.attemptNumber).toBe(expectedAttemptNumber);
-
-  const planId = startData.planId;
-  if (typeof planId !== 'string' || planId.length === 0) {
-    throw new Error('Expected plan_start event to include a planId');
-  }
-
-  return { planId };
-}
-
-function expectTerminalEventAfterStart(
-  events: Awaited<ReturnType<typeof readStreamingResponse>>,
-  terminalType: 'complete' | 'error' | 'cancelled',
-) {
-  const eventTypes = events.map((event) => event.type);
-  const startIndex = eventTypes.indexOf('plan_start');
-  const terminalIndex = eventTypes.indexOf(terminalType);
-
-  expect(startIndex).toBeGreaterThanOrEqual(0);
-  expect(terminalIndex).toBeGreaterThan(startIndex);
-  expect(
-    eventTypes
-      .slice(0, terminalIndex)
-      .filter((type) => ['complete', 'error', 'cancelled'].includes(type)),
-  ).toEqual([]);
-
-  const terminalEvent = events[terminalIndex];
-  if (!terminalEvent) {
-    throw new Error(`Expected ${terminalType} event`);
-  }
-
-  return terminalEvent;
+function createRetryInvocation(planId: string) {
+  return {
+    request: new Request(`http://localhost/api/v1/plans/${planId}/retry`, {
+      method: 'POST',
+    }),
+    context: buildRouteHandlerContext({ planId }),
+  };
 }
 
 async function listAttempts(planId: string) {
@@ -153,13 +111,14 @@ describe('POST /api/v1/plans/:planId/retry — HTTP preflight + default boundary
       },
     });
 
-    const response = await POST(createRetryRequest(plan.id));
+    const { request, context } = createRetryInvocation(plan.id);
+    const response = await POST(request, context);
     expect(response.status).toBe(200);
 
     const events = await readStreamingResponse(response);
     const { planId } = expectPlanStartEvent(events, 2);
     const completeEvent = expectTerminalEventAfterStart(events, 'complete');
-    expect(expectJsonObject(completeEvent.data).planId).toBe(planId);
+    expect(expectStreamingJsonObject(completeEvent.data).planId).toBe(planId);
 
     const attempts = await listAttempts(plan.id);
     const [persistedPlan] = await db
@@ -199,9 +158,10 @@ describe('POST /api/v1/plans/:planId/retry — HTTP preflight + default boundary
       },
     });
 
+    const invocation = createRetryInvocation(plan.id);
     const [resA, resB] = await Promise.all([
-      POST(createRetryRequest(plan.id)),
-      POST(createRetryRequest(plan.id)),
+      POST(invocation.request, invocation.context),
+      POST(invocation.request, invocation.context),
     ]);
 
     if (resA.status === 200 && resB.status === 200) {
@@ -254,8 +214,8 @@ describe('POST /api/v1/plans/:planId/retry — HTTP preflight + default boundary
     await seedFailedAttemptsForDurableWindow(plan.id);
 
     await withRunGenerationAttemptSpy(async (runSpy) => {
-      const request = createRetryRequest(plan.id);
-      const response = await POST(request);
+      const { request, context } = createRetryInvocation(plan.id);
+      const response = await POST(request, context);
       expect(response.status).toBe(429);
       expect(response.headers.get('X-RateLimit-Remaining')).toBe('0');
 
@@ -286,7 +246,8 @@ describe('POST /api/v1/plans/:planId/retry — HTTP preflight + default boundary
     });
 
     await withRunGenerationAttemptSpy(async (runSpy) => {
-      const response = await POST(createRetryRequest(plan.id));
+      const { request, context } = createRetryInvocation(plan.id);
+      const response = await POST(request, context);
       expect(response.status).toBe(400);
       const body = (await response.json()) as { error?: string; code?: string };
       expect(body.code).toBe('VALIDATION_ERROR');

--- a/tests/integration/api/plans-stream.spec.ts
+++ b/tests/integration/api/plans-stream.spec.ts
@@ -8,6 +8,9 @@ import { db } from '@supabase/service-role';
 import { setTestUser } from '../../helpers/auth';
 import { ensureUser } from '../../helpers/db/users';
 import {
+  expectPlanStartEvent,
+  expectStreamingJsonObject,
+  expectTerminalEventAfterStart,
   readStreamingResponse,
   type StreamingEvent,
 } from '../../helpers/streaming';
@@ -30,18 +33,12 @@ function assertNumericHeader(response: Response, name: string): void {
   );
 }
 
-function expectJsonObject(value: unknown): Record<string, unknown> {
-  expect(value).toBeTypeOf('object');
-  expect(value).not.toBeNull();
-  return value as Record<string, unknown>;
-}
-
 async function expectCompletedPlanId(
   events: StreamingEvent[],
 ): Promise<string> {
   const start = expectPlanStartEvent(events, 1);
   const completeEvent = expectTerminalEventAfterStart(events, 'complete');
-  const completeData = expectJsonObject(completeEvent.data);
+  const completeData = expectStreamingJsonObject(completeEvent.data);
   expect(completeData.planId).toBe(start.planId);
   await expect(getPlanGenerationStatus(start.planId)).resolves.toBe('ready');
   await expect(listAttempts(start.planId)).resolves.toMatchObject([
@@ -51,51 +48,6 @@ async function expectCompletedPlanId(
     },
   ]);
   return start.planId;
-}
-
-function expectPlanStartEvent(
-  events: StreamingEvent[],
-  expectedAttemptNumber: number,
-): { planId: string } {
-  const startEvent = events.find((event) => event.type === 'plan_start');
-  if (!startEvent) {
-    throw new Error('Expected plan_start event');
-  }
-
-  const startData = expectJsonObject(startEvent.data);
-  expect(startData.planId).toEqual(expect.any(String));
-  expect(startData.attemptNumber).toBe(expectedAttemptNumber);
-
-  const planId = startData.planId;
-  if (typeof planId !== 'string' || planId.length === 0) {
-    throw new Error('Expected plan_start event to include a planId');
-  }
-
-  return { planId };
-}
-
-function expectTerminalEventAfterStart(
-  events: StreamingEvent[],
-  terminalType: 'complete' | 'error' | 'cancelled',
-): StreamingEvent {
-  const eventTypes = events.map((event) => event.type);
-  const startIndex = eventTypes.indexOf('plan_start');
-  const terminalIndex = eventTypes.indexOf(terminalType);
-
-  expect(startIndex).toBeGreaterThanOrEqual(0);
-  expect(terminalIndex).toBeGreaterThan(startIndex);
-  expect(
-    eventTypes
-      .slice(0, terminalIndex)
-      .filter((type) => ['complete', 'error', 'cancelled'].includes(type)),
-  ).toEqual([]);
-
-  const terminalEvent = events[terminalIndex];
-  if (!terminalEvent) {
-    throw new Error(`Expected ${terminalType} event`);
-  }
-
-  return terminalEvent;
 }
 
 async function listAttempts(planId: string) {
@@ -151,7 +103,7 @@ describe('POST /api/v1/plans/stream — HTTP preflight + default boundary smoke'
 
     const response = await POST(request);
     expect(response.status).toBe(400);
-    const body = expectJsonObject(await response.json());
+    const body = expectStreamingJsonObject(await response.json());
     expect(body.error).toBe('Invalid request body.');
     expect(body.details).toEqual({
       reason: 'Malformed or invalid JSON payload.',

--- a/tests/integration/features/plans/session/respond-create-stream.spec.ts
+++ b/tests/integration/features/plans/session/respond-create-stream.spec.ts
@@ -9,15 +9,16 @@ import { buildTestAuthUserId } from '@tests/helpers/testIds';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { PlanLifecycleService } from '@/features/plans/lifecycle/service';
-import type {
-  CreatePlanResult,
-  GenerationAttemptResult,
-  ProcessGenerationInput,
-} from '@/features/plans/lifecycle/types';
-import type { RespondCreateStreamArgs } from '@/features/plans/session/plan-generation-session';
-import type { CreateLearningPlanInput } from '@/features/plans/validation/learningPlans.types';
+import type { ProcessGenerationInput } from '@/features/plans/lifecycle/types';
 import type { AttemptsDbClient } from '@/lib/db/queries/types/attempts.types';
-import { buildMockCreateLifecycle } from './stream-session-test-helpers';
+import {
+  BASE_CREATE_BODY,
+  buildCreateStreamArgs,
+  buildCreateStreamRequest,
+  buildMockCreateLifecycle,
+  SUCCESS_CREATE_ATTEMPT_RESULT,
+  SUCCESS_CREATE_RESULT,
+} from './stream-session-test-helpers';
 
 const VALID_PRO_MODEL = AVAILABLE_MODELS.find(({ tier }) => tier === 'pro')?.id;
 
@@ -25,78 +26,11 @@ if (!VALID_PRO_MODEL) {
   throw new Error('Expected at least one pro-tier model fixture');
 }
 
-const SUCCESS_CREATE_RESULT: CreatePlanResult = {
-  status: 'success',
-  planId: 'plan_boundary_create_success',
-  tier: 'pro',
-  normalizedInput: {
-    topic: 'Boundary Topic',
-    skillLevel: 'beginner',
-    weeklyHours: 5,
-    learningStyle: 'mixed',
-    startDate: null,
-    deadlineDate: '2030-01-01',
-  },
-};
-
-const SUCCESS_ATTEMPT_RESULT: GenerationAttemptResult = {
-  status: 'generation_success',
-  data: {
-    modules: [
-      {
-        title: 'Boundary Module',
-        estimatedMinutes: 60,
-        tasks: [{ title: 'Boundary Task', estimatedMinutes: 30 }],
-      },
-    ],
-    metadata: {
-      provider: 'mock',
-      model: 'mock-model',
-      usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
-    },
-    durationMs: 5,
-  },
-};
-
-const BASE_BODY: CreateLearningPlanInput = {
-  topic: 'Boundary Topic',
-  skillLevel: 'beginner',
-  weeklyHours: 5,
-  learningStyle: 'mixed',
-  notes: undefined,
-  startDate: undefined,
-  deadlineDate: '2030-01-01',
-  visibility: 'private',
-  origin: 'ai',
-};
-
-function buildCreateRequest(
-  overrides: { signal?: AbortSignal; url?: string } = {},
-): Request {
-  return new Request(overrides.url ?? 'http://localhost/api/v1/plans/stream', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(BASE_BODY),
-    ...(overrides.signal ? { signal: overrides.signal } : {}),
-  });
-}
-
-function buildArgs(
-  args: Partial<RespondCreateStreamArgs> & { req: Request; authUserId: string },
-): RespondCreateStreamArgs {
-  return {
-    internalUserId: 'internal-user-id',
-    body: { ...BASE_BODY },
-    savedPreferredAiModel: null,
-    ...args,
-  };
-}
-
 describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
   it('emits plan_start, module_summary, progress, then complete on success', async () => {
     const fake = buildMockCreateLifecycle({
       createResult: SUCCESS_CREATE_RESULT,
-      process: async () => SUCCESS_ATTEMPT_RESULT,
+      process: async () => SUCCESS_CREATE_ATTEMPT_RESULT,
     });
     const createLifecycleService = vi.fn(() => fake.service);
     const boundary = createPlanGenerationSessionBoundary({
@@ -104,10 +38,10 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
     });
 
     const authUserId = buildTestAuthUserId('boundary-create-success');
-    const req = buildCreateRequest();
+    const req = buildCreateStreamRequest();
 
     const response = await boundary.respondCreateStream(
-      buildArgs({ req, authUserId }),
+      buildCreateStreamArgs({ req, authUserId }),
     );
 
     expect(response.status).toBe(200);
@@ -128,7 +62,7 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
     expect(planStart?.data).toMatchObject({
       planId: SUCCESS_CREATE_RESULT.planId,
       attemptNumber: 1,
-      topic: 'Boundary Topic',
+      topic: BASE_CREATE_BODY.topic,
     });
 
     const complete = findStreamingEvent(events, 'complete');
@@ -156,10 +90,10 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
     });
 
     const authUserId = buildTestAuthUserId('boundary-create-retryable');
-    const req = buildCreateRequest();
+    const req = buildCreateStreamRequest();
 
     const response = await boundary.respondCreateStream(
-      buildArgs({ req, authUserId }),
+      buildCreateStreamArgs({ req, authUserId }),
     );
 
     expect(response.status).toBe(200);
@@ -197,10 +131,10 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
     });
 
     const authUserId = buildTestAuthUserId('boundary-create-reqid');
-    const req = buildCreateRequest();
+    const req = buildCreateStreamRequest();
 
     const response = await boundary.respondCreateStream(
-      buildArgs({
+      buildCreateStreamArgs({
         req,
         authUserId,
         requestId: 'corr-boundary-create-1',
@@ -229,10 +163,10 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
     });
 
     const authUserId = buildTestAuthUserId('boundary-create-permanent');
-    const req = buildCreateRequest();
+    const req = buildCreateStreamRequest();
 
     const response = await boundary.respondCreateStream(
-      buildArgs({ req, authUserId }),
+      buildCreateStreamArgs({ req, authUserId }),
     );
 
     const events = await readStreamingResponse(response);
@@ -260,10 +194,10 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
     });
 
     const authUserId = buildTestAuthUserId('boundary-create-unhandled');
-    const req = buildCreateRequest();
+    const req = buildCreateStreamRequest();
 
     const response = await boundary.respondCreateStream(
-      buildArgs({
+      buildCreateStreamArgs({
         req,
         authUserId,
         requestId: 'corr-boundary-create-unhandled',
@@ -302,10 +236,10 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
     });
 
     const authUserId = buildTestAuthUserId('boundary-create-disconnect');
-    const req = buildCreateRequest({ signal: controller.signal });
+    const req = buildCreateStreamRequest({ signal: controller.signal });
 
     const response = await boundary.respondCreateStream(
-      buildArgs({ req, authUserId }),
+      buildCreateStreamArgs({ req, authUserId }),
     );
 
     expect(response.status).toBe(200);
@@ -319,17 +253,17 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
   it('passes responseHeaders through to the streaming Response', async () => {
     const fake = buildMockCreateLifecycle({
       createResult: SUCCESS_CREATE_RESULT,
-      process: async () => SUCCESS_ATTEMPT_RESULT,
+      process: async () => SUCCESS_CREATE_ATTEMPT_RESULT,
     });
     const boundary = createPlanGenerationSessionBoundary({
       createLifecycleService: () => fake.service,
     });
 
     const authUserId = buildTestAuthUserId('boundary-create-headers');
-    const req = buildCreateRequest();
+    const req = buildCreateStreamRequest();
 
     const response = await boundary.respondCreateStream(
-      buildArgs({
+      buildCreateStreamArgs({
         req,
         authUserId,
         responseHeaders: {
@@ -352,7 +286,7 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
       createResult: SUCCESS_CREATE_RESULT,
       process: async (input) => {
         captured.push(input);
-        return SUCCESS_ATTEMPT_RESULT;
+        return SUCCESS_CREATE_ATTEMPT_RESULT;
       },
     });
     const boundary = createPlanGenerationSessionBoundary({
@@ -360,12 +294,12 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
     });
 
     const authUserId = buildTestAuthUserId('boundary-create-model-invalid');
-    const req = buildCreateRequest({
+    const req = buildCreateStreamRequest({
       url: 'http://localhost/api/v1/plans/stream?model=invalid/model-id',
     });
 
     const response = await boundary.respondCreateStream(
-      buildArgs({
+      buildCreateStreamArgs({
         req,
         authUserId,
         savedPreferredAiModel: null,
@@ -385,7 +319,7 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
       createResult: SUCCESS_CREATE_RESULT,
       process: async (input) => {
         captured.push(input);
-        return SUCCESS_ATTEMPT_RESULT;
+        return SUCCESS_CREATE_ATTEMPT_RESULT;
       },
     });
     const boundary = createPlanGenerationSessionBoundary({
@@ -393,12 +327,12 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
     });
 
     const authUserId = buildTestAuthUserId('boundary-create-model-valid');
-    const req = buildCreateRequest({
+    const req = buildCreateStreamRequest({
       url: `http://localhost/api/v1/plans/stream?model=${encodeURIComponent(VALID_PRO_MODEL)}`,
     });
 
     const response = await boundary.respondCreateStream(
-      buildArgs({
+      buildCreateStreamArgs({
         req,
         authUserId,
         savedPreferredAiModel: null,
@@ -417,7 +351,7 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
       createResult: SUCCESS_CREATE_RESULT,
       process: async (input) => {
         captured.push(input);
-        return SUCCESS_ATTEMPT_RESULT;
+        return SUCCESS_CREATE_ATTEMPT_RESULT;
       },
     });
     const boundary = createPlanGenerationSessionBoundary({
@@ -425,10 +359,10 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
     });
 
     const authUserId = buildTestAuthUserId('boundary-create-saved-pref');
-    const req = buildCreateRequest();
+    const req = buildCreateStreamRequest();
 
     const response = await boundary.respondCreateStream(
-      buildArgs({
+      buildCreateStreamArgs({
         req,
         authUserId,
         savedPreferredAiModel: VALID_PRO_MODEL,
@@ -444,7 +378,7 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
   it('builds a fresh lifecycle service per request via the injected factory', async () => {
     const fake = buildMockCreateLifecycle({
       createResult: SUCCESS_CREATE_RESULT,
-      process: async () => SUCCESS_ATTEMPT_RESULT,
+      process: async () => SUCCESS_CREATE_ATTEMPT_RESULT,
     });
     const createLifecycleService = vi.fn<
       (db: AttemptsDbClient) => PlanLifecycleService
@@ -457,10 +391,10 @@ describe('PlanGenerationSessionBoundary.respondCreateStream', () => {
 
     const responses = await Promise.all([
       boundary.respondCreateStream(
-        buildArgs({ req: buildCreateRequest(), authUserId }),
+        buildCreateStreamArgs({ req: buildCreateStreamRequest(), authUserId }),
       ),
       boundary.respondCreateStream(
-        buildArgs({ req: buildCreateRequest(), authUserId }),
+        buildCreateStreamArgs({ req: buildCreateStreamRequest(), authUserId }),
       ),
     ]);
 

--- a/tests/integration/features/plans/session/respond-retry-stream.spec.ts
+++ b/tests/integration/features/plans/session/respond-retry-stream.spec.ts
@@ -1,121 +1,44 @@
-import type {
-  GenerationAttemptResult,
-  ProcessGenerationInput,
-} from '@/features/plans/lifecycle/types';
+import type { ProcessGenerationInput } from '@/features/plans/lifecycle/types';
 import {
   createPlanGenerationSessionBoundary,
   PLAN_RETRY_RESERVATION_ALLOWED_STATUSES,
-  type RespondRetryStreamArgs,
-  type RetryPlanGenerationPlanSnapshot,
 } from '@/features/plans/session/plan-generation-session';
 import * as streamCleanup from '@/features/plans/session/stream-cleanup';
-import { ensureUser } from '@tests/helpers/db/users';
-import {
-  buildMockProcessLifecycle,
-  type MockProcessLifecycleHandle,
-} from './stream-session-test-helpers';
 import {
   findStreamingEvent,
   readStreamingResponse,
 } from '@tests/helpers/streaming';
-import { buildTestAuthUserId, buildTestEmail } from '@tests/helpers/testIds';
 import { describe, expect, it, vi } from 'vitest';
-import { db } from '@supabase/service-role';
-
-const SUCCESS_ATTEMPT_RESULT: GenerationAttemptResult = {
-  status: 'generation_success',
-  data: {
-    modules: [
-      {
-        title: 'Retry Module',
-        estimatedMinutes: 90,
-        tasks: [
-          { title: 'Retry Task A', estimatedMinutes: 30 },
-          { title: 'Retry Task B', estimatedMinutes: 60 },
-        ],
-      },
-    ],
-    metadata: {
-      provider: 'mock',
-      model: 'mock-model',
-      usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
-    },
-    durationMs: 5,
-  },
-};
-
-const BASE_PLAN_SNAPSHOT: RetryPlanGenerationPlanSnapshot = {
-  topic: 'Retry Topic',
-  skillLevel: 'intermediate',
-  weeklyHours: 6,
-  learningStyle: 'mixed',
-  startDate: '2030-01-01',
-  deadlineDate: '2030-06-01',
-  origin: 'ai',
-};
-
-function buildRetryRequest(planId: string, signal?: AbortSignal): Request {
-  return new Request(`http://localhost/api/v1/plans/${planId}/retry`, {
-    method: 'POST',
-    ...(signal ? { signal } : {}),
-  });
-}
-
-interface BuildArgsInput {
-  req: Request;
-  authUserId: string;
-  internalUserId: string;
-  planId?: string;
-  plan?: RetryPlanGenerationPlanSnapshot;
-  responseHeaders?: HeadersInit;
-  requestId?: string;
-}
-
-function buildArgs(input: BuildArgsInput): RespondRetryStreamArgs {
-  return {
-    req: input.req,
-    authUserId: input.authUserId,
-    internalUserId: input.internalUserId,
-    planId: input.planId ?? 'plan_boundary_retry',
-    plan: input.plan ?? { ...BASE_PLAN_SNAPSHOT },
-    tierDb: db,
-    ...(input.responseHeaders
-      ? { responseHeaders: input.responseHeaders }
-      : {}),
-    ...(input.requestId !== undefined ? { requestId: input.requestId } : {}),
-  };
-}
-
-async function setupUser(scenario: string): Promise<{
-  authUserId: string;
-  internalUserId: string;
-}> {
-  const authUserId = buildTestAuthUserId(scenario);
-  const internalUserId = await ensureUser({
-    authUserId,
-    email: buildTestEmail(authUserId),
-    subscriptionTier: 'pro',
-  });
-  return { authUserId, internalUserId };
-}
+import {
+  BASE_RETRY_PLAN_SNAPSHOT,
+  buildMockProcessLifecycle,
+  buildRetryStreamArgs,
+  buildRetryStreamRequest,
+  setupPlanSessionUser,
+  SUCCESS_RETRY_ATTEMPT_RESULT,
+  type MockProcessLifecycleHandle,
+} from './stream-session-test-helpers';
 
 describe('PlanGenerationSessionBoundary.respondRetryStream', () => {
   it('emits plan_start with retry attempt number then complete on success', async () => {
-    const fake = buildMockProcessLifecycle(async () => SUCCESS_ATTEMPT_RESULT, {
-      topic: BASE_PLAN_SNAPSHOT.topic,
-    });
+    const fake = buildMockProcessLifecycle(
+      async () => SUCCESS_RETRY_ATTEMPT_RESULT,
+      {
+        topic: BASE_RETRY_PLAN_SNAPSHOT.topic,
+      },
+    );
     const createLifecycleService = vi.fn(() => fake.service);
     const boundary = createPlanGenerationSessionBoundary({
       createLifecycleService,
     });
 
-    const { authUserId, internalUserId } = await setupUser(
+    const { authUserId, internalUserId } = await setupPlanSessionUser(
       'boundary-retry-success',
     );
-    const req = buildRetryRequest('plan_retry_success');
+    const req = buildRetryStreamRequest('plan_retry_success');
 
     const response = await boundary.respondRetryStream(
-      buildArgs({
+      buildRetryStreamArgs({
         req,
         authUserId,
         internalUserId,
@@ -134,7 +57,7 @@ describe('PlanGenerationSessionBoundary.respondRetryStream', () => {
     expect(planStart?.data).toMatchObject({
       planId: 'plan_retry_success',
       attemptNumber: 2,
-      topic: BASE_PLAN_SNAPSHOT.topic,
+      topic: BASE_RETRY_PLAN_SNAPSHOT.topic,
     });
     expect(complete?.data).toMatchObject({
       planId: 'plan_retry_success',
@@ -156,13 +79,13 @@ describe('PlanGenerationSessionBoundary.respondRetryStream', () => {
       createLifecycleService: () => fake.service,
     });
 
-    const { authUserId, internalUserId } = await setupUser(
+    const { authUserId, internalUserId } = await setupPlanSessionUser(
       'boundary-retry-retryable',
     );
 
     const response = await boundary.respondRetryStream(
-      buildArgs({
-        req: buildRetryRequest('plan_retry_retryable'),
+      buildRetryStreamArgs({
+        req: buildRetryStreamRequest('plan_retry_retryable'),
         authUserId,
         internalUserId,
         planId: 'plan_retry_retryable',
@@ -192,13 +115,13 @@ describe('PlanGenerationSessionBoundary.respondRetryStream', () => {
       createLifecycleService: () => fake.service,
     });
 
-    const { authUserId, internalUserId } = await setupUser(
+    const { authUserId, internalUserId } = await setupPlanSessionUser(
       'boundary-retry-reqid',
     );
 
     const response = await boundary.respondRetryStream(
-      buildArgs({
-        req: buildRetryRequest('plan_retry_reqid'),
+      buildRetryStreamArgs({
+        req: buildRetryStreamRequest('plan_retry_reqid'),
         authUserId,
         internalUserId,
         planId: 'plan_retry_reqid',
@@ -224,13 +147,13 @@ describe('PlanGenerationSessionBoundary.respondRetryStream', () => {
       createLifecycleService: () => fake.service,
     });
 
-    const { authUserId, internalUserId } = await setupUser(
+    const { authUserId, internalUserId } = await setupPlanSessionUser(
       'boundary-retry-permanent',
     );
 
     const response = await boundary.respondRetryStream(
-      buildArgs({
-        req: buildRetryRequest('plan_retry_permanent'),
+      buildRetryStreamArgs({
+        req: buildRetryStreamRequest('plan_retry_permanent'),
         authUserId,
         internalUserId,
         planId: 'plan_retry_permanent',
@@ -255,19 +178,19 @@ describe('PlanGenerationSessionBoundary.respondRetryStream', () => {
       async () => {
         throw new Error('retry boom');
       },
-      { topic: BASE_PLAN_SNAPSHOT.topic },
+      { topic: BASE_RETRY_PLAN_SNAPSHOT.topic },
     );
     const boundary = createPlanGenerationSessionBoundary({
       createLifecycleService: () => fake.service,
     });
 
-    const { authUserId, internalUserId } = await setupUser(
+    const { authUserId, internalUserId } = await setupPlanSessionUser(
       'boundary-retry-unhandled',
     );
 
     const response = await boundary.respondRetryStream(
-      buildArgs({
-        req: buildRetryRequest('plan_retry_unhandled'),
+      buildRetryStreamArgs({
+        req: buildRetryStreamRequest('plan_retry_unhandled'),
         authUserId,
         internalUserId,
         planId: 'plan_retry_unhandled',
@@ -298,19 +221,22 @@ describe('PlanGenerationSessionBoundary.respondRetryStream', () => {
         controller.abort();
         throw new DOMException('Client disconnected', 'AbortError');
       },
-      { topic: BASE_PLAN_SNAPSHOT.topic },
+      { topic: BASE_RETRY_PLAN_SNAPSHOT.topic },
     );
     const boundary = createPlanGenerationSessionBoundary({
       createLifecycleService: () => fake.service,
     });
 
-    const { authUserId, internalUserId } = await setupUser(
+    const { authUserId, internalUserId } = await setupPlanSessionUser(
       'boundary-retry-disconnect',
     );
 
     const response = await boundary.respondRetryStream(
-      buildArgs({
-        req: buildRetryRequest('plan_retry_disconnect', controller.signal),
+      buildRetryStreamArgs({
+        req: buildRetryStreamRequest(
+          'plan_retry_disconnect',
+          controller.signal,
+        ),
         authUserId,
         internalUserId,
         planId: 'plan_retry_disconnect',
@@ -325,20 +251,23 @@ describe('PlanGenerationSessionBoundary.respondRetryStream', () => {
   });
 
   it('passes responseHeaders through to the streaming Response', async () => {
-    const fake = buildMockProcessLifecycle(async () => SUCCESS_ATTEMPT_RESULT, {
-      topic: BASE_PLAN_SNAPSHOT.topic,
-    });
+    const fake = buildMockProcessLifecycle(
+      async () => SUCCESS_RETRY_ATTEMPT_RESULT,
+      {
+        topic: BASE_RETRY_PLAN_SNAPSHOT.topic,
+      },
+    );
     const boundary = createPlanGenerationSessionBoundary({
       createLifecycleService: () => fake.service,
     });
 
-    const { authUserId, internalUserId } = await setupUser(
+    const { authUserId, internalUserId } = await setupPlanSessionUser(
       'boundary-retry-headers',
     );
 
     const response = await boundary.respondRetryStream(
-      buildArgs({
-        req: buildRetryRequest('plan_retry_headers'),
+      buildRetryStreamArgs({
+        req: buildRetryStreamRequest('plan_retry_headers'),
         authUserId,
         internalUserId,
         planId: 'plan_retry_headers',
@@ -361,21 +290,21 @@ describe('PlanGenerationSessionBoundary.respondRetryStream', () => {
     const fake = buildMockProcessLifecycle(
       async (input) => {
         captured.push(input);
-        return SUCCESS_ATTEMPT_RESULT;
+        return SUCCESS_RETRY_ATTEMPT_RESULT;
       },
-      { topic: BASE_PLAN_SNAPSHOT.topic },
+      { topic: BASE_RETRY_PLAN_SNAPSHOT.topic },
     );
     const boundary = createPlanGenerationSessionBoundary({
       createLifecycleService: () => fake.service,
     });
 
-    const { authUserId, internalUserId } = await setupUser(
+    const { authUserId, internalUserId } = await setupPlanSessionUser(
       'boundary-retry-allowed-statuses',
     );
 
     const response = await boundary.respondRetryStream(
-      buildArgs({
-        req: buildRetryRequest('plan_retry_allowed'),
+      buildRetryStreamArgs({
+        req: buildRetryStreamRequest('plan_retry_allowed'),
         authUserId,
         internalUserId,
         planId: 'plan_retry_allowed',
@@ -394,9 +323,9 @@ describe('PlanGenerationSessionBoundary.respondRetryStream', () => {
     const builtFakes: MockProcessLifecycleHandle[] = [];
     const createLifecycleService = vi.fn(() => {
       const next = buildMockProcessLifecycle(
-        async () => SUCCESS_ATTEMPT_RESULT,
+        async () => SUCCESS_RETRY_ATTEMPT_RESULT,
         {
-          topic: BASE_PLAN_SNAPSHOT.topic,
+          topic: BASE_RETRY_PLAN_SNAPSHOT.topic,
         },
       );
       builtFakes.push(next);
@@ -406,22 +335,22 @@ describe('PlanGenerationSessionBoundary.respondRetryStream', () => {
       createLifecycleService,
     });
 
-    const { authUserId, internalUserId } = await setupUser(
+    const { authUserId, internalUserId } = await setupPlanSessionUser(
       'boundary-retry-factory',
     );
 
     const responses = await Promise.all([
       boundary.respondRetryStream(
-        buildArgs({
-          req: buildRetryRequest('plan_retry_factory_a'),
+        buildRetryStreamArgs({
+          req: buildRetryStreamRequest('plan_retry_factory_a'),
           authUserId,
           internalUserId,
           planId: 'plan_retry_factory_a',
         }),
       ),
       boundary.respondRetryStream(
-        buildArgs({
-          req: buildRetryRequest('plan_retry_factory_b'),
+        buildRetryStreamArgs({
+          req: buildRetryStreamRequest('plan_retry_factory_b'),
           authUserId,
           internalUserId,
           planId: 'plan_retry_factory_b',

--- a/tests/integration/features/plans/session/stream-session-test-helpers.ts
+++ b/tests/integration/features/plans/session/stream-session-test-helpers.ts
@@ -1,10 +1,19 @@
 import type { PlanLifecycleService } from '@/features/plans/lifecycle/service';
 import type {
-  CreatePlanResult,
+  CreatePlanSuccess,
   GenerationAttemptResult,
   ProcessGenerationInput,
 } from '@/features/plans/lifecycle/types';
+import type {
+  RespondCreateStreamArgs,
+  RespondRetryStreamArgs,
+  RetryPlanGenerationPlanSnapshot,
+} from '@/features/plans/session/plan-generation-session';
+import type { CreateLearningPlanInput } from '@/features/plans/validation/learningPlans.types';
 import type { AttemptReservation } from '@/lib/db/queries/types/attempts.types';
+import { ensureUser } from '@tests/helpers/db/users';
+import { buildTestAuthUserId, buildTestEmail } from '@tests/helpers/testIds';
+import { db } from '@supabase/service-role';
 import { vi } from 'vitest';
 
 export interface MockProcessLifecycleHandle {
@@ -14,6 +23,158 @@ export interface MockProcessLifecycleHandle {
 
 export interface MockCreateLifecycleHandle extends MockProcessLifecycleHandle {
   createPlan: ReturnType<typeof vi.fn>;
+}
+
+export const SUCCESS_CREATE_RESULT: CreatePlanSuccess = {
+  status: 'success',
+  planId: 'plan_boundary_create_success',
+  tier: 'pro',
+  normalizedInput: {
+    topic: 'Boundary Topic',
+    skillLevel: 'beginner',
+    weeklyHours: 5,
+    learningStyle: 'mixed',
+    startDate: null,
+    deadlineDate: '2030-01-01',
+  },
+};
+
+export const SUCCESS_CREATE_ATTEMPT_RESULT: GenerationAttemptResult = {
+  status: 'generation_success',
+  data: {
+    modules: [
+      {
+        title: 'Boundary Module',
+        estimatedMinutes: 60,
+        tasks: [{ title: 'Boundary Task', estimatedMinutes: 30 }],
+      },
+    ],
+    metadata: {
+      provider: 'mock',
+      model: 'mock-model',
+      usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+    },
+    durationMs: 5,
+  },
+};
+
+export const SUCCESS_RETRY_ATTEMPT_RESULT: GenerationAttemptResult = {
+  status: 'generation_success',
+  data: {
+    modules: [
+      {
+        title: 'Retry Module',
+        estimatedMinutes: 90,
+        tasks: [
+          { title: 'Retry Task A', estimatedMinutes: 30 },
+          { title: 'Retry Task B', estimatedMinutes: 60 },
+        ],
+      },
+    ],
+    metadata: {
+      provider: 'mock',
+      model: 'mock-model',
+      usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+    },
+    durationMs: 5,
+  },
+};
+
+export const BASE_CREATE_BODY: CreateLearningPlanInput = {
+  topic: 'Boundary Topic',
+  skillLevel: 'beginner',
+  weeklyHours: 5,
+  learningStyle: 'mixed',
+  notes: undefined,
+  startDate: undefined,
+  deadlineDate: '2030-01-01',
+  visibility: 'private',
+  origin: 'ai',
+};
+
+export const BASE_RETRY_PLAN_SNAPSHOT: RetryPlanGenerationPlanSnapshot = {
+  topic: 'Retry Topic',
+  skillLevel: 'intermediate',
+  weeklyHours: 6,
+  learningStyle: 'mixed',
+  startDate: '2030-01-01',
+  deadlineDate: '2030-06-01',
+  origin: 'ai',
+};
+
+export function buildCreateStreamRequest(
+  overrides: { signal?: AbortSignal; url?: string } = {},
+): Request {
+  return new Request(overrides.url ?? 'http://localhost/api/v1/plans/stream', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(BASE_CREATE_BODY),
+    ...(overrides.signal ? { signal: overrides.signal } : {}),
+  });
+}
+
+export function buildRetryStreamRequest(
+  planId: string,
+  signal?: AbortSignal,
+): Request {
+  return new Request(`http://localhost/api/v1/plans/${planId}/retry`, {
+    method: 'POST',
+    ...(signal ? { signal } : {}),
+  });
+}
+
+export function buildCreateStreamArgs(
+  args: Partial<RespondCreateStreamArgs> & {
+    req: Request;
+    authUserId: string;
+  },
+): RespondCreateStreamArgs {
+  return {
+    internalUserId: 'internal-user-id',
+    body: { ...BASE_CREATE_BODY },
+    savedPreferredAiModel: null,
+    ...args,
+  };
+}
+
+export interface BuildRetryStreamArgsInput {
+  req: Request;
+  authUserId: string;
+  internalUserId: string;
+  planId?: string;
+  plan?: RetryPlanGenerationPlanSnapshot;
+  responseHeaders?: HeadersInit;
+  requestId?: string;
+}
+
+export function buildRetryStreamArgs(
+  input: BuildRetryStreamArgsInput,
+): RespondRetryStreamArgs {
+  return {
+    req: input.req,
+    authUserId: input.authUserId,
+    internalUserId: input.internalUserId,
+    planId: input.planId ?? 'plan_boundary_retry',
+    plan: input.plan ?? { ...BASE_RETRY_PLAN_SNAPSHOT },
+    tierDb: db,
+    ...(input.responseHeaders
+      ? { responseHeaders: input.responseHeaders }
+      : {}),
+    ...(input.requestId !== undefined ? { requestId: input.requestId } : {}),
+  };
+}
+
+export async function setupPlanSessionUser(scenario: string): Promise<{
+  authUserId: string;
+  internalUserId: string;
+}> {
+  const authUserId = buildTestAuthUserId(scenario);
+  const internalUserId = await ensureUser({
+    authUserId,
+    email: buildTestEmail(authUserId),
+    subscriptionTier: 'pro',
+  });
+  return { authUserId, internalUserId };
 }
 
 export function fakeAttemptReservation(
@@ -67,7 +228,7 @@ export function buildMockCreateLifecycle({
   reserveAttemptNumber = 1,
   topic = 'Boundary Topic',
 }: {
-  createResult: CreatePlanResult;
+  createResult: CreatePlanSuccess;
   process: (input: ProcessGenerationInput) => Promise<GenerationAttemptResult>;
   reserveAttemptNumber?: number;
   topic?: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Surgical test-helper extraction for plan/session streaming specs. No production code changes.

- **`tests/helpers/streaming.ts`**: shared SSE assertion helpers (`expectStreamingJsonObject`, `expectPlanStartEvent`, `expectTerminalEventAfterStart`) alongside existing parsers
- **`stream-session-test-helpers.ts`**: shared create/retry fixtures, request builders, `setupPlanSessionUser`, and lifecycle mocks (create vs retry kept as separate builders)
- **Updated specs**: `plans-stream`, `plans-retry`, `respond-create-stream`, `respond-retry-stream` — removed duplicated local helpers; test names and core assertions remain local

## Validation

- Targeted integration specs (all passed):
  - `tests/integration/api/plans-stream.spec.ts`
  - `tests/integration/api/plans-retry.spec.ts`
  - `tests/integration/features/plans/session/respond-create-stream.spec.ts`
  - `tests/integration/features/plans/session/respond-retry-stream.spec.ts`
- `pnpm test:changed`
- `pnpm check:full`

## Out of scope

- No `vi.hoisted` auth mock extraction (per repo lesson on Vitest hoisting)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48fde7cc-67c3-45ae-8e12-be7e0678188f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48fde7cc-67c3-45ae-8e12-be7e0678188f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

