### PR TITLE
refactor(api): use route params and shared query helper for plans

### DIFF
--- a/src/app/api/v1/plans/[planId]/attempts/route.ts
+++ b/src/app/api/v1/plans/[planId]/attempts/route.ts
@@ -1,4 +1,4 @@
-import { requirePlanIdFromRequest } from '@/features/plans/api/route-context';
+import { requireUuidRouteParam } from '@/features/plans/api/route-context';
 import { getPlanGenerationAttemptsForRead } from '@/features/plans/read-projection/service';
 import { NotFoundError } from '@/lib/api/errors';
 import { requestBoundary } from '@/lib/api/request-boundary';
@@ -6,8 +6,8 @@ import { json } from '@/lib/api/response';
 
 export const GET = requestBoundary.route(
   { rateLimit: 'read' },
-  async ({ req, actor }) => {
-    const planId = requirePlanIdFromRequest(req, 'second-to-last');
+  async ({ params, actor }) => {
+    const planId = requireUuidRouteParam(params, 'planId');
 
     const attempts = await getPlanGenerationAttemptsForRead({
       planId,

--- a/src/app/api/v1/plans/[planId]/regenerate/route.ts
+++ b/src/app/api/v1/plans/[planId]/regenerate/route.ts
@@ -1,4 +1,4 @@
-import { requirePlanIdFromRequest } from '@/features/plans/api/route-context';
+import { requireUuidRouteParam } from '@/features/plans/api/route-context';
 import { requestPlanRegeneration } from '@/features/plans/regeneration-orchestration/request';
 import { planRegenerationRequestSchema } from '@/features/plans/validation/learningPlans';
 import type { PlanRegenerationOverridesInput } from '@/features/plans/validation/learningPlans.types';
@@ -22,8 +22,8 @@ import { ZodError } from 'zod';
  */
 export const POST: PlainHandler = requestBoundary.route(
   { rateLimit: 'aiGeneration' },
-  async ({ req, actor }) => {
-    const planId = requirePlanIdFromRequest(req, 'second-to-last');
+  async ({ req, params, actor }) => {
+    const planId = requireUuidRouteParam(params, 'planId');
 
     const body = await parseJsonBody(req, {
       mode: 'required',

--- a/src/app/api/v1/plans/[planId]/retry/route.ts
+++ b/src/app/api/v1/plans/[planId]/retry/route.ts
@@ -1,6 +1,6 @@
 import {
   requireOwnedPlanById,
-  requirePlanIdFromRequest,
+  requireUuidRouteParam,
 } from '@/features/plans/api/route-context';
 import {
   createPlanGenerationSessionBoundary,
@@ -43,10 +43,10 @@ function createRetryHandler(deps?: {
 
   return requestBoundary.route(
     { rateLimit: 'aiGeneration' },
-    async ({ req, actor, db, correlationId }): Promise<Response> => {
+    async ({ req, params, actor, db, correlationId }): Promise<Response> => {
       const authUserId = actor.authUserId;
       const internalUserId = actor.id;
-      const planId = requirePlanIdFromRequest(req, 'second-to-last');
+      const planId = requireUuidRouteParam(params, 'planId');
 
       const rateLimit = await checkPlanGenerationRateLimit(internalUserId, db);
       const generationRateLimitHeaders =

--- a/src/app/api/v1/plans/[planId]/route.ts
+++ b/src/app/api/v1/plans/[planId]/route.ts
@@ -1,4 +1,4 @@
-import { requirePlanIdFromRequest } from '@/features/plans/api/route-context';
+import { requireUuidRouteParam } from '@/features/plans/api/route-context';
 import { getPlanDetailForRead } from '@/features/plans/read-projection/service';
 import { removePlanForWrite } from '@/features/plans/write-service';
 import { NotFoundError } from '@/lib/api/errors';
@@ -20,8 +20,8 @@ import { logger } from '@/lib/logging/logger';
 
 export const GET = requestBoundary.route(
   { rateLimit: 'read' },
-  async ({ req, actor, db }) => {
-    const planId = requirePlanIdFromRequest(req, 'last');
+  async ({ params, actor, db }) => {
+    const planId = requireUuidRouteParam(params, 'planId');
 
     logger.info({ planId, userId: actor.id }, 'Fetching learning plan detail');
 
@@ -46,8 +46,8 @@ export const GET = requestBoundary.route(
 
 export const DELETE = requestBoundary.route(
   { rateLimit: 'mutation' },
-  async ({ req, actor, db }) => {
-    const planId = requirePlanIdFromRequest(req, 'last');
+  async ({ params, actor, db }) => {
+    const planId = requireUuidRouteParam(params, 'planId');
 
     logger.info({ planId, userId: actor.id }, 'Deleting learning plan');
 

--- a/src/app/api/v1/plans/[planId]/status/route.ts
+++ b/src/app/api/v1/plans/[planId]/status/route.ts
@@ -1,5 +1,5 @@
 import { classificationToUserMessage } from '@/features/ai/failure-presentation';
-import { requirePlanIdFromRequest } from '@/features/plans/api/route-context';
+import { requireUuidRouteParam } from '@/features/plans/api/route-context';
 import { getPlanGenerationStatusSnapshot } from '@/features/plans/read-projection/service';
 import { NotFoundError } from '@/lib/api/errors';
 import { requestBoundary } from '@/lib/api/request-boundary';
@@ -17,8 +17,8 @@ import { PlanStatusResponseSchema } from '@/shared/schemas/plan-status';
 
 export const GET = requestBoundary.route(
   { rateLimit: 'read' },
-  async ({ req, actor, db, correlationId }): Promise<Response> => {
-    const planId = requirePlanIdFromRequest(req, 'second-to-last');
+  async ({ params, actor, db, correlationId }): Promise<Response> => {
+    const planId = requireUuidRouteParam(params, 'planId');
 
     logger.debug(
       { planId, userId: actor.id, correlationId },

--- a/src/app/api/v1/plans/[planId]/tasks/route.ts
+++ b/src/app/api/v1/plans/[planId]/tasks/route.ts
@@ -1,6 +1,6 @@
 import {
   requireOwnedPlanById,
-  requirePlanIdFromRequest,
+  requireUuidRouteParam,
 } from '@/features/plans/api/route-context';
 import { requestBoundary } from '@/lib/api/request-boundary';
 import { json } from '@/lib/api/response';
@@ -8,8 +8,8 @@ import { getAllTasksInPlan } from '@/lib/db/queries/tasks';
 
 export const GET = requestBoundary.route(
   { rateLimit: 'read' },
-  async ({ req, actor, db }) => {
-    const planId = requirePlanIdFromRequest(req, 'second-to-last');
+  async ({ params, actor, db }) => {
+    const planId = requireUuidRouteParam(params, 'planId');
     await requireOwnedPlanById({
       planId,
       ownerUserId: actor.id,

--- a/src/app/api/v1/plans/route.ts
+++ b/src/app/api/v1/plans/route.ts
@@ -4,6 +4,7 @@ import {
 } from '@/features/plans/read-projection/service';
 import type { PlainHandler } from '@/lib/api/auth';
 import { parseListPaginationParams } from '@/lib/api/pagination';
+import { getRequestSearchParams } from '@/lib/api/request-url';
 import { requestBoundary } from '@/lib/api/request-boundary';
 import { json } from '@/lib/api/response';
 import { logger } from '@/lib/logging/logger';
@@ -15,12 +16,13 @@ import {
 export const GET: PlainHandler = requestBoundary.route(
   { rateLimit: 'read' },
   async ({ req, actor, db }) => {
-    const url = new URL(req.url);
-
-    const { limit, offset } = parseListPaginationParams(url.searchParams, {
-      defaultLimit: getPaginationDefault('limit'),
-      maxLimit: PAGINATION_MAX_LIMIT,
-    });
+    const { limit, offset } = parseListPaginationParams(
+      getRequestSearchParams(req),
+      {
+        defaultLimit: getPaginationDefault('limit'),
+        maxLimit: PAGINATION_MAX_LIMIT,
+      },
+    );
 
     logger.info(
       {

--- a/src/app/api/v1/resources/route.ts
+++ b/src/app/api/v1/resources/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import { ValidationError } from '@/lib/api/errors';
 import { parseListPaginationParams } from '@/lib/api/pagination';
+import { getRequestSearchParams } from '@/lib/api/request-url';
 import { requestBoundary } from '@/lib/api/request-boundary';
 import { json } from '@/lib/api/response';
 import { resources } from '@supabase/schema';
@@ -19,10 +20,10 @@ const resourcesTypeQuerySchema = z.object({
 export const GET = requestBoundary.route(
   { rateLimit: 'read' },
   async ({ req, db }) => {
-    const url = new URL(req.url);
+    const searchParams = getRequestSearchParams(req);
 
     const parsedTypeQuery = resourcesTypeQuerySchema.safeParse({
-      type: url.searchParams.get('type') ?? undefined,
+      type: searchParams.get('type') ?? undefined,
     });
     if (!parsedTypeQuery.success) {
       throw new ValidationError(
@@ -31,7 +32,7 @@ export const GET = requestBoundary.route(
       );
     }
 
-    const { limit, offset } = parseListPaginationParams(url.searchParams, {
+    const { limit, offset } = parseListPaginationParams(searchParams, {
       defaultLimit: DEFAULT_RESOURCES_LIMIT,
       maxLimit: PAGINATION_MAX_LIMIT,
     });

--- a/src/features/plans/api/route-context.ts
+++ b/src/features/plans/api/route-context.ts
@@ -9,36 +9,10 @@ export type PlansDbClient = DbClient;
 
 type LearningPlanRecord = OwnedPlanRecord;
 
-function getPlanIdFromUrl(
-  req: Request,
-  position: 'last' | 'second-to-last' = 'last',
-): string | undefined {
-  const url = new URL(req.url);
-  const segments = url.pathname.split('/').filter(Boolean);
-
-  return position === 'last'
-    ? segments[segments.length - 1]
-    : segments[segments.length - 2];
-}
-
 function isUuid(value: string): boolean {
   return /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(
     value,
   );
-}
-
-export function requirePlanIdFromRequest(
-  req: Request,
-  position: 'last' | 'second-to-last' = 'second-to-last',
-): string {
-  const planId = getPlanIdFromUrl(req, position);
-  if (!planId) {
-    throw new ValidationError('Plan id is required in the request path.');
-  }
-  if (!isUuid(planId)) {
-    throw new ValidationError('Invalid plan id format.');
-  }
-  return planId;
 }
 
 export function requireUuidRouteParam(

--- a/src/features/plans/session/session-command.ts
+++ b/src/features/plans/session/session-command.ts
@@ -1,4 +1,5 @@
 import { resolveUserTier } from '@/features/billing/tier';
+import { getRequestSearchParams } from '@/lib/api/request-url';
 import { logger } from '@/lib/logging/logger';
 
 import type { PlansDbClient } from '@/features/plans/api/route-context';
@@ -218,7 +219,7 @@ function resolveCreateStreamModel({
 }): string | undefined {
   const { modelOverride, resolutionSource, suppliedModel } =
     resolveStreamModelResolution({
-      searchParams: new URL(req.url).searchParams,
+      searchParams: getRequestSearchParams(req),
       tier: createResult.tier,
       savedPreferredAiModel,
     });

--- a/src/lib/api/request-url.ts
+++ b/src/lib/api/request-url.ts
@@ -1,0 +1,7 @@
+/**
+ * Returns query-string parameters from a request URL.
+ * Use when only search params are needed (not path or origin).
+ */
+export function getRequestSearchParams(req: Request): URLSearchParams {
+  return new URL(req.url).searchParams;
+}

--- a/tests/helpers/route-handler-context.ts
+++ b/tests/helpers/route-handler-context.ts
@@ -1,0 +1,8 @@
+import type { RouteHandlerContext } from '@/lib/api/types/auth.types';
+
+/** Next.js route handler context for direct handler invocation in tests. */
+export function buildRouteHandlerContext(
+  params: Record<string, string>,
+): RouteHandlerContext {
+  return { params: Promise.resolve(params) };
+}

--- a/tests/integration/api/plan-tasks.spec.ts
+++ b/tests/integration/api/plan-tasks.spec.ts
@@ -3,6 +3,7 @@ import { NextRequest } from 'next/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { db } from '@supabase/service-role';
 import { mockServerSession } from '@tests/helpers/mock-server-auth';
+import { buildRouteHandlerContext } from '@tests/helpers/route-handler-context';
 import { clearTestUser, setTestUser } from '../../helpers/auth';
 import { ensureUser } from '../../helpers/db/users';
 
@@ -94,7 +95,7 @@ describe('GET /api/v1/plans/:planId/tasks', () => {
       { method: 'GET' },
     );
 
-    const response = await GET(request);
+    const response = await GET(request, buildRouteHandlerContext({ planId }));
 
     expect(response.status).toBe(200);
     const body = await response.json();
@@ -107,13 +108,17 @@ describe('GET /api/v1/plans/:planId/tasks', () => {
   });
 
   it('should return 404 for non-existent plan', async () => {
+    const missingPlanId = '00000000-0000-0000-0000-000000000000';
     const { GET } = await import('@/app/api/v1/plans/[planId]/tasks/route');
     const request = new NextRequest(
-      'http://localhost:3000/api/v1/plans/00000000-0000-0000-0000-000000000000/tasks',
+      `http://localhost:3000/api/v1/plans/${missingPlanId}/tasks`,
       { method: 'GET' },
     );
 
-    const response = await GET(request);
+    const response = await GET(
+      request,
+      buildRouteHandlerContext({ planId: missingPlanId }),
+    );
 
     expect(response.status).toBe(404);
     const body = await response.json();
@@ -133,7 +138,7 @@ describe('GET /api/v1/plans/:planId/tasks', () => {
       { method: 'GET' },
     );
 
-    const response = await GET(request);
+    const response = await GET(request, buildRouteHandlerContext({ planId }));
 
     expect(response.status).toBe(401);
   });
@@ -151,7 +156,7 @@ describe('GET /api/v1/plans/:planId/tasks', () => {
       { method: 'GET' },
     );
 
-    const response = await GET(request);
+    const response = await GET(request, buildRouteHandlerContext({ planId }));
 
     expect(response.status).toBe(401);
   });
@@ -168,7 +173,7 @@ describe('GET /api/v1/plans/:planId/tasks', () => {
       { method: 'GET' },
     );
 
-    const response = await GET(request);
+    const response = await GET(request, buildRouteHandlerContext({ planId }));
 
     expect(response.status).toBe(404);
   });
@@ -194,7 +199,10 @@ describe('GET /api/v1/plans/:planId/tasks', () => {
       { method: 'GET' },
     );
 
-    const response = await GET(request);
+    const response = await GET(
+      request,
+      buildRouteHandlerContext({ planId: emptyPlan.id }),
+    );
 
     expect(response.status).toBe(200);
     const body = await response.json();
@@ -237,7 +245,7 @@ describe('GET /api/v1/plans/:planId/tasks', () => {
       { method: 'GET' },
     );
 
-    const response = await GET(request);
+    const response = await GET(request, buildRouteHandlerContext({ planId }));
 
     expect(response.status).toBe(200);
     const body = await response.json();

--- a/tests/integration/api/plans-retry.spec.ts
+++ b/tests/integration/api/plans-retry.spec.ts
@@ -204,10 +204,11 @@ describe('POST /api/v1/plans/:planId/retry — HTTP preflight + default boundary
       },
     });
 
-    const invocation = createRetryInvocation(plan.id);
+    const invocationA = createRetryInvocation(plan.id);
+    const invocationB = createRetryInvocation(plan.id);
     const [resA, resB] = await Promise.all([
-      POST(invocation.request, invocation.context),
-      POST(invocation.request, invocation.context),
+      POST(invocationA.request, invocationA.context),
+      POST(invocationB.request, invocationB.context),
     ]);
 
     if (resA.status === 200 && resB.status === 200) {

--- a/tests/integration/api/plans-retry.spec.ts
+++ b/tests/integration/api/plans-retry.spec.ts
@@ -9,6 +9,7 @@ import { seedFailedAttemptsForDurableWindow } from '../../fixtures/attempts';
 import { createPlanForRetryTest } from '../../fixtures/plans';
 import { setTestUser } from '../../helpers/auth';
 import { ensureUser } from '../../helpers/db/users';
+import { buildRouteHandlerContext } from '@tests/helpers/route-handler-context';
 import { readStreamingResponse } from '../../helpers/streaming';
 
 type RetryAttemptOverrides = Partial<
@@ -56,10 +57,13 @@ async function withRunGenerationAttemptSpy<T>(
   }
 }
 
-function createRetryRequest(planId: string): Request {
-  return new Request(`http://localhost/api/v1/plans/${planId}/retry`, {
-    method: 'POST',
-  });
+function createRetryInvocation(planId: string) {
+  return {
+    request: new Request(`http://localhost/api/v1/plans/${planId}/retry`, {
+      method: 'POST',
+    }),
+    context: buildRouteHandlerContext({ planId }),
+  };
 }
 
 function expectJsonObject(value: unknown): Record<string, unknown> {
@@ -153,7 +157,8 @@ describe('POST /api/v1/plans/:planId/retry — HTTP preflight + default boundary
       },
     });
 
-    const response = await POST(createRetryRequest(plan.id));
+    const { request, context } = createRetryInvocation(plan.id);
+    const response = await POST(request, context);
     expect(response.status).toBe(200);
 
     const events = await readStreamingResponse(response);
@@ -199,9 +204,10 @@ describe('POST /api/v1/plans/:planId/retry — HTTP preflight + default boundary
       },
     });
 
+    const invocation = createRetryInvocation(plan.id);
     const [resA, resB] = await Promise.all([
-      POST(createRetryRequest(plan.id)),
-      POST(createRetryRequest(plan.id)),
+      POST(invocation.request, invocation.context),
+      POST(invocation.request, invocation.context),
     ]);
 
     if (resA.status === 200 && resB.status === 200) {
@@ -254,8 +260,8 @@ describe('POST /api/v1/plans/:planId/retry — HTTP preflight + default boundary
     await seedFailedAttemptsForDurableWindow(plan.id);
 
     await withRunGenerationAttemptSpy(async (runSpy) => {
-      const request = createRetryRequest(plan.id);
-      const response = await POST(request);
+      const { request, context } = createRetryInvocation(plan.id);
+      const response = await POST(request, context);
       expect(response.status).toBe(429);
       expect(response.headers.get('X-RateLimit-Remaining')).toBe('0');
 
@@ -286,7 +292,8 @@ describe('POST /api/v1/plans/:planId/retry — HTTP preflight + default boundary
     });
 
     await withRunGenerationAttemptSpy(async (runSpy) => {
-      const response = await POST(createRetryRequest(plan.id));
+      const { request, context } = createRetryInvocation(plan.id);
+      const response = await POST(request, context);
       expect(response.status).toBe(400);
       const body = (await response.json()) as { error?: string; code?: string };
       expect(body.code).toBe('VALIDATION_ERROR');

--- a/tests/integration/api/plans.status.rls.spec.ts
+++ b/tests/integration/api/plans.status.rls.spec.ts
@@ -3,6 +3,7 @@ import { NextRequest } from 'next/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { db } from '@supabase/service-role';
 import { mockServerSession } from '@tests/helpers/mock-server-auth';
+import { buildRouteHandlerContext } from '@tests/helpers/route-handler-context';
 import { setTestUser } from '../../helpers/auth';
 import { ensureUser } from '../../helpers/db/users';
 
@@ -65,7 +66,10 @@ describe('GET /api/v1/plans/:planId/status - access control', () => {
       `http://localhost:3000/api/v1/plans/${ownerPlanId}/status`,
       { method: 'GET' },
     );
-    const response = await GET(request);
+    const response = await GET(
+      request,
+      buildRouteHandlerContext({ planId: ownerPlanId }),
+    );
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.planId).toBe(ownerPlanId);
@@ -92,7 +96,10 @@ describe('GET /api/v1/plans/:planId/status - access control', () => {
       `http://localhost:3000/api/v1/plans/${otherPlan.id}/status`,
       { method: 'GET' },
     );
-    const response = await GET(request);
+    const response = await GET(
+      request,
+      buildRouteHandlerContext({ planId: otherPlan.id }),
+    );
     expect(response.status).toBe(404);
   });
 });

--- a/tests/integration/api/plans/plans-read.contract.spec.ts
+++ b/tests/integration/api/plans/plans-read.contract.spec.ts
@@ -14,6 +14,7 @@ import { buildTestPlanInsert } from '@tests/fixtures/plans';
 import { clearTestUser, setTestUser } from '@tests/helpers/auth';
 import { ensureUser } from '@tests/helpers/db/users';
 import { mockServerSession } from '@tests/helpers/mock-server-auth';
+import { buildRouteHandlerContext } from '@tests/helpers/route-handler-context';
 import { NextRequest } from 'next/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
@@ -219,6 +220,7 @@ describe('Plan read API response contracts', () => {
       new NextRequest(`http://localhost:3000/api/v1/plans/${plan.id}`, {
         method: 'GET',
       }),
+      buildRouteHandlerContext({ planId: plan.id }),
     );
     expect(detailRes.status).toBe(200);
     const detailJson: unknown = await detailRes.json();
@@ -232,6 +234,7 @@ describe('Plan read API response contracts', () => {
       new NextRequest(`http://localhost:3000/api/v1/plans/${plan.id}/status`, {
         method: 'GET',
       }),
+      buildRouteHandlerContext({ planId: plan.id }),
     );
     expect(statusRes.status).toBe(200);
     const statusJson: unknown = await statusRes.json();
@@ -246,6 +249,7 @@ describe('Plan read API response contracts', () => {
         `http://localhost:3000/api/v1/plans/${plan.id}/attempts`,
         { method: 'GET' },
       ),
+      buildRouteHandlerContext({ planId: plan.id }),
     );
     expect(attemptsRes.status).toBe(200);
     const attemptsJson: unknown = await attemptsRes.json();

--- a/tests/integration/contract/plans.api-integration.spec.ts
+++ b/tests/integration/contract/plans.api-integration.spec.ts
@@ -6,6 +6,7 @@ import { generationAttempts, learningPlans, modules } from '@supabase/schema';
 import { db } from '@supabase/service-role';
 import { setTestUser } from '../../helpers/auth';
 import { ensureUser } from '../../helpers/db/users';
+import { buildRouteHandlerContext } from '@tests/helpers/route-handler-context';
 import { buildTestAuthUserId, buildTestEmail } from '../../helpers/testIds';
 
 const BASE_URL = 'http://localhost/api/v1/plans';
@@ -41,7 +42,10 @@ describe('Phase 4: API Integration', () => {
         .returning();
 
       let statusRequest = await createStatusRequest(plan.id);
-      let statusResponse = await GET_STATUS(statusRequest);
+      let statusResponse = await GET_STATUS(
+        statusRequest,
+        buildRouteHandlerContext({ planId: plan.id }),
+      );
       expect(statusResponse.status).toBe(200);
       let statusPayload = await statusResponse.json();
       expect(statusPayload.status).toBe('processing');
@@ -61,7 +65,10 @@ describe('Phase 4: API Integration', () => {
       });
 
       statusRequest = await createStatusRequest(plan.id);
-      statusResponse = await GET_STATUS(statusRequest);
+      statusResponse = await GET_STATUS(
+        statusRequest,
+        buildRouteHandlerContext({ planId: plan.id }),
+      );
       statusPayload = await statusResponse.json();
       expect(statusPayload.status).toBe('ready');
     });
@@ -94,7 +101,10 @@ describe('Phase 4: API Integration', () => {
       });
 
       const statusRequest = await createStatusRequest(plan.id);
-      const statusResponse = await GET_STATUS(statusRequest);
+      const statusResponse = await GET_STATUS(
+        statusRequest,
+        buildRouteHandlerContext({ planId: plan.id }),
+      );
       const statusPayload = await statusResponse.json();
       expect(statusPayload.status).toBe('failed');
       expect(statusPayload.latestError).toBe(

--- a/tests/integration/contract/plans.attempts.get.spec.ts
+++ b/tests/integration/contract/plans.attempts.get.spec.ts
@@ -5,12 +5,16 @@ import { generationAttempts, learningPlans } from '@supabase/schema';
 import { db } from '@supabase/service-role';
 import { setTestUser } from '../../helpers/auth';
 import { ensureUser } from '../../helpers/db/users';
+import { buildRouteHandlerContext } from '@tests/helpers/route-handler-context';
 import { buildTestAuthUserId, buildTestEmail } from '../../helpers/testIds';
 
 function buildRequest(planId: string) {
-  return new Request(`http://localhost/api/v1/plans/${planId}/attempts`, {
-    method: 'GET',
-  });
+  return {
+    request: new Request(`http://localhost/api/v1/plans/${planId}/attempts`, {
+      method: 'GET',
+    }),
+    context: buildRouteHandlerContext({ planId }),
+  };
 }
 
 describe('GET /api/v1/plans/:planId/attempts', () => {
@@ -65,7 +69,8 @@ describe('GET /api/v1/plans/:planId/attempts', () => {
       },
     ]);
 
-    const response = await GET(buildRequest(plan.id));
+    const { request, context } = buildRequest(plan.id);
+    const response = await GET(request, context);
     expect(response.status).toBe(200);
 
     const attempts = await response.json();
@@ -83,9 +88,10 @@ describe('GET /api/v1/plans/:planId/attempts', () => {
       email: buildTestEmail(otherOwnerAuthId),
     });
 
-    const response = await GET(
-      buildRequest('00000000-0000-0000-0000-000000000000'),
+    const { request, context } = buildRequest(
+      '00000000-0000-0000-0000-000000000000',
     );
+    const response = await GET(request, context);
     expect(response.status).toBe(404);
   });
 });

--- a/tests/integration/contract/plans.get.spec.ts
+++ b/tests/integration/contract/plans.get.spec.ts
@@ -5,12 +5,16 @@ import { learningPlans, modules, tasks } from '@supabase/schema';
 import { db } from '@supabase/service-role';
 import { setTestUser } from '../../helpers/auth';
 import { ensureUser } from '../../helpers/db/users';
+import { buildRouteHandlerContext } from '@tests/helpers/route-handler-context';
 import { buildTestAuthUserId, buildTestEmail } from '../../helpers/testIds';
 
 function buildRequest(planId: string) {
-  return new Request(`http://localhost/api/v1/plans/${planId}`, {
-    method: 'GET',
-  });
+  return {
+    request: new Request(`http://localhost/api/v1/plans/${planId}`, {
+      method: 'GET',
+    }),
+    context: buildRouteHandlerContext({ planId }),
+  };
 }
 
 describe('GET /api/v1/plans/:planId', () => {
@@ -81,7 +85,8 @@ describe('GET /api/v1/plans/:planId', () => {
       },
     ]);
 
-    const response = await GET(buildRequest(plan.id));
+    const { request, context } = buildRequest(plan.id);
+    const response = await GET(request, context);
     expect(response.status).toBe(200);
 
     const detail = await response.json();
@@ -102,9 +107,10 @@ describe('GET /api/v1/plans/:planId', () => {
       email: buildTestEmail(nonOwnerAuthId),
     });
 
-    const response = await GET(
-      buildRequest('00000000-0000-0000-0000-000000000000'),
+    const { request, context } = buildRequest(
+      '00000000-0000-0000-0000-000000000000',
     );
+    const response = await GET(request, context);
     expect(response.status).toBe(404);
   });
 
@@ -138,7 +144,8 @@ describe('GET /api/v1/plans/:planId', () => {
       email: attackerEmail,
     });
 
-    const response = await GET(buildRequest(ownerPlan.id));
+    const { request, context } = buildRequest(ownerPlan.id);
+    const response = await GET(request, context);
     expect(response.status).toBe(404);
 
     const error = await response.json();

--- a/tests/integration/contract/plans.status-parity.spec.ts
+++ b/tests/integration/contract/plans.status-parity.spec.ts
@@ -1,3 +1,4 @@
+import { buildRouteHandlerContext } from '@tests/helpers/route-handler-context';
 import { GET as GET_PLAN_DETAIL } from '@/app/api/v1/plans/[planId]/route';
 import { GET as GET_PLAN_STATUS } from '@/app/api/v1/plans/[planId]/status/route';
 import { getGenerationAttemptCap } from '@/features/ai/generation-policy';
@@ -127,15 +128,18 @@ describe('Plan status parity contract', () => {
     for (const fixture of fixtures) {
       const planId = await createPlanFixture(userId, fixture);
 
+      const routeContext = buildRouteHandlerContext({ planId });
       const detailResponse = await GET_PLAN_DETAIL(
         new Request(`http://localhost/api/v1/plans/${planId}`, {
           method: 'GET',
         }),
+        routeContext,
       );
       const statusResponse = await GET_PLAN_STATUS(
         new Request(`http://localhost/api/v1/plans/${planId}/status`, {
           method: 'GET',
         }),
+        routeContext,
       );
 
       expect(detailResponse.status).toBe(200);

--- a/tests/integration/rls/attempts-visibility.spec.ts
+++ b/tests/integration/rls/attempts-visibility.spec.ts
@@ -2,6 +2,7 @@ import { GET as GET_ATTEMPTS } from '@/app/api/v1/plans/[planId]/attempts/route'
 import { generationAttempts, learningPlans } from '@supabase/schema';
 import { describe, expect, it } from 'vitest';
 import { db } from '@supabase/service-role';
+import { buildRouteHandlerContext } from '@tests/helpers/route-handler-context';
 import { setTestUser } from '../../helpers/auth';
 import { ensureUser } from '../../helpers/db/users';
 
@@ -58,6 +59,7 @@ describe('RLS attempt visibility', () => {
     setTestUser(owner.authUserId);
     const ownerResp = await GET_ATTEMPTS(
       new Request(`http://localhost/api/v1/plans/${owner.planId}/attempts`),
+      buildRouteHandlerContext({ planId: owner.planId }),
     );
     expect(ownerResp.status).toBe(200);
     const ownerPayload = await ownerResp.json();
@@ -73,6 +75,7 @@ describe('RLS attempt visibility', () => {
 
     const otherResp = await GET_ATTEMPTS(
       new Request(`http://localhost/api/v1/plans/${owner.planId}/attempts`),
+      buildRouteHandlerContext({ planId: owner.planId }),
     );
     // RLS should cause 404 (plan not found in authorized scope)
     expect(otherResp.status).toBe(404);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the handoff to push shared API helpers through remaining duplicate call sites, focused on plan routes and query-param access.

## Changes

### Plan route params (replaces URL path parsing)
- Removed `requirePlanIdFromRequest()` / `getPlanIdFromUrl()` from `src/features/plans/api/route-context.ts`
- Migrated six `[planId]` routes to `requireUuidRouteParam(params, 'planId')` via `requestBoundary.route()` scope:
  - `GET`/`DELETE` plan detail
  - tasks, attempts, status, regenerate, retry
- Added `tests/helpers/route-handler-context.ts` with `buildRouteHandlerContext()` for direct handler invocation in tests
- Updated integration/contract tests to pass `{ params: Promise.resolve({ planId }) }`

### Query params helper
- Added `getRequestSearchParams(req)` in `src/lib/api/request-url.ts`
- Used in plans list, resources list, and session-command model override resolution

### Intentionally unchanged
- No `withResponseHeaders` extraction — only one API-layer response-clone caller (`applyUserRateLimitHeaders`)
- Webhook/internal header reads (Stripe webhook, regeneration worker token, IP rate limit) left domain-specific
- Stripe `complete-checkout` still uses `new URL(req.url)` where path/origin matter

## Verification

- `pnpm exec vitest run --project unit tests/unit/api/request-boundary.spec.ts`
- `pnpm exec vitest run --project unit tests/unit/lib/api/route-wrappers.spec.ts`
- `pnpm exec vitest run --project integration tests/integration/api/plans-retry.spec.ts` (and related plan route specs)
- `pnpm test:changed`
- `pnpm check:full`
- `git diff --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea113ccd-d112-451f-8024-de1159576910"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea113ccd-d112-451f-8024-de1159576910"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

