### PR TITLE
fix(plans): harden task progress batch updates (ATLARIS-6W)

### DIFF
--- a/src/app/(app)/plans/[id]/actions.ts
+++ b/src/app/(app)/plans/[id]/actions.ts
@@ -10,8 +10,9 @@ import {
   validateTaskProgressBatchInput,
 } from '@/features/plans/task-progress/boundary';
 import { requestBoundary } from '@/lib/api/request-boundary';
+import { serializeErrorForLog } from '@/lib/errors';
 import { logger } from '@/lib/logging/logger';
-import { revalidatePath } from 'next/cache';
+import { revalidatePathsBestEffort } from '@/lib/next/revalidate-paths';
 
 interface BatchUpdateTaskProgressInput {
   planId: string;
@@ -48,9 +49,7 @@ export async function batchUpdateTaskProgressAction({
         updates,
         dbClient: db,
       });
-      for (const path of outcome.revalidatePaths) {
-        revalidatePath(path);
-      }
+      revalidatePathsBestEffort(outcome.revalidatePaths);
     } catch (error) {
       logger.error(
         {
@@ -58,7 +57,7 @@ export async function batchUpdateTaskProgressAction({
           userId: actor.id,
           updateCount: updates.length,
           taskIds: updates.map((update) => update.taskId),
-          err: error,
+          err: serializeErrorForLog(error),
         },
         'Failed to batch update task progress',
       );

--- a/src/app/(app)/plans/[id]/components/PlanDetails.tsx
+++ b/src/app/(app)/plans/[id]/components/PlanDetails.tsx
@@ -30,6 +30,11 @@ interface PlanDetailClientProps {
 export function PlanDetails({ plan }: PlanDetailClientProps): ReactElement {
   const modules = plan.modules;
   const initialStatuses = getStatusesFromModules(modules);
+  const scopedTaskIds = useMemo(
+    () =>
+      new Set(modules.flatMap((module) => module.tasks.map((task) => task.id))),
+    [modules],
+  );
 
   const flushTaskProgress = useCallback(
     async (updates: Array<{ taskId: string; status: ProgressStatus }>) => {
@@ -64,6 +69,7 @@ export function PlanDetails({ plan }: PlanDetailClientProps): ReactElement {
 
   const { statuses, handleStatusChange } = useOptimisticTaskStatusUpdates({
     initialStatuses,
+    scopedTaskIds,
     flushAction: flushTaskProgress,
     onError: handleTaskStatusError,
   });

--- a/src/app/(app)/plans/[id]/hooks/useOptimisticTaskStatusUpdates.ts
+++ b/src/app/(app)/plans/[id]/hooks/useOptimisticTaskStatusUpdates.ts
@@ -20,6 +20,7 @@ type TaskStatusUpdateErrorContext = {
 
 type UseOptimisticTaskStatusUpdatesOptions = {
   initialStatuses: Record<string, ProgressStatus>;
+  scopedTaskIds?: ReadonlySet<string>;
   flushAction: (
     updates: Array<{ taskId: string; status: ProgressStatus }>,
   ) => Promise<void>;
@@ -28,6 +29,7 @@ type UseOptimisticTaskStatusUpdatesOptions = {
 
 export function useOptimisticTaskStatusUpdates({
   initialStatuses,
+  scopedTaskIds,
   flushAction,
   onError,
 }: UseOptimisticTaskStatusUpdatesOptions): {
@@ -53,7 +55,7 @@ export function useOptimisticTaskStatusUpdates({
 
   const [_isPending, startTransition] = useTransition();
 
-  const batcher = useTaskStatusBatcher({ flushAction });
+  const batcher = useTaskStatusBatcher({ flushAction, scopedTaskIds });
 
   const handleStatusChange = useCallback(
     (taskId: string, nextStatus: ProgressStatus) => {

--- a/src/app/(app)/plans/[id]/modules/[moduleId]/actions.ts
+++ b/src/app/(app)/plans/[id]/modules/[moduleId]/actions.ts
@@ -21,8 +21,9 @@ import {
   validateTaskProgressBatchInput,
 } from '@/features/plans/task-progress/boundary';
 import { requestBoundary } from '@/lib/api/request-boundary';
+import { serializeErrorForLog } from '@/lib/errors';
 import { logger } from '@/lib/logging/logger';
-import { revalidatePath } from 'next/cache';
+import { revalidatePathsBestEffort } from '@/lib/next/revalidate-paths';
 
 export async function getModuleForPage(
   planId: string,
@@ -86,9 +87,7 @@ export async function batchUpdateModuleTaskProgressAction({
         updates,
         dbClient: db,
       });
-      for (const path of outcome.revalidatePaths) {
-        revalidatePath(path);
-      }
+      revalidatePathsBestEffort(outcome.revalidatePaths);
     } catch (error) {
       logger.error(
         {
@@ -96,7 +95,8 @@ export async function batchUpdateModuleTaskProgressAction({
           moduleId,
           userId: actor.id,
           updateCount: updates.length,
-          err: error,
+          taskIds: updates.map((update) => update.taskId),
+          err: serializeErrorForLog(error),
         },
         'Failed to batch update module task progress',
       );

--- a/src/app/(app)/plans/[id]/modules/[moduleId]/components/ModuleDetailClient.tsx
+++ b/src/app/(app)/plans/[id]/modules/[moduleId]/components/ModuleDetailClient.tsx
@@ -8,7 +8,7 @@ import { batchUpdateModuleTaskProgressAction } from '@/app/(app)/plans/[id]/modu
 import { ModuleHeader } from '@/app/(app)/plans/[id]/modules/[moduleId]/components/ModuleHeader';
 import { ModuleLessonsClient } from '@/app/(app)/plans/[id]/modules/[moduleId]/components/ModuleLessonsClient';
 import { clientLogger } from '@/lib/logging/client';
-import { type JSX, useCallback } from 'react';
+import { type JSX, useCallback, useMemo } from 'react';
 
 interface ModuleDetailClientProps {
   moduleData: ModuleDetailReadModel;
@@ -31,6 +31,10 @@ export function ModuleDetailClient({
   } = moduleData;
 
   const lessons = module.tasks;
+  const scopedTaskIds = useMemo(
+    () => new Set(lessons.map((lesson) => lesson.id)),
+    [lessons],
+  );
 
   const flushModuleTaskProgress = useCallback(
     async (updates: Array<{ taskId: string; status: ProgressStatus }>) => {
@@ -57,6 +61,7 @@ export function ModuleDetailClient({
 
   const { statuses, handleStatusChange } = useOptimisticTaskStatusUpdates({
     initialStatuses,
+    scopedTaskIds,
     flushAction: flushModuleTaskProgress,
     onError: handleTaskStatusError,
   });

--- a/src/hooks/useTaskStatusBatcher.ts
+++ b/src/hooks/useTaskStatusBatcher.ts
@@ -25,6 +25,8 @@ export interface TaskStatusUpdate {
 
 interface UseTaskStatusBatcherOptions {
   flushAction: (updates: TaskStatusUpdate[]) => Promise<void>;
+  /** When set, pending/flushed updates for unknown task ids are dropped (navigation/regen). */
+  scopedTaskIds?: ReadonlySet<string>;
   debounceMs?: number;
   maxWaitMs?: number;
 }
@@ -44,6 +46,7 @@ const DEFAULT_MAX_WAIT_MS = 5000;
  */
 export function useTaskStatusBatcher({
   flushAction,
+  scopedTaskIds,
   debounceMs = DEFAULT_DEBOUNCE_MS,
   maxWaitMs = DEFAULT_MAX_WAIT_MS,
 }: UseTaskStatusBatcherOptions): {
@@ -59,6 +62,8 @@ export function useTaskStatusBatcher({
   const firstQueuedAtRef = useRef<number | null>(null);
   const flushActionRef = useRef(flushAction);
   flushActionRef.current = flushAction;
+  const scopedTaskIdsRef = useRef(scopedTaskIds);
+  scopedTaskIdsRef.current = scopedTaskIds;
 
   const clearScheduledFlush = useCallback(() => {
     if (timerRef.current) {
@@ -74,6 +79,32 @@ export function useTaskStatusBatcher({
     firstQueuedAtRef.current = null;
   }, []);
 
+  const dropOutOfScopePending = useCallback(() => {
+    const allowed = scopedTaskIdsRef.current;
+    if (!allowed) return;
+
+    const pending = pendingRef.current;
+    let droppedCount = 0;
+
+    for (const [taskId, entry] of pending) {
+      if (allowed.has(taskId)) continue;
+      droppedCount += 1;
+      for (const resolver of entry.resolvers) {
+        resolver.resolve();
+      }
+      pending.delete(taskId);
+    }
+
+    if (droppedCount > 0) {
+      clientLogger.warn('Dropped out-of-scope task progress updates', {
+        droppedCount,
+      });
+      if (pending.size === 0) {
+        clearScheduledFlush();
+      }
+    }
+  }, [clearScheduledFlush]);
+
   const flush = useCallback(async () => {
     clearScheduledFlush();
 
@@ -83,17 +114,40 @@ export function useTaskStatusBatcher({
     const snapshot = new Map(pending);
     pending.clear();
 
-    const updates: TaskStatusUpdate[] = Array.from(snapshot.entries()).map(
+    const allowed = scopedTaskIdsRef.current;
+    const inScopeEntries: Array<[string, PendingUpdate]> = [];
+    let skippedCount = 0;
+
+    for (const entry of snapshot) {
+      if (!allowed || allowed.has(entry[0])) {
+        inScopeEntries.push(entry);
+        continue;
+      }
+      skippedCount += 1;
+      for (const resolver of entry[1].resolvers) {
+        resolver.resolve();
+      }
+    }
+
+    if (skippedCount > 0) {
+      clientLogger.warn('Skipped out-of-scope task progress flush', {
+        skippedCount,
+      });
+    }
+
+    if (inScopeEntries.length === 0) return;
+
+    const updates: TaskStatusUpdate[] = inScopeEntries.map(
       ([taskId, { targetStatus }]) => ({ taskId, status: targetStatus }),
     );
 
     try {
       await flushActionRef.current(updates);
-      for (const [, { resolvers }] of snapshot) {
+      for (const [, { resolvers }] of inScopeEntries) {
         for (const r of resolvers) r.resolve();
       }
     } catch (error) {
-      for (const [, { resolvers }] of snapshot) {
+      for (const [, { resolvers }] of inScopeEntries) {
         for (const r of resolvers) r.reject(error);
       }
       const { errorMessage, errorStack } = getLoggableErrorDetails(error);
@@ -162,6 +216,10 @@ export function useTaskStatusBatcher({
     },
     [clearScheduledFlush, debounceMs, flush, maxWaitMs],
   );
+
+  useEffect(() => {
+    dropOutOfScopePending();
+  }, [dropOutOfScopePending, scopedTaskIds]);
 
   useEffect(() => {
     return () => {

--- a/src/lib/next/revalidate-paths.ts
+++ b/src/lib/next/revalidate-paths.ts
@@ -1,3 +1,4 @@
+import { serializeErrorForLog } from '@/lib/errors';
 import { logger } from '@/lib/logging/logger';
 import { revalidatePath } from 'next/cache';
 
@@ -11,7 +12,7 @@ export function revalidatePathsBestEffort(paths: readonly string[]): void {
       revalidatePath(path);
     } catch (error) {
       logger.warn(
-        { path, err: error },
+        { path, err: serializeErrorForLog(error) },
         'Failed to revalidate path after mutation',
       );
     }

--- a/src/lib/next/revalidate-paths.ts
+++ b/src/lib/next/revalidate-paths.ts
@@ -1,0 +1,19 @@
+import { logger } from '@/lib/logging/logger';
+import { revalidatePath } from 'next/cache';
+
+/**
+ * Revalidates app paths after a successful mutation without failing the mutation
+ * when cache invalidation throws (e.g. transient Next cache/runtime issues).
+ */
+export function revalidatePathsBestEffort(paths: readonly string[]): void {
+  for (const path of paths) {
+    try {
+      revalidatePath(path);
+    } catch (error) {
+      logger.warn(
+        { path, err: error },
+        'Failed to revalidate path after mutation',
+      );
+    }
+  }
+}

--- a/tests/unit/app/plans/actions.spec.ts
+++ b/tests/unit/app/plans/actions.spec.ts
@@ -150,6 +150,38 @@ describe('batchUpdateTaskProgressAction', () => {
     expect(revalidatePathMock).toHaveBeenCalledWith('/plans');
   });
 
+  it('succeeds when persistence succeeds but revalidatePath throws', async () => {
+    requestBoundaryActionMock.mockImplementationOnce(
+      async (fn: (scope: RequestScope) => Promise<void>) =>
+        fn(makeActionTestScope()),
+    );
+    applyTaskProgressUpdatesMock.mockResolvedValueOnce({
+      progress: [],
+      revalidatePaths: ['/plans/plan-123', '/plans'],
+      visibleState: { appliedByTaskId: {} },
+    });
+    revalidatePathMock.mockImplementation((path: string) => {
+      if (path === '/plans') {
+        throw new Error('revalidate failed');
+      }
+    });
+
+    await expect(
+      batchUpdateTaskProgressAction({
+        planId: 'plan-123',
+        updates: [{ taskId: 't1', status: 'completed' }],
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(applyTaskProgressUpdatesMock).toHaveBeenCalledOnce();
+    expect(revalidatePathMock).toHaveBeenCalledWith('/plans/plan-123');
+    expect(revalidatePathMock).toHaveBeenCalledWith('/plans');
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/plans' }),
+      'Failed to revalidate path after mutation',
+    );
+  });
+
   it('maps boundary persistence errors to generic user message', async () => {
     requestBoundaryActionMock.mockImplementationOnce(
       async (fn: (scope: RequestScope) => Promise<void>) =>
@@ -166,7 +198,11 @@ describe('batchUpdateTaskProgressAction', () => {
     ).rejects.toThrow('Unable to update task progress right now.');
 
     expect(loggerMock.error).toHaveBeenCalledWith(
-      expect.objectContaining({ err: persistenceError }),
+      expect.objectContaining({
+        err: expect.objectContaining({
+          message: 'db exploded',
+        }),
+      }),
       'Failed to batch update task progress',
     );
   });

--- a/tests/unit/app/plans/actions.spec.ts
+++ b/tests/unit/app/plans/actions.spec.ts
@@ -160,7 +160,12 @@ describe('batchUpdateTaskProgressAction', () => {
       revalidatePaths: ['/plans/plan-123', '/plans'],
       visibleState: { appliedByTaskId: {} },
     });
-    revalidatePathMock.mockImplementation((path: string) => {
+    revalidatePathMock.mockImplementationOnce((path: string) => {
+      if (path === '/plans') {
+        throw new Error('revalidate failed');
+      }
+    });
+    revalidatePathMock.mockImplementationOnce((path: string) => {
       if (path === '/plans') {
         throw new Error('revalidate failed');
       }

--- a/tests/unit/app/plans/modules/actions.spec.ts
+++ b/tests/unit/app/plans/modules/actions.spec.ts
@@ -158,7 +158,17 @@ describe('batchUpdateModuleTaskProgressAction', () => {
       revalidatePaths: ['/plans/p1/modules/m1', '/plans/p1', '/plans'],
       visibleState: { appliedByTaskId: {} },
     });
-    revalidatePathMock.mockImplementation((path: string) => {
+    revalidatePathMock.mockImplementationOnce((path: string) => {
+      if (path === '/plans/p1') {
+        throw new Error('revalidate failed');
+      }
+    });
+    revalidatePathMock.mockImplementationOnce((path: string) => {
+      if (path === '/plans/p1') {
+        throw new Error('revalidate failed');
+      }
+    });
+    revalidatePathMock.mockImplementationOnce((path: string) => {
       if (path === '/plans/p1') {
         throw new Error('revalidate failed');
       }

--- a/tests/unit/app/plans/modules/actions.spec.ts
+++ b/tests/unit/app/plans/modules/actions.spec.ts
@@ -148,4 +148,57 @@ describe('batchUpdateModuleTaskProgressAction', () => {
     expect(revalidatePathMock).toHaveBeenCalledWith('/plans/p1');
     expect(revalidatePathMock).toHaveBeenCalledWith('/plans');
   });
+
+  it('succeeds when persistence succeeds but revalidatePath throws', async () => {
+    requestBoundaryActionMock.mockImplementationOnce(
+      mockRequestBoundaryAction(makeActionTestScope()),
+    );
+    applyTaskProgressUpdatesMock.mockResolvedValueOnce({
+      progress: [],
+      revalidatePaths: ['/plans/p1/modules/m1', '/plans/p1', '/plans'],
+      visibleState: { appliedByTaskId: {} },
+    });
+    revalidatePathMock.mockImplementation((path: string) => {
+      if (path === '/plans/p1') {
+        throw new Error('revalidate failed');
+      }
+    });
+
+    await expect(
+      batchUpdateModuleTaskProgressAction({
+        planId: 'p1',
+        moduleId: 'm1',
+        updates: [{ taskId: 't1', status: 'completed' }],
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/plans/p1' }),
+      'Failed to revalidate path after mutation',
+    );
+  });
+
+  it('maps boundary persistence errors to generic user message', async () => {
+    requestBoundaryActionMock.mockImplementationOnce(
+      mockRequestBoundaryAction(makeActionTestScope()),
+    );
+    const persistenceError = new Error('db exploded');
+    applyTaskProgressUpdatesMock.mockRejectedValueOnce(persistenceError);
+
+    await expect(
+      batchUpdateModuleTaskProgressAction({
+        planId: 'p1',
+        moduleId: 'm1',
+        updates: [{ taskId: 't1', status: 'completed' }],
+      }),
+    ).rejects.toThrow('Unable to update task progress right now.');
+
+    expect(loggerMock.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskIds: ['t1'],
+        err: expect.objectContaining({ message: 'db exploded' }),
+      }),
+      'Failed to batch update module task progress',
+    );
+  });
 });

--- a/tests/unit/hooks/useTaskStatusBatcher.spec.tsx
+++ b/tests/unit/hooks/useTaskStatusBatcher.spec.tsx
@@ -7,6 +7,17 @@ import {
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+const { clientLoggerWarnMock } = vi.hoisted(() => ({
+  clientLoggerWarnMock: vi.fn(),
+}));
+
+vi.mock('@/lib/logging/client', () => ({
+  clientLogger: {
+    error: vi.fn(),
+    warn: clientLoggerWarnMock,
+  },
+}));
+
 const NOT_STARTED: ProgressStatus = 'not_started';
 const IN_PROGRESS: ProgressStatus = 'in_progress';
 const COMPLETED: ProgressStatus = 'completed';
@@ -157,5 +168,73 @@ describe('useTaskStatusBatcher', () => {
     ]);
 
     await expect(nextBatchPromise).resolves.toBeUndefined();
+  });
+
+  it('drops out-of-scope pending updates when scoped task ids change', async () => {
+    vi.useFakeTimers();
+
+    const flushAction = vi.fn<(updates: TaskStatusUpdate[]) => Promise<void>>();
+    flushAction.mockResolvedValue(undefined);
+
+    const scopedTaskIds = new Set(['task-1']);
+    const { result, rerender } = renderHook(
+      ({ scoped }) =>
+        useTaskStatusBatcher({
+          flushAction,
+          scopedTaskIds: scoped,
+          debounceMs: 100,
+          maxWaitMs: 250,
+        }),
+      { initialProps: { scoped: scopedTaskIds } },
+    );
+
+    let stalePromise: Promise<void> = Promise.resolve();
+    act(() => {
+      stalePromise = result.current.queue('task-stale', COMPLETED, NOT_STARTED);
+    });
+
+    rerender({ scoped: new Set(['task-2']) });
+
+    await expect(stalePromise).resolves.toBeUndefined();
+    expect(flushAction).not.toHaveBeenCalled();
+    expect(clientLoggerWarnMock).toHaveBeenCalledWith(
+      'Dropped out-of-scope task progress updates',
+      expect.objectContaining({ droppedCount: 1 }),
+    );
+  });
+
+  it('flushes only in-scope updates when scoped task ids are provided', async () => {
+    vi.useFakeTimers();
+
+    const flushAction = vi.fn<(updates: TaskStatusUpdate[]) => Promise<void>>();
+    flushAction.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() =>
+      useTaskStatusBatcher({
+        flushAction,
+        scopedTaskIds: new Set(['task-1']),
+        debounceMs: 100,
+        maxWaitMs: 250,
+      }),
+    );
+
+    let inScopePromise: Promise<void> = Promise.resolve();
+    let stalePromise: Promise<void> = Promise.resolve();
+    act(() => {
+      inScopePromise = result.current.queue('task-1', COMPLETED, NOT_STARTED);
+      stalePromise = result.current.queue('task-stale', COMPLETED, NOT_STARTED);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    expect(flushAction).toHaveBeenCalledWith([
+      { taskId: 'task-1', status: COMPLETED },
+    ]);
+    await expect(Promise.all([inScopePromise, stalePromise])).resolves.toEqual([
+      undefined,
+      undefined,
+    ]);
   });
 });

--- a/tests/unit/hooks/useTaskStatusBatcher.spec.tsx
+++ b/tests/unit/hooks/useTaskStatusBatcher.spec.tsx
@@ -5,6 +5,7 @@ import {
   useTaskStatusBatcher,
 } from '@/hooks/useTaskStatusBatcher';
 import { act, renderHook } from '@testing-library/react';
+import { createId } from '@tests/fixtures/ids';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const { clientLoggerWarnMock } = vi.hoisted(() => ({
@@ -176,7 +177,10 @@ describe('useTaskStatusBatcher', () => {
     const flushAction = vi.fn<(updates: TaskStatusUpdate[]) => Promise<void>>();
     flushAction.mockResolvedValue(undefined);
 
-    const scopedTaskIds = new Set(['task-1']);
+    const id1 = createId('task');
+    const id2 = createId('task');
+    const staleId = createId('task');
+    const scopedTaskIds = new Set([id1]);
     const { result, rerender } = renderHook(
       ({ scoped }) =>
         useTaskStatusBatcher({
@@ -190,10 +194,10 @@ describe('useTaskStatusBatcher', () => {
 
     let stalePromise: Promise<void> = Promise.resolve();
     act(() => {
-      stalePromise = result.current.queue('task-stale', COMPLETED, NOT_STARTED);
+      stalePromise = result.current.queue(staleId, COMPLETED, NOT_STARTED);
     });
 
-    rerender({ scoped: new Set(['task-2']) });
+    rerender({ scoped: new Set([id2]) });
 
     await expect(stalePromise).resolves.toBeUndefined();
     expect(flushAction).not.toHaveBeenCalled();
@@ -209,10 +213,12 @@ describe('useTaskStatusBatcher', () => {
     const flushAction = vi.fn<(updates: TaskStatusUpdate[]) => Promise<void>>();
     flushAction.mockResolvedValue(undefined);
 
+    const id1 = createId('task');
+    const staleId = createId('task');
     const { result } = renderHook(() =>
       useTaskStatusBatcher({
         flushAction,
-        scopedTaskIds: new Set(['task-1']),
+        scopedTaskIds: new Set([id1]),
         debounceMs: 100,
         maxWaitMs: 250,
       }),
@@ -221,8 +227,8 @@ describe('useTaskStatusBatcher', () => {
     let inScopePromise: Promise<void> = Promise.resolve();
     let stalePromise: Promise<void> = Promise.resolve();
     act(() => {
-      inScopePromise = result.current.queue('task-1', COMPLETED, NOT_STARTED);
-      stalePromise = result.current.queue('task-stale', COMPLETED, NOT_STARTED);
+      inScopePromise = result.current.queue(id1, COMPLETED, NOT_STARTED);
+      stalePromise = result.current.queue(staleId, COMPLETED, NOT_STARTED);
     });
 
     await act(async () => {
@@ -230,7 +236,7 @@ describe('useTaskStatusBatcher', () => {
     });
 
     expect(flushAction).toHaveBeenCalledWith([
-      { taskId: 'task-1', status: COMPLETED },
+      { taskId: id1, status: COMPLETED },
     ]);
     await expect(Promise.all([inScopePromise, stalePromise])).resolves.toEqual([
       undefined,

--- a/tests/unit/lib/next/revalidate-paths.spec.ts
+++ b/tests/unit/lib/next/revalidate-paths.spec.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { revalidatePathMock, loggerWarnMock } = vi.hoisted(() => ({
+  revalidatePathMock: vi.fn(),
+  loggerWarnMock: vi.fn(),
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: revalidatePathMock,
+}));
+
+vi.mock('@/lib/logging/logger', () => ({
+  logger: {
+    warn: loggerWarnMock,
+  },
+}));
+
+import { revalidatePathsBestEffort } from '@/lib/next/revalidate-paths';
+
+describe('revalidatePathsBestEffort', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('revalidates every path and continues when one path throws', () => {
+    revalidatePathMock.mockImplementation((path: string) => {
+      if (path === '/plans/bad') {
+        throw new Error('revalidate failed');
+      }
+    });
+
+    revalidatePathsBestEffort(['/plans/ok', '/plans/bad', '/plans']);
+
+    expect(revalidatePathMock).toHaveBeenCalledTimes(3);
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/plans/bad' }),
+      'Failed to revalidate path after mutation',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Stop reporting task progress mutations as failed when `revalidatePath` throws after persistence succeeds (`revalidatePathsBestEffort`).
- Drop or skip out-of-scope task IDs in the client batcher before flush (navigation, unmount, plan regeneration) to avoid `One or more tasks not found.` batches.
- Improve server error logs (`serializeErrorForLog`, module `taskIds`) for Sentry correlation on remaining failures.

Fixes #342 / Sentry `ATLARIS-6W`.

## Root cause note

Sentry event details were not available in the investigation environment (no local auth token). The fix targets the two most likely masked causes from code path analysis; confirm via latest event `error.cause.message` after deploy.

## Test plan

- [x] `pnpm exec vitest run --project unit` on changed specs (actions, batcher, revalidate helper)
- [x] `pnpm test:changed`
- [x] `pnpm check:full`
- [ ] After deploy: verify `ATLARIS-6W` volume drops in Sentry; spot-check `cause.message` on any remaining events

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible success/failure for progress updates and drops client batches for out-of-scope tasks, which could briefly desync UI vs server if mis-scoped; persistence and auth paths are unchanged.
> 
> **Overview**
> Hardens plan/module **task progress** batch updates so users see fewer false failures and Sentry gets clearer signals (ATLARIS-6W / #342).
> 
> **Server:** Plan and module batch actions now call **`revalidatePathsBestEffort`** instead of failing the whole mutation when **`revalidatePath`** throws after DB success; failures are logged as warnings. Error logs use **`serializeErrorForLog`** and include **`taskIds`** on module failures.
> 
> **Client:** Plan and module UIs pass **`scopedTaskIds`** into optimistic updates. **`useTaskStatusBatcher`** drops or skips queued updates for task IDs no longer on the current plan/module (navigation/regeneration), resolving those promises locally and only flushing in-scope IDs.
> 
> **Tests:** Coverage for best-effort revalidation, scoped batcher behavior, and updated action error logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40309e4728417e5cce27ee498504e3402d43458d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Harden task progress batch updates to reduce spurious failures reported in Sentry (ATLARIS-6W). The change separates non-critical cache revalidation from persistence success, scopes client-side optimistic batching to the current UI (plan/module) to avoid stale updates, and improves server-side error serialization and logging for better Sentry correlation.

## Key changes
- Fault-tolerant revalidation: introduce revalidatePathsBestEffort(paths) which revalidates each Next.js path inside per-path try/catch blocks and logs warnings for failures so persistence success is preserved.
- Scoped client batching: add optional scopedTaskIds (ReadonlySet<string>) to optimistic update hooks and useTaskStatusBatcher. The batcher drops out-of-scope queued updates (resolves their promises locally and logs a warning) and only includes in-scope updates in flush requests.
- Flush semantics: flush filters pending entries to in-scope updates; out-of-scope entries are settled locally and do not trigger network requests or error reporting.
- Improved observability: server actions now use serializeErrorForLog and include taskIds in error logs to improve Sentry grouping and root-cause analysis.
- Tests: add/update unit tests covering best-effort revalidation, scoped batcher behavior (dropping out-of-scope updates and scoped flushes), revalidation failure handling, and updated error-logging expectations.

## Files modified (high level)
- src/lib/next/revalidate-paths.ts — new revalidatePathsBestEffort helper
- src/hooks/useTaskStatusBatcher.ts — add scopedTaskIds support; drop out-of-scope pending updates; scope flush logic
- src/app/(app)/plans/[id]/hooks/useOptimisticTaskStatusUpdates.ts — accept/propagate scopedTaskIds
- src/app/(app)/plans/[id]/components/PlanDetails.tsx and src/app/(app)/plans/[id]/modules/[moduleId]/components/ModuleDetailClient.tsx — compute and pass scopedTaskIds
- src/app/(app)/plans/[id]/actions.ts and src/app/(app)/plans/[id]/modules/[moduleId]/actions.ts — use best-effort revalidation and serialized error logging (include taskIds)
- tests/unit/... — new/updated specs for actions, batcher, and revalidation helper

## Testing & deployment
- Run unit tests: vitest (pnpm test:changed, pnpm check:full). Updated specs exercise revalidation failures and scoped batching.
- Post-deploy: monitor Sentry ATLARIS-6W volume, inspect enriched logged fields (planId, moduleId, updateCount, taskIds, underlying error / error.cause.message) to validate reduction of false positives and identify remaining root causes.

## Fixes
- Fixes issue `#342` (Sentry ATLARIS-6W: Unable to update task progress right now).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/saldanaj97/atlaris/pull/343?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->