### PR TITLE
refactor(ui): remove product-page-* globals from PageHeader

### DIFF
--- a/src/app/(app)/plans/new/components/CreatePlanPageClient.tsx
+++ b/src/app/(app)/plans/new/components/CreatePlanPageClient.tsx
@@ -1,18 +1,18 @@
 'use client';
 
 import { ManualCreatePanel } from '@/app/(app)/plans/new/components/ManualCreatePanel';
+import { PageHeader } from '@/components/ui/page-header';
 import type React from 'react';
 
 export function CreatePlanPageClient(): React.ReactElement {
   return (
     <>
-      <div className="mb-6 max-w-3xl text-center">
-        <h1 className="product-page-title">What do you want to learn?</h1>
-        <p className="product-page-subtitle mt-2">
-          Describe your learning goal. We&apos;ll create a personalized,
-          time-blocked schedule that syncs to your calendar.
-        </p>
-      </div>
+      <PageHeader
+        align="center"
+        className="mb-6 max-w-3xl"
+        title="What do you want to learn?"
+        subtitle="Describe your learning goal. We'll create a personalized, time-blocked schedule that syncs to your calendar."
+      />
 
       <ManualCreatePanel />
     </>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -256,36 +256,6 @@
     text-transform: uppercase;
   }
 
-  /* Typography for product pages and shared page headers */
-  .product-page-title {
-    font-family: var(--font-family-heading);
-    font-weight: var(--font-weight-heading);
-    font-size: 1.5rem; /* 24px */
-    line-height: 1.25;
-    letter-spacing: -0.02em;
-    text-wrap: balance;
-    color: var(--foreground);
-  }
-
-  .product-page-title-nested {
-    font-family: var(--font-family-heading);
-    font-weight: var(--font-weight-heading);
-    font-size: 1.25rem; /* 20px */
-    line-height: 1.3;
-    letter-spacing: -0.015em;
-    text-wrap: balance;
-    color: var(--foreground);
-  }
-
-  .product-page-subtitle {
-    font-family: var(--font-family-base);
-    font-weight: var(--font-weight-base);
-    font-size: 0.875rem; /* 14px */
-    line-height: 1.5;
-    letter-spacing: 0;
-    color: var(--muted-foreground);
-  }
-
   /* Legacy subtitle helper: keep aligned with PageHeader subtitle scale. */
   .subtitle {
     font-family: var(--font-family-base);

--- a/src/components/ui/page-header.tsx
+++ b/src/components/ui/page-header.tsx
@@ -2,6 +2,9 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
+const PAGE_HEADER_SUBTITLE_CLASS =
+  'mt-1 text-sm leading-[1.5] tracking-normal text-muted-foreground';
+
 /**
  * Product page title row: centralizes app title/subtitle scale so pages do not improvise typography.
  */
@@ -11,6 +14,7 @@ function PageHeader({
   subtitle,
   actions,
   titleAs: TitleTag = 'h1',
+  align = 'start',
   ...props
 }: React.ComponentProps<'div'> & {
   title: React.ReactNode;
@@ -18,26 +22,28 @@ function PageHeader({
   actions?: React.ReactNode;
   /** Use `h2` for nested pages under a parent title (e.g. settings sub-routes). */
   titleAs?: 'h1' | 'h2';
+  align?: 'start' | 'center';
 }) {
-  const titleClassName =
-    TitleTag === 'h2' ? 'product-page-title-nested' : 'product-page-title';
+  const isCentered = align === 'center';
 
   return (
     <header
       data-slot="page-header"
       className={cn(
-        'mb-5 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between',
+        isCentered
+          ? 'mb-5 flex flex-col items-center gap-3 text-center'
+          : 'mb-5 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between',
         className,
       )}
       {...props}
     >
-      <div className="min-w-0 flex-1">
-        <TitleTag className={titleClassName}>{title}</TitleTag>
+      <div className={cn('min-w-0 flex-1', isCentered && 'w-full')}>
+        <TitleTag className="text-foreground">{title}</TitleTag>
         {subtitle != null ? (
           typeof subtitle === 'string' ? (
-            <p className="product-page-subtitle mt-1">{subtitle}</p>
+            <p className={PAGE_HEADER_SUBTITLE_CLASS}>{subtitle}</p>
           ) : (
-            <div className="product-page-subtitle mt-1">{subtitle}</div>
+            <div className={PAGE_HEADER_SUBTITLE_CLASS}>{subtitle}</div>
           )
         ) : null}
       </div>

--- a/tests/unit/components/ui/page-header.spec.tsx
+++ b/tests/unit/components/ui/page-header.spec.tsx
@@ -19,4 +19,18 @@ describe('PageHeader', () => {
       screen.getByRole('heading', { name: 'Sub page', level: 2 }),
     ).toBeInTheDocument();
   });
+
+  it('renders centered title and subtitle when align is center', () => {
+    render(
+      <PageHeader
+        align="center"
+        title="Create plan"
+        subtitle="Describe your goal"
+      />,
+    );
+    expect(
+      screen.getByRole('heading', { name: 'Create plan', level: 1 }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Describe your goal')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the `product-page-title`, `product-page-title-nested`, and `product-page-subtitle` global selectors from `globals.css` and colocates product page header typography in `PageHeader`.

## Changes

- **`PageHeader`**: Uses base `h1`/`h2` scale plus `text-foreground` for titles and Tailwind utilities for subtitles. Adds optional `align="center"` for centered stacks (create-plan).
- **`CreatePlanPageClient`**: Uses `PageHeader` instead of hand-rolled markup with global classes.
- **`globals.css`**: Deletes the three `product-page-*` selectors only.

## Verification

- `rg -n "product-page-" src tests docs/styles/style-guide.md` — no matches in live code/docs
- `pnpm exec vitest run --project unit tests/unit/components/ui/page-header.spec.tsx` — 3 passed
- `pnpm check:type` / `pnpm check:lint` / `pnpm check:full` — passed
- `pnpm test:changed` — passed

## Notes

Historical references in `.agents/plans/001-ui-polish-audit/*` are unchanged (out of scope).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b72e636f-ff2c-4ce2-bc2c-dbe6fd23b792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b72e636f-ff2c-4ce2-bc2c-dbe6fd23b792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Consolidates page header styling into a reusable component

This refactoring moves product page header typography from global CSS selectors into a new shared `PageHeader` component, eliminating style duplication and providing a consistent interface for page titles and subtitles across the application.

### Key changes

**PageHeader component** (`src/components/ui/page-header.tsx`):
- Centralizes page header typography with configurable heading levels (`h1` or `h2`) and alignment (`start` or `center`)
- Uses base semantic heading tags with `text-foreground` and Tailwind utilities (`text-sm`, `text-muted-foreground`) for subtitles
- Supports optional `actions` slot for inline controls
- Provides layout flexibility: stacked on mobile, row-based (with justify-between) on desktop, or centered stack when `align="center"`

**CreatePlanPageClient** (`src/app/(app)/plans/new/components/CreatePlanPageClient.tsx`):
- Migrated from hand-rolled `<div>` with `<h1>` and `<p>` tags to use the shared `PageHeader` component
- Uses `align="center"` for the centered layout specific to the create plan flow

**Removed global styles** (`src/app/globals.css`):
- Deleted `product-page-title`, `product-page-title-nested`, and `product-page-subtitle` CSS class definitions
- Typography styling is now colocated within the PageHeader component using Tailwind utilities

**Tests** (`tests/unit/components/ui/page-header.spec.tsx`):
- Added three test cases covering default h1 rendering, h2 for nested pages, and centered alignment

### Verification
All existing tests pass, type checking and linting succeed, and no remaining references to the removed global selectors exist in live code or documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/saldanaj97/atlaris/pull/336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->