### PR TITLE
fix(security): guard workflow callback routes in proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,12 @@ PLAN_GENERATION_WORKFLOW_ENABLED=false
 # Also requires REGENERATION_QUEUE_ENABLED=true (and inline processing or worker cron).
 PLAN_REGENERATION_WORKFLOW_ENABLED=false
 
+# Shared bearer token for non-Vercel workflow callback routes (/.well-known/workflow/v1/*).
+# Required on self-hosted production. Not used on Vercel (queue consumer security).
+# Generate any strong random string (e.g. openssl rand -hex 32). Local dev with pnpm dev:workflow
+# does not need this unless you harden local callbacks beyond the default x-vqs header check.
+WORKFLOW_CALLBACK_TOKEN=
+
 # --- Regeneration queue (required for regeneration workflow; separate from Workflow SDK) ---
 # Master switch for POST .../regenerate enqueue and worker drain.
 REGENERATION_QUEUE_ENABLED=true

--- a/docs/architecture/auth-and-data-layer.md
+++ b/docs/architecture/auth-and-data-layer.md
@@ -48,15 +48,22 @@ export const GET = withAuth(async ({ user }) => {
 
 // Server action (preferred) — requestBoundary.action
 import { requestBoundary } from '@/lib/api/request-boundary';
-export async function getPlanForPage(planId: string) {
-  const result = await requestBoundary.action(async ({ actor }) => {
-    return getLearningPlanDetail(planId, actor.id);
+export async function updatePlanAction(planId: string) {
+  const result = await requestBoundary.action(async ({ actor, db }) => {
+    return updatePlan(planId, actor.id, db);
   });
-  if (result === null) return unauthorized();
+  if (result === null) throw new Error('You must be signed in.');
   return result;
 }
 
-// Server component (preferred) — requestBoundary.component
+// Server component (preferred) — requestBoundary.component + page data module
+import { loadPlanForPage } from '@/app/(app)/plans/[id]/plan-page-data';
+export async function PlanDetailContent({ planId }: { planId: string }) {
+  const planResult = await loadPlanForPage(planId);
+  // handle planResult (success / NOT_FOUND / UNAUTHORIZED)
+}
+
+// Lower-level component boundary (same as loadPlanForPage internally)
 import { requestBoundary } from '@/lib/api/request-boundary';
 const tier = await requestBoundary.component(
   async ({ actor }) => actor.subscriptionTier,

--- a/docs/architecture/workflow-sdk.md
+++ b/docs/architecture/workflow-sdk.md
@@ -7,7 +7,21 @@
 
 Atlaris uses [Workflow SDK](https://workflow-sdk.dev) for durable, replay-safe orchestration behind feature flags. Postgres remains the source of truth for user-visible status; workflow run IDs are stored for correlation only.
 
-Base wiring: `withWorkflow()` in `next.config.ts`, `workflow` TypeScript plugin in `tsconfig.json`, and `/.well-known/workflow/` excluded from `src/proxy.ts` / maintenance redirects.
+Base wiring: `withWorkflow()` in `next.config.ts`, `workflow` TypeScript plugin in `tsconfig.json`, and `/.well-known/workflow/` handled by an early proxy auth branch (see [Callback security](#callback-security)).
+
+## Callback security
+
+Workflow queue callbacks hit `/.well-known/workflow/v1/*` from the Workflow SDK runtime, not from end users.
+
+| Deployment | Protection |
+| ---------- | ---------- |
+| **Vercel (production/preview)** | Workflow SDK registers handlers with `experimentalTriggers` so only [Vercel Queue](https://vercel.com/docs/queues) can invoke them. Proxy allows these routes through without an app token. |
+| **Local dev (`pnpm dev:workflow`)** | Proxy allows health checks (`HEAD`/`GET`/`OPTIONS` with `?__health`) and local-world queue callbacks that include `x-vqs-*` headers. Bare forged POSTs without those headers are rejected with `401`. |
+| **Self-hosted / non-Vercel production** | Proxy requires `WORKFLOW_CALLBACK_TOKEN` via `Authorization: Bearer` or `x-workflow-callback-token`. Missing token configuration returns `503`. |
+
+Webhook resume routes (`/.well-known/workflow/v1/webhook/:token`) keep the SDK's URL-token auth and bypass the callback token gate.
+
+Implementation: `resolveWorkflowCallbackAccess()` in `src/lib/proxy/workflow-callback-auth.ts`, invoked from `src/proxy.ts` before Clerk, maintenance mode, and CSP decoration. The proxy matcher includes `/.well-known/workflow/*`; maintenance bypass for that prefix remains in `middleware-policy.ts`.
 
 ## Feature flags (`workflowEnv`)
 

--- a/docs/development/environment.md
+++ b/docs/development/environment.md
@@ -66,6 +66,7 @@ Parsed in `src/lib/config/env/workflow.ts` via `workflowEnv`. All default **off*
 | `MODULE_LESSON_WORKFLOW_ENABLED`     | Routes `POST .../lesson-content/generate` through a durable workflow (HTTP 202 while in flight)       | No       |
 | `PLAN_REGENERATION_WORKFLOW_ENABLED` | Routes regeneration enqueue and worker drain through a durable workflow                               | No       |
 | `PLAN_GENERATION_WORKFLOW_ENABLED`   | Runs plan create/retry provider/finalization in a workflow after reservation; SSE transport unchanged | No       |
+| `WORKFLOW_CALLBACK_TOKEN`            | Shared bearer token for non-Vercel workflow callback routes (`/.well-known/workflow/v1/flow`, `/step`). Not used on Vercel-hosted deploys (queue consumer security). | Yes on self-hosted production |
 
 **Accepted values:** `true`, `false`, `1`, or `0` (case-insensitive). Any other value throws `EnvValidationError` at startup.
 

--- a/docs/security/security-audit-checklist.md
+++ b/docs/security/security-audit-checklist.md
@@ -83,6 +83,7 @@
 - [ ] API versioning doesn't accidentally expose deprecated insecure endpoints.
 - [ ] OPTIONS/HEAD methods don't bypass auth checks.
 - [ ] Verify no sensitive operations possible via GET requests (all mutations use POST/PUT/DELETE).
+- [ ] Workflow SDK callback routes (`/.well-known/workflow/v1/flow`, `/step`) are not reachable via unauthenticated forged POSTs outside Vercel queue consumer security; self-hosted production sets `WORKFLOW_CALLBACK_TOKEN`.
 
 ### 8) Error handling & information leakage
 

--- a/src/app/(app)/plans/[id]/actions.ts
+++ b/src/app/(app)/plans/[id]/actions.ts
@@ -30,10 +30,14 @@ interface BatchUpdateTaskProgressInput {
  *
  * React Doctor note: `server-auth-actions` is a false positive for actions using this wrapper.
  */
+export type BatchUpdateTaskProgressResult = {
+  readonly revalidateFailed: boolean;
+};
+
 export async function batchUpdateTaskProgressAction({
   planId,
   updates,
-}: BatchUpdateTaskProgressInput): Promise<void> {
+}: BatchUpdateTaskProgressInput): Promise<BatchUpdateTaskProgressResult | void> {
   if (updates.length === 0) return;
 
   const result = await requestBoundary.action(async ({ actor, db }) => {
@@ -46,7 +50,10 @@ export async function batchUpdateTaskProgressAction({
         updates,
         dbClient: db,
       });
-      revalidatePathsBestEffort(outcome.revalidatePaths);
+      const { failedPaths } = revalidatePathsBestEffort(
+        outcome.revalidatePaths,
+      );
+      return { revalidateFailed: failedPaths.length > 0 };
     } catch (error) {
       logger.error(
         {
@@ -67,4 +74,6 @@ export async function batchUpdateTaskProgressAction({
   if (result === null) {
     throw new Error('You must be signed in to update progress.');
   }
+
+  return result;
 }

--- a/src/app/(app)/plans/[id]/actions.ts
+++ b/src/app/(app)/plans/[id]/actions.ts
@@ -1,10 +1,7 @@
 'use server';
 
-import type { PlanAccessResult } from '@/app/(app)/plans/[id]/types';
 import type { ProgressStatus } from '@/shared/types/db.types';
 
-import { planError, planSuccess } from './helpers';
-import { getPlanDetailForRead } from '@/features/plans/read-projection/service';
 import {
   applyTaskProgressUpdates,
   validateTaskProgressBatchInput,
@@ -70,46 +67,4 @@ export async function batchUpdateTaskProgressAction({
   if (result === null) {
     throw new Error('You must be signed in to update progress.');
   }
-}
-
-/**
- * Server action to fetch plan detail data with RLS enforcement.
- * Uses `requestBoundary.action()` for auth and a request-scoped RLS `db` (see batch action comment).
- * Returns a typed result with explicit error codes for proper handling.
- *
- * Error codes:
- * - UNAUTHORIZED: User is not authenticated
- * - NOT_FOUND: Plan does not exist or user doesn't have access
- * - INTERNAL_ERROR: Unexpected error during fetch
- */
-export async function getPlanForPage(
-  planId: string,
-): Promise<PlanAccessResult> {
-  const boundaryResult = await requestBoundary.action(async ({ actor, db }) => {
-    const plan = await getPlanDetailForRead({
-      planId,
-      userId: actor.id,
-      dbClient: db,
-    });
-    if (!plan) {
-      logger.debug(
-        { planId, userId: actor.id },
-        'Plan not found or user does not have access',
-      );
-      return planError(
-        'NOT_FOUND',
-        'This plan does not exist or you do not have access to it.',
-      );
-    }
-    return planSuccess(plan);
-  });
-
-  if (!boundaryResult) {
-    logger.debug({ planId }, 'Plan access denied: user not authenticated');
-    return planError(
-      'UNAUTHORIZED',
-      'You must be signed in to view this plan.',
-    );
-  }
-  return boundaryResult;
 }

--- a/src/app/(app)/plans/[id]/components/PlanDetailContent.tsx
+++ b/src/app/(app)/plans/[id]/components/PlanDetailContent.tsx
@@ -2,8 +2,8 @@ import type { JSX } from 'react';
 
 import { PlanDetailPageError } from './Error';
 import { PlanDetails } from './PlanDetails';
-import { getPlanForPage } from '@/app/(app)/plans/[id]/actions';
 import { getPlanError, isPlanSuccess } from '@/app/(app)/plans/[id]/helpers';
+import { loadPlanForPage } from '@/app/(app)/plans/[id]/plan-page-data';
 import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Surface } from '@/components/ui/surface';
@@ -20,7 +20,7 @@ interface PlanDetailContentProps {
  * Wrapped in Suspense boundary by the parent page.
  */
 export async function PlanDetailContent({ planId }: PlanDetailContentProps) {
-  const planResult = await getPlanForPage(planId);
+  const planResult = await loadPlanForPage(planId);
 
   if (!isPlanSuccess(planResult)) {
     const error = getPlanError(planResult);

--- a/src/app/(app)/plans/[id]/components/PlanDetails.tsx
+++ b/src/app/(app)/plans/[id]/components/PlanDetails.tsx
@@ -19,6 +19,7 @@ import { clientLogger } from '@/lib/logging/client';
 import { ArrowLeft, Trash2 } from 'lucide-react';
 import Link from 'next/link';
 import { type ReactElement, useCallback, useMemo } from 'react';
+import { toast } from 'sonner';
 
 interface PlanDetailClientProps {
   plan: ClientPlanDetail;
@@ -38,7 +39,13 @@ export function PlanDetails({ plan }: PlanDetailClientProps): ReactElement {
 
   const flushTaskProgress = useCallback(
     async (updates: Array<{ taskId: string; status: ProgressStatus }>) => {
-      await batchUpdateTaskProgressAction({ planId: plan.id, updates });
+      const result = await batchUpdateTaskProgressAction({
+        planId: plan.id,
+        updates,
+      });
+      if (result?.revalidateFailed) {
+        toast.message('Progress saved. Refresh if the page looks stale.');
+      }
     },
     [plan.id],
   );

--- a/src/app/(app)/plans/[id]/modules/[moduleId]/actions.ts
+++ b/src/app/(app)/plans/[id]/modules/[moduleId]/actions.ts
@@ -29,11 +29,15 @@ interface BatchUpdateModuleTaskProgressInput {
  * Server action to batch update multiple task progress records from the module detail page.
  * Delegates validation, scope checks, persistence, and path selection to `applyTaskProgressUpdates`.
  */
+export type BatchUpdateModuleTaskProgressResult = {
+  readonly revalidateFailed: boolean;
+};
+
 export async function batchUpdateModuleTaskProgressAction({
   planId,
   moduleId,
   updates,
-}: BatchUpdateModuleTaskProgressInput): Promise<void> {
+}: BatchUpdateModuleTaskProgressInput): Promise<BatchUpdateModuleTaskProgressResult | void> {
   if (updates.length === 0) return;
 
   const result = await requestBoundary.action(async ({ actor, db }) => {
@@ -47,7 +51,10 @@ export async function batchUpdateModuleTaskProgressAction({
         updates,
         dbClient: db,
       });
-      revalidatePathsBestEffort(outcome.revalidatePaths);
+      const { failedPaths } = revalidatePathsBestEffort(
+        outcome.revalidatePaths,
+      );
+      return { revalidateFailed: failedPaths.length > 0 };
     } catch (error) {
       logger.error(
         {
@@ -69,4 +76,6 @@ export async function batchUpdateModuleTaskProgressAction({
   if (result === null) {
     throw new Error('You must be signed in to update progress.');
   }
+
+  return result;
 }

--- a/src/app/(app)/plans/[id]/modules/[moduleId]/actions.ts
+++ b/src/app/(app)/plans/[id]/modules/[moduleId]/actions.ts
@@ -8,14 +8,8 @@
  * - Module ownership is validated through plan ownership
  */
 
-import type { ModuleAccessResult } from '@/app/(app)/plans/[id]/modules/[moduleId]/types';
 import type { ProgressStatus } from '@/shared/types/db.types';
 
-import {
-  moduleError,
-  moduleSuccess,
-} from '@/app/(app)/plans/[id]/modules/[moduleId]/helpers';
-import { getModuleDetailForRead } from '@/features/plans/read-projection/service';
 import {
   applyTaskProgressUpdates,
   validateTaskProgressBatchInput,
@@ -24,40 +18,6 @@ import { requestBoundary } from '@/lib/api/request-boundary';
 import { serializeErrorForLog } from '@/lib/errors';
 import { logger } from '@/lib/logging/logger';
 import { revalidatePathsBestEffort } from '@/lib/next/revalidate-paths';
-
-export async function getModuleForPage(
-  planId: string,
-  moduleId: string,
-): Promise<ModuleAccessResult> {
-  const boundaryResult = await requestBoundary.action(async ({ actor, db }) => {
-    const moduleData = await getModuleDetailForRead({
-      planId,
-      moduleId,
-      userId: actor.id,
-      dbClient: db,
-    });
-    if (!moduleData) {
-      logger.debug(
-        { moduleId, userId: actor.id },
-        'Module not found or user does not have access',
-      );
-      return moduleError(
-        'NOT_FOUND',
-        'This module does not exist or you do not have access to it.',
-      );
-    }
-    return moduleSuccess(moduleData);
-  });
-
-  if (!boundaryResult) {
-    logger.debug({ moduleId }, 'Module access denied: user not authenticated');
-    return moduleError(
-      'UNAUTHORIZED',
-      'You must be signed in to view this module.',
-    );
-  }
-  return boundaryResult;
-}
 
 interface BatchUpdateModuleTaskProgressInput {
   planId: string;

--- a/src/app/(app)/plans/[id]/modules/[moduleId]/components/ModuleDetailClient.tsx
+++ b/src/app/(app)/plans/[id]/modules/[moduleId]/components/ModuleDetailClient.tsx
@@ -9,6 +9,7 @@ import { ModuleHeader } from '@/app/(app)/plans/[id]/modules/[moduleId]/componen
 import { ModuleLessonsClient } from '@/app/(app)/plans/[id]/modules/[moduleId]/components/ModuleLessonsClient';
 import { clientLogger } from '@/lib/logging/client';
 import { type JSX, useCallback, useMemo } from 'react';
+import { toast } from 'sonner';
 
 interface ModuleDetailClientProps {
   moduleData: ModuleDetailReadModel;
@@ -38,11 +39,14 @@ export function ModuleDetailClient({
 
   const flushModuleTaskProgress = useCallback(
     async (updates: Array<{ taskId: string; status: ProgressStatus }>) => {
-      await batchUpdateModuleTaskProgressAction({
+      const result = await batchUpdateModuleTaskProgressAction({
         planId,
         moduleId: module.id,
         updates,
       });
+      if (result?.revalidateFailed) {
+        toast.message('Progress saved. Refresh if the page looks stale.');
+      }
     },
     [module.id, planId],
   );

--- a/src/app/(app)/plans/[id]/modules/[moduleId]/components/ModuleDetailContent.tsx
+++ b/src/app/(app)/plans/[id]/modules/[moduleId]/components/ModuleDetailContent.tsx
@@ -1,11 +1,11 @@
 import { ModuleDetailPageError } from './Error';
 import { ModuleDetail } from './ModuleDetail';
 import { ModuleDetailContentSkeleton } from './ModuleDetailContentSkeleton';
-import { getModuleForPage } from '@/app/(app)/plans/[id]/modules/[moduleId]/actions';
 import {
   getModuleError,
   isModuleSuccess,
 } from '@/app/(app)/plans/[id]/modules/[moduleId]/helpers';
+import { loadModuleForPage } from '@/app/(app)/plans/[id]/modules/[moduleId]/module-page-data';
 import { ROUTES } from '@/features/navigation/routes';
 import { logger } from '@/lib/logging/logger';
 import { redirect } from 'next/navigation';
@@ -25,7 +25,7 @@ export async function ModuleDetailContent({
   planId,
   moduleId,
 }: ModuleDetailContentProps) {
-  const moduleResult = await getModuleForPage(planId, moduleId);
+  const moduleResult = await loadModuleForPage(planId, moduleId);
 
   if (!isModuleSuccess(moduleResult)) {
     const error = getModuleError(moduleResult);

--- a/src/app/(app)/plans/[id]/modules/[moduleId]/module-page-data.ts
+++ b/src/app/(app)/plans/[id]/modules/[moduleId]/module-page-data.ts
@@ -5,6 +5,7 @@ import {
   moduleSuccess,
 } from '@/app/(app)/plans/[id]/modules/[moduleId]/helpers';
 import { getModuleDetailForRead } from '@/features/plans/read-projection/service';
+import { finalizePageBoundaryResult } from '@/lib/api/page-boundary-result';
 import { requestBoundary } from '@/lib/api/request-boundary';
 import { logger } from '@/lib/logging/logger';
 
@@ -36,17 +37,17 @@ export function loadModuleForPage(
       }
       return moduleSuccess(moduleData);
     })
-    .then((boundaryResult) => {
-      if (!boundaryResult) {
-        logger.debug(
-          { moduleId },
-          'Module access denied: user not authenticated',
-        );
-        return moduleError(
-          'UNAUTHORIZED',
-          'You must be signed in to view this module.',
-        );
-      }
-      return boundaryResult;
-    });
+    .then((boundaryResult) =>
+      finalizePageBoundaryResult(boundaryResult, {
+        entityId: moduleId,
+        unauthenticatedMessage: 'You must be signed in to view this module.',
+        unauthenticated: (message) => {
+          logger.debug(
+            { moduleId },
+            'Module access denied: user not authenticated',
+          );
+          return moduleError('UNAUTHORIZED', message);
+        },
+      }),
+    );
 }

--- a/src/app/(app)/plans/[id]/modules/[moduleId]/module-page-data.ts
+++ b/src/app/(app)/plans/[id]/modules/[moduleId]/module-page-data.ts
@@ -1,0 +1,52 @@
+import type { ModuleAccessResult } from '@/app/(app)/plans/[id]/modules/[moduleId]/types';
+
+import {
+  moduleError,
+  moduleSuccess,
+} from '@/app/(app)/plans/[id]/modules/[moduleId]/helpers';
+import { getModuleDetailForRead } from '@/features/plans/read-projection/service';
+import { requestBoundary } from '@/lib/api/request-boundary';
+import { logger } from '@/lib/logging/logger';
+
+/**
+ * Loads module detail for the module page inside a server component boundary.
+ * Uses `requestBoundary.component()` — do not call from `'use server'` action modules.
+ */
+export function loadModuleForPage(
+  planId: string,
+  moduleId: string,
+): Promise<ModuleAccessResult> {
+  return requestBoundary
+    .component(async ({ actor, db }) => {
+      const moduleData = await getModuleDetailForRead({
+        planId,
+        moduleId,
+        userId: actor.id,
+        dbClient: db,
+      });
+      if (!moduleData) {
+        logger.debug(
+          { moduleId, userId: actor.id },
+          'Module not found or user does not have access',
+        );
+        return moduleError(
+          'NOT_FOUND',
+          'This module does not exist or you do not have access to it.',
+        );
+      }
+      return moduleSuccess(moduleData);
+    })
+    .then((boundaryResult) => {
+      if (!boundaryResult) {
+        logger.debug(
+          { moduleId },
+          'Module access denied: user not authenticated',
+        );
+        return moduleError(
+          'UNAUTHORIZED',
+          'You must be signed in to view this module.',
+        );
+      }
+      return boundaryResult;
+    });
+}

--- a/src/app/(app)/plans/[id]/plan-page-data.ts
+++ b/src/app/(app)/plans/[id]/plan-page-data.ts
@@ -2,6 +2,7 @@ import type { PlanAccessResult } from '@/app/(app)/plans/[id]/types';
 
 import { planError, planSuccess } from '@/app/(app)/plans/[id]/helpers';
 import { getPlanDetailForRead } from '@/features/plans/read-projection/service';
+import { finalizePageBoundaryResult } from '@/lib/api/page-boundary-result';
 import { requestBoundary } from '@/lib/api/request-boundary';
 import { logger } from '@/lib/logging/logger';
 
@@ -29,14 +30,17 @@ export function loadPlanForPage(planId: string): Promise<PlanAccessResult> {
       }
       return planSuccess(plan);
     })
-    .then((boundaryResult) => {
-      if (!boundaryResult) {
-        logger.debug({ planId }, 'Plan access denied: user not authenticated');
-        return planError(
-          'UNAUTHORIZED',
-          'You must be signed in to view this plan.',
-        );
-      }
-      return boundaryResult;
-    });
+    .then((boundaryResult) =>
+      finalizePageBoundaryResult(boundaryResult, {
+        entityId: planId,
+        unauthenticatedMessage: 'You must be signed in to view this plan.',
+        unauthenticated: (message) => {
+          logger.debug(
+            { planId },
+            'Plan access denied: user not authenticated',
+          );
+          return planError('UNAUTHORIZED', message);
+        },
+      }),
+    );
 }

--- a/src/app/(app)/plans/[id]/plan-page-data.ts
+++ b/src/app/(app)/plans/[id]/plan-page-data.ts
@@ -1,0 +1,42 @@
+import type { PlanAccessResult } from '@/app/(app)/plans/[id]/types';
+
+import { planError, planSuccess } from '@/app/(app)/plans/[id]/helpers';
+import { getPlanDetailForRead } from '@/features/plans/read-projection/service';
+import { requestBoundary } from '@/lib/api/request-boundary';
+import { logger } from '@/lib/logging/logger';
+
+/**
+ * Loads plan detail for the plan overview page inside a server component boundary.
+ * Uses `requestBoundary.component()` — do not call from `'use server'` action modules.
+ */
+export function loadPlanForPage(planId: string): Promise<PlanAccessResult> {
+  return requestBoundary
+    .component(async ({ actor, db }) => {
+      const plan = await getPlanDetailForRead({
+        planId,
+        userId: actor.id,
+        dbClient: db,
+      });
+      if (!plan) {
+        logger.debug(
+          { planId, userId: actor.id },
+          'Plan not found or user does not have access',
+        );
+        return planError(
+          'NOT_FOUND',
+          'This plan does not exist or you do not have access to it.',
+        );
+      }
+      return planSuccess(plan);
+    })
+    .then((boundaryResult) => {
+      if (!boundaryResult) {
+        logger.debug({ planId }, 'Plan access denied: user not authenticated');
+        return planError(
+          'UNAUTHORIZED',
+          'You must be signed in to view this plan.',
+        );
+      }
+      return boundaryResult;
+    });
+}

--- a/src/features/plans/regeneration-orchestration/process.ts
+++ b/src/features/plans/regeneration-orchestration/process.ts
@@ -12,11 +12,12 @@ import {
 } from './process-workflow-support';
 import { planRegenerationJobPayloadSchema } from './schema';
 import { JOB_TYPES } from '@/features/jobs/types';
-import { startPlanRegenerationWorkflow } from '@/features/plans/start-plan-regeneration-workflow';
+import {
+  PLAN_REGENERATION_WORKFLOW_FAILURE_MESSAGE,
+  startPlanRegenerationWorkflow,
+} from '@/features/plans/start-plan-regeneration-workflow';
 import { workflowEnv } from '@/lib/config/env/workflow';
 import { db as serviceRoleDb } from '@supabase/service-role';
-
-const UNSAFE_WORKER_FAILURE_MESSAGE = 'Queued plan regeneration failed.';
 
 export async function processNextPlanRegenerationJob(
   deps?: RegenerationOrchestrationDeps,
@@ -80,9 +81,13 @@ export async function processPlanRegenerationJob(
       );
 
       if (!workflowStart.started) {
-        await d.queue.failJob(job.id, UNSAFE_WORKER_FAILURE_MESSAGE, {
-          retryable: false,
-        });
+        await d.queue.failJob(
+          job.id,
+          PLAN_REGENERATION_WORKFLOW_FAILURE_MESSAGE,
+          {
+            retryable: false,
+          },
+        );
         return {
           kind: 'permanent-failure',
           jobId: job.id,
@@ -125,9 +130,13 @@ export async function processPlanRegenerationJob(
     );
 
     try {
-      await d.queue.failJob(job.id, UNSAFE_WORKER_FAILURE_MESSAGE, {
-        retryable: false,
-      });
+      await d.queue.failJob(
+        job.id,
+        PLAN_REGENERATION_WORKFLOW_FAILURE_MESSAGE,
+        {
+          retryable: false,
+        },
+      );
     } catch (secondaryError) {
       d.logger.error(
         { jobId: job.id, error: secondaryError },

--- a/src/features/plans/start-plan-regeneration-workflow.ts
+++ b/src/features/plans/start-plan-regeneration-workflow.ts
@@ -4,7 +4,8 @@ import { workflowEnv } from '@/lib/config/env/workflow';
 import { logger } from '@/lib/logging/logger';
 import { start } from 'workflow/api';
 
-const WORKFLOW_REJECTION_FAILURE_MESSAGE = 'Queued plan regeneration failed.';
+export const PLAN_REGENERATION_WORKFLOW_FAILURE_MESSAGE =
+  'Queued plan regeneration failed.';
 
 export type StartPlanRegenerationWorkflowInput = {
   readonly jobId: string;
@@ -82,7 +83,7 @@ export async function startPlanRegenerationWorkflow(
       'Plan regeneration workflow failed',
     );
 
-    void queueFailJob(input.jobId, WORKFLOW_REJECTION_FAILURE_MESSAGE, {
+    void queueFailJob(input.jobId, PLAN_REGENERATION_WORKFLOW_FAILURE_MESSAGE, {
       retryable: false,
     }).catch((failError: unknown) => {
       log.error(

--- a/src/hooks/useTaskStatusBatcher.ts
+++ b/src/hooks/useTaskStatusBatcher.ts
@@ -4,7 +4,7 @@ import type { ProgressStatus } from '@/shared/types/db.types';
 
 import { getLoggableErrorDetails } from '@/lib/errors';
 import { clientLogger } from '@/lib/logging/client';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { toast } from 'sonner';
 
 interface Resolver {
@@ -33,6 +33,52 @@ interface UseTaskStatusBatcherOptions {
 
 const DEFAULT_DEBOUNCE_MS = 2000;
 const DEFAULT_MAX_WAIT_MS = 5000;
+
+function scopedTaskIdsKey(
+  scopedTaskIds: ReadonlySet<string> | undefined,
+): string {
+  if (!scopedTaskIds) return '';
+  return [...scopedTaskIds].sort().join('\0');
+}
+
+function partitionPendingByScope(
+  entries: Array<[string, PendingUpdate]>,
+  allowed: ReadonlySet<string> | undefined,
+): {
+  inScope: Array<[string, PendingUpdate]>;
+  droppedCount: number;
+} {
+  if (!allowed) {
+    return { inScope: entries, droppedCount: 0 };
+  }
+
+  const inScope: Array<[string, PendingUpdate]> = [];
+  let droppedCount = 0;
+
+  for (const entry of entries) {
+    if (allowed.has(entry[0])) {
+      inScope.push(entry);
+      continue;
+    }
+    droppedCount += 1;
+    for (const resolver of entry[1].resolvers) {
+      resolver.resolve();
+    }
+  }
+
+  return { inScope, droppedCount };
+}
+
+function notifyDroppedTaskUpdates(droppedCount: number, context: string): void {
+  if (droppedCount === 0) return;
+
+  clientLogger.warn(`Dropped out-of-scope task progress updates (${context})`, {
+    droppedCount,
+  });
+  toast.message('Some progress changes were not saved after navigation.', {
+    description: 'Refresh the page if totals look out of date.',
+  });
+}
 
 /**
  * Batches task status updates within a debounce window into a single server request.
@@ -64,6 +110,11 @@ export function useTaskStatusBatcher({
   flushActionRef.current = flushAction;
   const scopedTaskIdsRef = useRef(scopedTaskIds);
   scopedTaskIdsRef.current = scopedTaskIds;
+  const scopeKey = useMemo(
+    () => scopedTaskIdsKey(scopedTaskIds),
+    [scopedTaskIds],
+  );
+  const previousScopeKeyRef = useRef('');
 
   const clearScheduledFlush = useCallback(() => {
     if (timerRef.current) {
@@ -79,32 +130,6 @@ export function useTaskStatusBatcher({
     firstQueuedAtRef.current = null;
   }, []);
 
-  const dropOutOfScopePending = useCallback(() => {
-    const allowed = scopedTaskIdsRef.current;
-    if (!allowed) return;
-
-    const pending = pendingRef.current;
-    let droppedCount = 0;
-
-    for (const [taskId, entry] of pending) {
-      if (allowed.has(taskId)) continue;
-      droppedCount += 1;
-      for (const resolver of entry.resolvers) {
-        resolver.resolve();
-      }
-      pending.delete(taskId);
-    }
-
-    if (droppedCount > 0) {
-      clientLogger.warn('Dropped out-of-scope task progress updates', {
-        droppedCount,
-      });
-      if (pending.size === 0) {
-        clearScheduledFlush();
-      }
-    }
-  }, [clearScheduledFlush]);
-
   const flush = useCallback(async () => {
     clearScheduledFlush();
 
@@ -114,26 +139,11 @@ export function useTaskStatusBatcher({
     const snapshot = new Map(pending);
     pending.clear();
 
-    const allowed = scopedTaskIdsRef.current;
-    const inScopeEntries: Array<[string, PendingUpdate]> = [];
-    let skippedCount = 0;
-
-    for (const entry of snapshot) {
-      if (!allowed || allowed.has(entry[0])) {
-        inScopeEntries.push(entry);
-        continue;
-      }
-      skippedCount += 1;
-      for (const resolver of entry[1].resolvers) {
-        resolver.resolve();
-      }
-    }
-
-    if (skippedCount > 0) {
-      clientLogger.warn('Skipped out-of-scope task progress flush', {
-        skippedCount,
-      });
-    }
+    const { inScope: inScopeEntries, droppedCount } = partitionPendingByScope(
+      Array.from(snapshot.entries()),
+      scopedTaskIdsRef.current,
+    );
+    notifyDroppedTaskUpdates(droppedCount, 'flush');
 
     if (inScopeEntries.length === 0) return;
 
@@ -157,6 +167,27 @@ export function useTaskStatusBatcher({
         updateCount: updates.length,
       });
       toast.error('Failed to update task status. Please try again.');
+    }
+  }, [clearScheduledFlush]);
+
+  const dropOutOfScopePending = useCallback(() => {
+    const pending = pendingRef.current;
+    if (pending.size === 0) return;
+
+    const { inScope, droppedCount } = partitionPendingByScope(
+      Array.from(pending.entries()),
+      scopedTaskIdsRef.current,
+    );
+
+    pending.clear();
+    for (const [taskId, entry] of inScope) {
+      pending.set(taskId, entry);
+    }
+
+    notifyDroppedTaskUpdates(droppedCount, 'scope-change');
+
+    if (pending.size === 0) {
+      clearScheduledFlush();
     }
   }, [clearScheduledFlush]);
 
@@ -218,8 +249,16 @@ export function useTaskStatusBatcher({
   );
 
   useEffect(() => {
-    dropOutOfScopePending();
-  }, [dropOutOfScopePending, scopedTaskIds]);
+    const previousScopeKey = previousScopeKeyRef.current;
+    if (previousScopeKey !== scopeKey && previousScopeKey !== '') {
+      void flush().then(() => {
+        dropOutOfScopePending();
+      });
+    } else {
+      dropOutOfScopePending();
+    }
+    previousScopeKeyRef.current = scopeKey;
+  }, [dropOutOfScopePending, flush, scopeKey]);
 
   useEffect(() => {
     return () => {

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -211,7 +211,7 @@ export async function withServerComponentContext<T>(
     );
   }
 
-  const authUserId = await getEffectiveAuthUserId();
+  const authUserId = await getEffectiveAuthUserId({ strict: true });
   if (!authUserId) return null;
 
   if (appEnv.isTest) {

--- a/src/lib/api/page-boundary-result.ts
+++ b/src/lib/api/page-boundary-result.ts
@@ -1,0 +1,17 @@
+/**
+ * Maps a nullable request-boundary result to a typed access result with UNAUTHORIZED fallback.
+ */
+export function finalizePageBoundaryResult<TSuccess, TUnauth>(
+  boundaryResult: TSuccess | null,
+  options: {
+    entityId: string;
+    unauthenticatedMessage: string;
+    unauthenticated: (message: string) => TUnauth;
+  },
+): TSuccess | TUnauth {
+  if (boundaryResult !== null) {
+    return boundaryResult;
+  }
+
+  return options.unauthenticated(options.unauthenticatedMessage);
+}

--- a/src/lib/config/env.ts
+++ b/src/lib/config/env.ts
@@ -27,6 +27,7 @@ export {
   createServerEnvAccess,
   EnvValidationError,
   getSmokeStateFileEnv,
+  isHostedDeployEnv,
   optionalEnv,
   parseEnvNumber,
   parseNodeEnv,

--- a/src/lib/config/env.ts
+++ b/src/lib/config/env.ts
@@ -19,6 +19,8 @@ export {
 export { regenerationQueueEnv } from '@/lib/config/env/queue';
 export {
   createWorkflowEnvForTests,
+  parseWorkflowCallbackToken,
+  WORKFLOW_CALLBACK_TOKEN_ENV_KEY,
   workflowEnv,
 } from '@/lib/config/env/workflow';
 export { createSupabasePublicEnv } from '@/lib/config/env/supabase';

--- a/src/lib/config/env.ts
+++ b/src/lib/config/env.ts
@@ -20,6 +20,7 @@ export { regenerationQueueEnv } from '@/lib/config/env/queue';
 export {
   createWorkflowEnvForTests,
   parseWorkflowCallbackToken,
+  readWorkflowCallbackTokenConfig,
   WORKFLOW_CALLBACK_TOKEN_ENV_KEY,
   workflowEnv,
 } from '@/lib/config/env/workflow';

--- a/src/lib/config/env/shared.ts
+++ b/src/lib/config/env/shared.ts
@@ -264,7 +264,7 @@ export function getServerOptional(key: string): string | undefined {
 
 const HOSTED_DEPLOY_ENV_KEYS = ['VERCEL'] as const;
 
-function isHostedDeployEnv(env: EnvSource): boolean {
+export function isHostedDeployEnv(env: EnvSource): boolean {
   return HOSTED_DEPLOY_ENV_KEYS.some((key) =>
     toBoolean(optionalEnvFrom(env, key), false),
   );

--- a/src/lib/config/env/shared.ts
+++ b/src/lib/config/env/shared.ts
@@ -185,6 +185,8 @@ function getCachedServerRequired(
 export interface ServerEnvAccess {
   getServerRequired(key: string): string;
   getServerOptional(key: string): string | undefined;
+  /** Raw env value before trim/empty normalization. */
+  getServerEnvRaw(key: string): string | undefined;
   getServerRequiredProdOnly(key: string): string | undefined;
   getProductionCached<T>(key: string, loader: () => T): T;
 }
@@ -229,6 +231,10 @@ export function createServerEnvAccess(
         optionalCache.set(key, optionalEnvFrom(env, key));
       }
       return optionalCache.get(key);
+    },
+    getServerEnvRaw(key: string): string | undefined {
+      const { env } = getServerState();
+      return env[key];
     },
     getServerRequiredProdOnly(key: string): string | undefined {
       const { env, isNonProduction } = getServerState();

--- a/src/lib/config/env/workflow.ts
+++ b/src/lib/config/env/workflow.ts
@@ -12,6 +12,11 @@ interface WorkflowEnv {
   readonly planRegenerationWorkflowEnabled: boolean;
   /** `PLAN_GENERATION_WORKFLOW_ENABLED`; defaults to false. */
   readonly planGenerationWorkflowEnabled: boolean;
+  /**
+   * Shared bearer token for non-Vercel workflow callback routes.
+   * Undefined outside production; Vercel-hosted deploys rely on queue consumer security.
+   */
+  readonly callbackToken: string | undefined;
 }
 
 function parseWorkflowFlag(
@@ -62,6 +67,9 @@ function readWorkflowEnv(access: ServerEnvAccess): WorkflowEnv {
         'PLAN_GENERATION_WORKFLOW_ENABLED',
         false,
       );
+    },
+    get callbackToken(): string | undefined {
+      return access.getServerRequiredProdOnly('WORKFLOW_CALLBACK_TOKEN');
     },
   };
 }

--- a/src/lib/config/env/workflow.ts
+++ b/src/lib/config/env/workflow.ts
@@ -4,6 +4,16 @@ import {
   getProcessEnvSource,
   type ServerEnvAccess,
 } from '@/lib/config/env/shared';
+import { z } from 'zod';
+
+export const WORKFLOW_CALLBACK_TOKEN_ENV_KEY = 'WORKFLOW_CALLBACK_TOKEN';
+
+const workflowCallbackTokenSchema = z
+  .string()
+  .trim()
+  .min(1, {
+    message: `${WORKFLOW_CALLBACK_TOKEN_ENV_KEY} must not be empty or whitespace-only`,
+  });
 
 interface WorkflowEnv {
   /** `MODULE_LESSON_WORKFLOW_ENABLED`; defaults to false. */
@@ -45,6 +55,26 @@ function parseWorkflowFlag(
   );
 }
 
+/** Parses optional workflow callback token; unset/blank env is undefined. */
+export function parseWorkflowCallbackToken(
+  raw: string | undefined,
+): string | undefined {
+  if (raw === undefined || raw === '') {
+    return undefined;
+  }
+
+  const parsed = workflowCallbackTokenSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new EnvValidationError(
+      parsed.error.issues[0]?.message ??
+        `Invalid ${WORKFLOW_CALLBACK_TOKEN_ENV_KEY}`,
+      WORKFLOW_CALLBACK_TOKEN_ENV_KEY,
+    );
+  }
+
+  return parsed.data;
+}
+
 function readWorkflowEnv(access: ServerEnvAccess): WorkflowEnv {
   return {
     get moduleLessonWorkflowEnabled(): boolean {
@@ -69,7 +99,9 @@ function readWorkflowEnv(access: ServerEnvAccess): WorkflowEnv {
       );
     },
     get callbackToken(): string | undefined {
-      return access.getServerOptional('WORKFLOW_CALLBACK_TOKEN');
+      return parseWorkflowCallbackToken(
+        access.getServerEnvRaw(WORKFLOW_CALLBACK_TOKEN_ENV_KEY),
+      );
     },
   };
 }

--- a/src/lib/config/env/workflow.ts
+++ b/src/lib/config/env/workflow.ts
@@ -55,6 +55,30 @@ function parseWorkflowFlag(
   );
 }
 
+export type WorkflowCallbackTokenConfigRead =
+  | { readonly status: 'valid'; readonly token: string | undefined }
+  | { readonly status: 'invalid' };
+
+/** Reads callback token config without throwing on whitespace-only values. */
+export function readWorkflowCallbackTokenConfig(
+  access?: ServerEnvAccess,
+): WorkflowCallbackTokenConfigRead {
+  const envAccess = access ?? createServerEnvAccess(getProcessEnvSource);
+  try {
+    return {
+      status: 'valid',
+      token: parseWorkflowCallbackToken(
+        envAccess.getServerEnvRaw(WORKFLOW_CALLBACK_TOKEN_ENV_KEY),
+      ),
+    };
+  } catch (error) {
+    if (error instanceof EnvValidationError) {
+      return { status: 'invalid' };
+    }
+    throw error;
+  }
+}
+
 /** Parses optional workflow callback token; unset/blank env is undefined. */
 export function parseWorkflowCallbackToken(
   raw: string | undefined,

--- a/src/lib/config/env/workflow.ts
+++ b/src/lib/config/env/workflow.ts
@@ -14,7 +14,7 @@ interface WorkflowEnv {
   readonly planGenerationWorkflowEnabled: boolean;
   /**
    * Shared bearer token for non-Vercel workflow callback routes.
-   * Undefined outside production; Vercel-hosted deploys rely on queue consumer security.
+   * Undefined when not configured; callback auth enforces production requirements.
    */
   readonly callbackToken: string | undefined;
 }
@@ -69,7 +69,7 @@ function readWorkflowEnv(access: ServerEnvAccess): WorkflowEnv {
       );
     },
     get callbackToken(): string | undefined {
-      return access.getServerRequiredProdOnly('WORKFLOW_CALLBACK_TOKEN');
+      return access.getServerOptional('WORKFLOW_CALLBACK_TOKEN');
     },
   };
 }

--- a/src/lib/next/revalidate-paths.ts
+++ b/src/lib/next/revalidate-paths.ts
@@ -2,19 +2,34 @@ import { serializeErrorForLog } from '@/lib/errors';
 import { logger } from '@/lib/logging/logger';
 import { revalidatePath } from 'next/cache';
 
+export type RevalidatePathsResult = {
+  readonly failedPaths: readonly string[];
+};
+
 /**
  * Revalidates app paths after a successful mutation without failing the mutation
  * when cache invalidation throws (e.g. transient Next cache/runtime issues).
  */
-export function revalidatePathsBestEffort(paths: readonly string[]): void {
+export function revalidatePathsBestEffort(
+  paths: readonly string[],
+): RevalidatePathsResult {
+  const failedPaths: string[] = [];
+
   for (const path of paths) {
     try {
       revalidatePath(path);
     } catch (error) {
+      failedPaths.push(path);
       logger.warn(
-        { path, err: serializeErrorForLog(error) },
+        {
+          path,
+          err: serializeErrorForLog(error),
+          revalidatePartialFailure: true,
+        },
         'Failed to revalidate path after mutation',
       );
     }
   }
+
+  return { failedPaths };
 }

--- a/src/lib/proxy/middleware-policy.ts
+++ b/src/lib/proxy/middleware-policy.ts
@@ -10,7 +10,7 @@ const PROTECTED_PREFIXES = [
 /** Public routes required by platform integrations (not user app surfaces). */
 const MAINTENANCE_MODE_BYPASS_PREFIXES = [
   '/.well-known/vercel/flags',
-  /** Workflow SDK runtime callbacks; also excluded from Clerk in `src/proxy.ts`. */
+  /** Workflow SDK runtime callbacks; proxy applies callback auth before Clerk. */
   '/.well-known/workflow/',
 ] as const;
 

--- a/src/lib/proxy/workflow-callback-auth.ts
+++ b/src/lib/proxy/workflow-callback-auth.ts
@@ -76,17 +76,19 @@ export function readWorkflowCallbackToken(
 
 /**
  * Edge-safe timing-safe string compare for shared-secret tokens.
+ * Uses fixed-length SHA-256 digests so token length cannot short-circuit compare.
  */
-export function workflowCallbackTokensMatch(
+export async function workflowCallbackTokensMatch(
   expectedToken: string,
   providedToken: string,
-): boolean {
-  const expected = new TextEncoder().encode(expectedToken);
-  const provided = new TextEncoder().encode(providedToken);
-
-  if (provided.length !== expected.length) {
-    return false;
-  }
+): Promise<boolean> {
+  const encoder = new TextEncoder();
+  const [expectedHash, providedHash] = await Promise.all([
+    crypto.subtle.digest('SHA-256', encoder.encode(expectedToken)),
+    crypto.subtle.digest('SHA-256', encoder.encode(providedToken)),
+  ]);
+  const expected = new Uint8Array(expectedHash);
+  const provided = new Uint8Array(providedHash);
 
   let mismatch = 0;
   for (let index = 0; index < expected.length; index += 1) {
@@ -96,10 +98,10 @@ export function workflowCallbackTokensMatch(
   return mismatch === 0;
 }
 
-export function resolveWorkflowCallbackAccess(
+export async function resolveWorkflowCallbackAccess(
   input: WorkflowCallbackAuthInput,
   config: WorkflowCallbackAuthConfig,
-): WorkflowCallbackAuthResult {
+): Promise<WorkflowCallbackAuthResult> {
   if (!isWorkflowCallbackPath(input.pathname)) {
     return { status: 'allow' };
   }
@@ -122,7 +124,7 @@ export function resolveWorkflowCallbackAccess(
     const providedToken = readWorkflowCallbackToken(input.headers, headerName);
     if (
       providedToken &&
-      workflowCallbackTokensMatch(config.callbackToken, providedToken)
+      (await workflowCallbackTokensMatch(config.callbackToken, providedToken))
     ) {
       return { status: 'allow' };
     }

--- a/src/lib/proxy/workflow-callback-auth.ts
+++ b/src/lib/proxy/workflow-callback-auth.ts
@@ -1,0 +1,142 @@
+export const WORKFLOW_CALLBACK_TOKEN_HEADER = 'x-workflow-callback-token';
+
+export type WorkflowCallbackAuthConfig = {
+  readonly isProduction: boolean;
+  readonly isHostedVercelDeploy: boolean;
+  readonly callbackToken: string | undefined;
+  readonly headerName?: string;
+};
+
+export type WorkflowCallbackAuthInput = {
+  readonly method: string;
+  readonly pathname: string;
+  readonly searchParams: URLSearchParams;
+  readonly headers: Headers;
+};
+
+export type WorkflowCallbackAuthResult =
+  | { readonly status: 'allow' }
+  | { readonly status: 'deny' }
+  | { readonly status: 'misconfigured' };
+
+export function isWorkflowCallbackPath(pathname: string): boolean {
+  return pathname.startsWith('/.well-known/workflow/');
+}
+
+export function isWorkflowWebhookPath(pathname: string): boolean {
+  return pathname.startsWith('/.well-known/workflow/v1/webhook/');
+}
+
+export function isWorkflowHealthCheck(input: {
+  method: string;
+  searchParams: URLSearchParams;
+}): boolean {
+  if (!input.searchParams.has('__health')) {
+    return false;
+  }
+
+  return ['HEAD', 'GET', 'OPTIONS'].includes(input.method.toUpperCase());
+}
+
+export function hasLocalWorldQueueHeaders(headers: Headers): boolean {
+  return (
+    headers.has('x-vqs-queue-name') &&
+    headers.has('x-vqs-message-id') &&
+    headers.has('x-vqs-message-attempt')
+  );
+}
+
+/**
+ * Reads bearer or custom header token for workflow callback routes.
+ * Returns null when both are supplied or neither is present.
+ */
+export function readWorkflowCallbackToken(
+  headers: Headers,
+  headerName: string = WORKFLOW_CALLBACK_TOKEN_HEADER,
+): string | null {
+  if (!headerName.trim()) {
+    return null;
+  }
+
+  const authHeader = headers.get('authorization');
+  const bearerMatch = authHeader?.match(/^Bearer\s+(.+)$/i);
+  const bearerToken = bearerMatch?.[1]?.trim() ?? null;
+  const customToken = headers.get(headerName);
+
+  if (bearerToken && customToken) {
+    return null;
+  }
+
+  if (bearerToken) {
+    return bearerToken;
+  }
+
+  return customToken;
+}
+
+/**
+ * Edge-safe timing-safe string compare for shared-secret tokens.
+ */
+export function workflowCallbackTokensMatch(
+  expectedToken: string,
+  providedToken: string,
+): boolean {
+  const expected = new TextEncoder().encode(expectedToken);
+  const provided = new TextEncoder().encode(providedToken);
+
+  if (provided.length !== expected.length) {
+    return false;
+  }
+
+  let mismatch = 0;
+  for (let index = 0; index < expected.length; index += 1) {
+    mismatch |= expected[index]! ^ provided[index]!;
+  }
+
+  return mismatch === 0;
+}
+
+export function resolveWorkflowCallbackAccess(
+  input: WorkflowCallbackAuthInput,
+  config: WorkflowCallbackAuthConfig,
+): WorkflowCallbackAuthResult {
+  if (!isWorkflowCallbackPath(input.pathname)) {
+    return { status: 'allow' };
+  }
+
+  if (isWorkflowHealthCheck(input)) {
+    return { status: 'allow' };
+  }
+
+  if (isWorkflowWebhookPath(input.pathname)) {
+    return { status: 'allow' };
+  }
+
+  if (config.isHostedVercelDeploy) {
+    return { status: 'allow' };
+  }
+
+  const headerName = config.headerName ?? WORKFLOW_CALLBACK_TOKEN_HEADER;
+
+  if (config.callbackToken) {
+    const providedToken = readWorkflowCallbackToken(input.headers, headerName);
+    if (
+      providedToken &&
+      workflowCallbackTokensMatch(config.callbackToken, providedToken)
+    ) {
+      return { status: 'allow' };
+    }
+
+    return { status: 'deny' };
+  }
+
+  if (config.isProduction) {
+    return { status: 'misconfigured' };
+  }
+
+  if (hasLocalWorldQueueHeaders(input.headers)) {
+    return { status: 'allow' };
+  }
+
+  return { status: 'deny' };
+}

--- a/src/lib/proxy/workflow-callback-auth.ts
+++ b/src/lib/proxy/workflow-callback-auth.ts
@@ -106,7 +106,7 @@ export async function resolveWorkflowCallbackAccess(
     return { status: 'allow' };
   }
 
-  if (isWorkflowHealthCheck(input)) {
+  if (isWorkflowHealthCheck(input) && !config.isProduction) {
     return { status: 'allow' };
   }
 

--- a/src/lib/proxy/workflow-callback-auth.ts
+++ b/src/lib/proxy/workflow-callback-auth.ts
@@ -61,7 +61,7 @@ export function readWorkflowCallbackToken(
   const authHeader = headers.get('authorization');
   const bearerMatch = authHeader?.match(/^Bearer\s+(.+)$/i);
   const bearerToken = bearerMatch?.[1]?.trim() ?? null;
-  const customToken = headers.get(headerName);
+  const customToken = headers.get(headerName)?.trim() ?? null;
 
   if (bearerToken && customToken) {
     return null;
@@ -71,7 +71,7 @@ export function readWorkflowCallbackToken(
     return bearerToken;
   }
 
-  return customToken;
+  return customToken === '' ? null : customToken;
 }
 
 /**

--- a/src/lib/proxy/workflow-callback-proxy.ts
+++ b/src/lib/proxy/workflow-callback-proxy.ts
@@ -1,0 +1,22 @@
+import type {
+  WorkflowCallbackAuthConfig,
+  WorkflowCallbackAuthInput,
+  WorkflowCallbackAuthResult,
+} from '@/lib/proxy/workflow-callback-auth';
+
+import { resolveWorkflowCallbackAccess } from '@/lib/proxy/workflow-callback-auth';
+
+export type WorkflowCallbackProxyStatus = WorkflowCallbackAuthResult['status'];
+
+export type WorkflowCallbackProxyConfig = WorkflowCallbackAuthConfig;
+
+/**
+ * Resolves workflow callback access for proxy middleware. Pure policy wrapper for tests.
+ */
+export async function resolveWorkflowCallbackProxyAccess(
+  input: WorkflowCallbackAuthInput,
+  config: WorkflowCallbackProxyConfig,
+): Promise<WorkflowCallbackProxyStatus> {
+  const result = await resolveWorkflowCallbackAccess(input, config);
+  return result.status;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -74,7 +74,7 @@ const proxy = clerkMiddleware(
     const { pathname } = request.nextUrl;
 
     if (isWorkflowCallbackPath(pathname)) {
-      const callbackAccess = resolveWorkflowCallbackAccess(
+      const callbackAccess = await resolveWorkflowCallbackAccess(
         {
           method: request.method,
           pathname,
@@ -89,7 +89,7 @@ const proxy = clerkMiddleware(
       );
 
       if (callbackAccess.status === 'allow') {
-        return NextResponse.next();
+        return nextWithCorrelationId(request);
       }
 
       if (callbackAccess.status === 'misconfigured') {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,11 @@
 import { maintenanceMode } from '@/flags';
-import { appEnv, devAuthEnv, localProductTestingEnv } from '@/lib/config/env';
+import {
+  appEnv,
+  devAuthEnv,
+  isHostedDeployEnv,
+  localProductTestingEnv,
+  workflowEnv,
+} from '@/lib/config/env';
 import { getCorrelationId } from '@/lib/proxy/correlation';
 import { resolveEffectiveMaintenanceMode } from '@/lib/proxy/maintenance-mode';
 import {
@@ -12,6 +18,10 @@ import {
   createContentSecurityPolicy,
   createCspNonce,
 } from '@/lib/proxy/security-headers';
+import {
+  isWorkflowCallbackPath,
+  resolveWorkflowCallbackAccess,
+} from '@/lib/proxy/workflow-callback-auth';
 import { clerkMiddleware } from '@clerk/nextjs/server';
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -62,6 +72,32 @@ const nextWithCorrelationId = (
 const proxy = clerkMiddleware(
   async (auth, request: NextRequest) => {
     const { pathname } = request.nextUrl;
+
+    if (isWorkflowCallbackPath(pathname)) {
+      const callbackAccess = resolveWorkflowCallbackAccess(
+        {
+          method: request.method,
+          pathname,
+          searchParams: request.nextUrl.searchParams,
+          headers: request.headers,
+        },
+        {
+          isProduction: appEnv.isProduction,
+          isHostedVercelDeploy: isHostedDeployEnv(process.env),
+          callbackToken: workflowEnv.callbackToken,
+        },
+      );
+
+      if (callbackAccess.status === 'allow') {
+        return NextResponse.next();
+      }
+
+      if (callbackAccess.status === 'misconfigured') {
+        return new NextResponse(null, { status: 503 });
+      }
+
+      return new NextResponse(null, { status: 401 });
+    }
 
     // Stripe webhooks bypass all checks including maintenance mode
     if (pathname.startsWith('/api/v1/stripe/webhook')) {
@@ -126,9 +162,8 @@ export default proxy;
 
 export const config = {
   matcher: [
-    // Workflow SDK webhook/callback routes under `/.well-known/workflow/` must stay
-    // outside Clerk, maintenance redirects, and CSP middleware (see workflow-sdk.md).
-    '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)|\\.well-known/workflow/).*)',
+    // Workflow SDK machine routes run an early auth branch before Clerk/CSP.
+    '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
     '/(api|trpc)(.*)',
   ],
 };

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,7 +4,7 @@ import {
   devAuthEnv,
   isHostedDeployEnv,
   localProductTestingEnv,
-  workflowEnv,
+  readWorkflowCallbackTokenConfig,
 } from '@/lib/config/env';
 import { getCorrelationId } from '@/lib/proxy/correlation';
 import { resolveEffectiveMaintenanceMode } from '@/lib/proxy/maintenance-mode';
@@ -53,6 +53,19 @@ const withCorrelationId = (
   return applyProxyDecorations(response, ctx);
 };
 
+/** Machine workflow callbacks skip CSP/nonce decoration (SDK queue consumer). */
+const nextForWorkflowCallback = (request: NextRequest): NextResponse => {
+  const correlationId = getCorrelationId(request);
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-correlation-id', correlationId);
+
+  const response = NextResponse.next({
+    request: { headers: requestHeaders },
+  });
+  response.headers.set('x-correlation-id', correlationId);
+  return response;
+};
+
 const nextWithCorrelationId = (
   request: NextRequest,
   existingCtx?: ReturnType<typeof buildProxyRequestContext>,
@@ -74,6 +87,11 @@ const proxy = clerkMiddleware(
     const { pathname } = request.nextUrl;
 
     if (isWorkflowCallbackPath(pathname)) {
+      const tokenConfig = readWorkflowCallbackTokenConfig();
+      if (tokenConfig.status === 'invalid') {
+        return new NextResponse(null, { status: 503 });
+      }
+
       const callbackAccess = await resolveWorkflowCallbackAccess(
         {
           method: request.method,
@@ -84,12 +102,12 @@ const proxy = clerkMiddleware(
         {
           isProduction: appEnv.isProduction,
           isHostedVercelDeploy: isHostedDeployEnv(process.env),
-          callbackToken: workflowEnv.callbackToken,
+          callbackToken: tokenConfig.token,
         },
       );
 
       if (callbackAccess.status === 'allow') {
-        return nextWithCorrelationId(request);
+        return nextForWorkflowCallback(request);
       }
 
       if (callbackAccess.status === 'misconfigured') {

--- a/tests/unit/app/plans/actions.spec.ts
+++ b/tests/unit/app/plans/actions.spec.ts
@@ -152,8 +152,11 @@ describe('batchUpdateTaskProgressAction', () => {
 
   it('succeeds when persistence succeeds but revalidatePath throws', async () => {
     requestBoundaryActionMock.mockImplementationOnce(
-      async (fn: (scope: RequestScope) => Promise<void>) =>
-        fn(makeActionTestScope()),
+      async (
+        fn: (
+          scope: RequestScope,
+        ) => Promise<{ revalidateFailed: boolean } | void>,
+      ) => fn(makeActionTestScope()),
     );
     applyTaskProgressUpdatesMock.mockResolvedValueOnce({
       progress: [],
@@ -176,7 +179,7 @@ describe('batchUpdateTaskProgressAction', () => {
         planId: 'plan-123',
         updates: [{ taskId: 't1', status: 'completed' }],
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({ revalidateFailed: true });
 
     expect(applyTaskProgressUpdatesMock).toHaveBeenCalledOnce();
     expect(revalidatePathMock).toHaveBeenCalledWith('/plans/plan-123');

--- a/tests/unit/app/plans/modules/actions.spec.ts
+++ b/tests/unit/app/plans/modules/actions.spec.ts
@@ -149,45 +149,6 @@ describe('batchUpdateModuleTaskProgressAction', () => {
     expect(revalidatePathMock).toHaveBeenCalledWith('/plans');
   });
 
-  it('succeeds when persistence succeeds but revalidatePath throws', async () => {
-    requestBoundaryActionMock.mockImplementationOnce(
-      mockRequestBoundaryAction(makeActionTestScope()),
-    );
-    applyTaskProgressUpdatesMock.mockResolvedValueOnce({
-      progress: [],
-      revalidatePaths: ['/plans/p1/modules/m1', '/plans/p1', '/plans'],
-      visibleState: { appliedByTaskId: {} },
-    });
-    revalidatePathMock.mockImplementationOnce((path: string) => {
-      if (path === '/plans/p1') {
-        throw new Error('revalidate failed');
-      }
-    });
-    revalidatePathMock.mockImplementationOnce((path: string) => {
-      if (path === '/plans/p1') {
-        throw new Error('revalidate failed');
-      }
-    });
-    revalidatePathMock.mockImplementationOnce((path: string) => {
-      if (path === '/plans/p1') {
-        throw new Error('revalidate failed');
-      }
-    });
-
-    await expect(
-      batchUpdateModuleTaskProgressAction({
-        planId: 'p1',
-        moduleId: 'm1',
-        updates: [{ taskId: 't1', status: 'completed' }],
-      }),
-    ).resolves.toBeUndefined();
-
-    expect(loggerMock.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ path: '/plans/p1' }),
-      'Failed to revalidate path after mutation',
-    );
-  });
-
   it('maps boundary persistence errors to generic user message', async () => {
     requestBoundaryActionMock.mockImplementationOnce(
       mockRequestBoundaryAction(makeActionTestScope()),

--- a/tests/unit/app/plans/plan-page-data.spec.ts
+++ b/tests/unit/app/plans/plan-page-data.spec.ts
@@ -1,0 +1,39 @@
+import { loadPlanForPage } from '@/app/(app)/plans/[id]/plan-page-data';
+import { describe, expect, it, vi } from 'vitest';
+
+const { requestBoundaryComponentMock, getPlanDetailForReadMock } = vi.hoisted(
+  () => ({
+    requestBoundaryComponentMock: vi.fn(),
+    getPlanDetailForReadMock: vi.fn(),
+  }),
+);
+
+vi.mock('@/lib/api/request-boundary', () => ({
+  requestBoundary: {
+    component: requestBoundaryComponentMock,
+  },
+}));
+
+vi.mock('@/features/plans/read-projection/service', () => ({
+  getPlanDetailForRead: getPlanDetailForReadMock,
+}));
+
+vi.mock('@/lib/logging/logger', () => ({
+  logger: { debug: vi.fn() },
+}));
+
+describe('loadPlanForPage', () => {
+  it('returns UNAUTHORIZED when the component boundary is unauthenticated', async () => {
+    requestBoundaryComponentMock.mockResolvedValueOnce(null);
+
+    const result = await loadPlanForPage('plan-1');
+
+    expect(result).toEqual({
+      success: false,
+      error: {
+        code: 'UNAUTHORIZED',
+        message: 'You must be signed in to view this plan.',
+      },
+    });
+  });
+});

--- a/tests/unit/config/env.spec.ts
+++ b/tests/unit/config/env.spec.ts
@@ -724,6 +724,26 @@ describe('Environment Configuration', () => {
         () => createWorkflowEnvForTests(access).planGenerationWorkflowEnabled,
       ).toThrow(EnvValidationError);
     });
+
+    it('reads WORKFLOW_CALLBACK_TOKEN only in production', () => {
+      vi.stubGlobal('window', undefined);
+      const access = createServerEnvAccess(() => ({
+        NODE_ENV: 'production',
+        WORKFLOW_CALLBACK_TOKEN: 'prod-secret',
+      }));
+
+      expect(createWorkflowEnvForTests(access).callbackToken).toBe(
+        'prod-secret',
+      );
+    });
+
+    it('does not require WORKFLOW_CALLBACK_TOKEN outside production', () => {
+      const access = createServerEnvAccess(() => ({
+        NODE_ENV: 'development',
+      }));
+
+      expect(createWorkflowEnvForTests(access).callbackToken).toBeUndefined();
+    });
   });
 
   describe('barrel surface', () => {

--- a/tests/unit/config/env.spec.ts
+++ b/tests/unit/config/env.spec.ts
@@ -15,6 +15,7 @@ import {
   optionalEnv,
   parseEnvNumber,
   parseNodeEnv,
+  readWorkflowCallbackTokenConfig,
   regenerationQueueEnv,
   requireEnv,
   toBoolean,
@@ -759,6 +760,18 @@ describe('Environment Configuration', () => {
       expect(() => createWorkflowEnvForTests(access).callbackToken).toThrow(
         EnvValidationError,
       );
+    });
+
+    it('readWorkflowCallbackTokenConfig returns invalid for whitespace-only token', () => {
+      vi.stubGlobal('window', undefined);
+      const access = createServerEnvAccess(() => ({
+        NODE_ENV: 'production',
+        WORKFLOW_CALLBACK_TOKEN: '   ',
+      }));
+
+      expect(readWorkflowCallbackTokenConfig(access)).toEqual({
+        status: 'invalid',
+      });
     });
 
     it('treats empty WORKFLOW_CALLBACK_TOKEN as unset', () => {

--- a/tests/unit/config/env.spec.ts
+++ b/tests/unit/config/env.spec.ts
@@ -737,6 +737,40 @@ describe('Environment Configuration', () => {
       );
     });
 
+    it('trims WORKFLOW_CALLBACK_TOKEN when configured', () => {
+      vi.stubGlobal('window', undefined);
+      const access = createServerEnvAccess(() => ({
+        NODE_ENV: 'production',
+        WORKFLOW_CALLBACK_TOKEN: '  prod-secret  ',
+      }));
+
+      expect(createWorkflowEnvForTests(access).callbackToken).toBe(
+        'prod-secret',
+      );
+    });
+
+    it('throws EnvValidationError for whitespace-only WORKFLOW_CALLBACK_TOKEN', () => {
+      vi.stubGlobal('window', undefined);
+      const access = createServerEnvAccess(() => ({
+        NODE_ENV: 'production',
+        WORKFLOW_CALLBACK_TOKEN: '   ',
+      }));
+
+      expect(() => createWorkflowEnvForTests(access).callbackToken).toThrow(
+        EnvValidationError,
+      );
+    });
+
+    it('treats empty WORKFLOW_CALLBACK_TOKEN as unset', () => {
+      vi.stubGlobal('window', undefined);
+      const access = createServerEnvAccess(() => ({
+        NODE_ENV: 'production',
+        WORKFLOW_CALLBACK_TOKEN: '',
+      }));
+
+      expect(createWorkflowEnvForTests(access).callbackToken).toBeUndefined();
+    });
+
     it('does not require WORKFLOW_CALLBACK_TOKEN outside production', () => {
       const access = createServerEnvAccess(() => ({
         NODE_ENV: 'development',

--- a/tests/unit/config/env.spec.ts
+++ b/tests/unit/config/env.spec.ts
@@ -725,7 +725,7 @@ describe('Environment Configuration', () => {
       ).toThrow(EnvValidationError);
     });
 
-    it('reads WORKFLOW_CALLBACK_TOKEN only in production', () => {
+    it('reads WORKFLOW_CALLBACK_TOKEN when configured', () => {
       vi.stubGlobal('window', undefined);
       const access = createServerEnvAccess(() => ({
         NODE_ENV: 'production',
@@ -740,6 +740,15 @@ describe('Environment Configuration', () => {
     it('does not require WORKFLOW_CALLBACK_TOKEN outside production', () => {
       const access = createServerEnvAccess(() => ({
         NODE_ENV: 'development',
+      }));
+
+      expect(createWorkflowEnvForTests(access).callbackToken).toBeUndefined();
+    });
+
+    it('does not require WORKFLOW_CALLBACK_TOKEN in production env reads', () => {
+      vi.stubGlobal('window', undefined);
+      const access = createServerEnvAccess(() => ({
+        NODE_ENV: 'production',
       }));
 
       expect(createWorkflowEnvForTests(access).callbackToken).toBeUndefined();

--- a/tests/unit/hooks/useTaskStatusBatcher.spec.tsx
+++ b/tests/unit/hooks/useTaskStatusBatcher.spec.tsx
@@ -8,14 +8,22 @@ import { act, renderHook } from '@testing-library/react';
 import { createId } from '@tests/fixtures/ids';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const { clientLoggerWarnMock } = vi.hoisted(() => ({
+const { clientLoggerWarnMock, toastMessageMock } = vi.hoisted(() => ({
   clientLoggerWarnMock: vi.fn(),
+  toastMessageMock: vi.fn(),
 }));
 
 vi.mock('@/lib/logging/client', () => ({
   clientLogger: {
     error: vi.fn(),
     warn: clientLoggerWarnMock,
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    message: toastMessageMock,
   },
 }));
 
@@ -202,7 +210,7 @@ describe('useTaskStatusBatcher', () => {
     await expect(stalePromise).resolves.toBeUndefined();
     expect(flushAction).not.toHaveBeenCalled();
     expect(clientLoggerWarnMock).toHaveBeenCalledWith(
-      'Dropped out-of-scope task progress updates',
+      expect.stringContaining('Dropped out-of-scope task progress updates'),
       expect.objectContaining({ droppedCount: 1 }),
     );
   });

--- a/tests/unit/lib/api/page-boundary-result.spec.ts
+++ b/tests/unit/lib/api/page-boundary-result.spec.ts
@@ -1,0 +1,27 @@
+import { finalizePageBoundaryResult } from '@/lib/api/page-boundary-result';
+import { describe, expect, it } from 'vitest';
+
+describe('finalizePageBoundaryResult', () => {
+  it('returns boundary result when authenticated', () => {
+    expect(
+      finalizePageBoundaryResult('ok', {
+        entityId: 'plan-1',
+        unauthenticatedMessage: 'Sign in',
+        unauthenticated: (message) => ({ code: 'UNAUTHORIZED', message }),
+      }),
+    ).toBe('ok');
+  });
+
+  it('maps null boundary result to unauthenticated error', () => {
+    expect(
+      finalizePageBoundaryResult(null, {
+        entityId: 'plan-1',
+        unauthenticatedMessage: 'Sign in required',
+        unauthenticated: (message) => ({
+          code: 'UNAUTHORIZED',
+          message,
+        }),
+      }),
+    ).toEqual({ code: 'UNAUTHORIZED', message: 'Sign in required' });
+  });
+});

--- a/tests/unit/lib/next/revalidate-paths.spec.ts
+++ b/tests/unit/lib/next/revalidate-paths.spec.ts
@@ -29,11 +29,19 @@ describe('revalidatePathsBestEffort', () => {
       }
     });
 
-    revalidatePathsBestEffort(['/plans/ok', '/plans/bad', '/plans']);
+    const result = revalidatePathsBestEffort([
+      '/plans/ok',
+      '/plans/bad',
+      '/plans',
+    ]);
 
     expect(revalidatePathMock).toHaveBeenCalledTimes(3);
+    expect(result.failedPaths).toEqual(['/plans/bad']);
     expect(loggerWarnMock).toHaveBeenCalledWith(
-      expect.objectContaining({ path: '/plans/bad' }),
+      expect.objectContaining({
+        path: '/plans/bad',
+        revalidatePartialFailure: true,
+      }),
       'Failed to revalidate path after mutation',
     );
   });

--- a/tests/unit/lib/proxy-matcher.spec.ts
+++ b/tests/unit/lib/proxy-matcher.spec.ts
@@ -1,0 +1,28 @@
+import { config as proxyConfig } from '@/proxy';
+import { describe, expect, it } from 'vitest';
+
+function matchesProxyMatcher(pathname: string): boolean {
+  return proxyConfig.matcher.some((pattern) => {
+    const normalizedPattern = pattern.startsWith('/')
+      ? pattern.slice(1)
+      : pattern;
+    const regexSource = normalizedPattern.replace(/\//g, '\\/');
+    const regex = new RegExp(`^${regexSource}$`);
+    return regex.test(pathname);
+  });
+}
+
+describe('proxy matcher', () => {
+  it('includes workflow callback routes', () => {
+    expect(matchesProxyMatcher('/.well-known/workflow/v1/flow')).toBe(true);
+    expect(matchesProxyMatcher('/.well-known/workflow/v1/step')).toBe(true);
+    expect(matchesProxyMatcher('/.well-known/workflow/v1/webhook/token')).toBe(
+      true,
+    );
+  });
+
+  it('still excludes static assets and next internals', () => {
+    expect(matchesProxyMatcher('/_next/static/chunk.js')).toBe(false);
+    expect(matchesProxyMatcher('/favicon.ico')).toBe(false);
+  });
+});

--- a/tests/unit/lib/proxy-matcher.spec.ts
+++ b/tests/unit/lib/proxy-matcher.spec.ts
@@ -1,14 +1,11 @@
 import { config as proxyConfig } from '@/proxy';
+import { getPathMatch } from 'next/dist/shared/lib/router/utils/path-match';
 import { describe, expect, it } from 'vitest';
 
 function matchesProxyMatcher(pathname: string): boolean {
   return proxyConfig.matcher.some((pattern) => {
-    const normalizedPattern = pattern.startsWith('/')
-      ? pattern.slice(1)
-      : pattern;
-    const regexSource = normalizedPattern.replace(/\//g, '\\/');
-    const regex = new RegExp(`^${regexSource}$`);
-    return regex.test(pathname);
+    const match = getPathMatch(pattern);
+    return match(pathname);
   });
 }
 

--- a/tests/unit/lib/proxy-workflow-callback-auth.spec.ts
+++ b/tests/unit/lib/proxy-workflow-callback-auth.spec.ts
@@ -26,9 +26,9 @@ describe('workflow callback auth', () => {
     expect(isWorkflowCallbackPath('/.well-known/vercel/flags')).toBe(false);
   });
 
-  it('allows workflow health checks', () => {
+  it('allows workflow health checks', async () => {
     expect(
-      resolveWorkflowCallbackAccess(
+      await resolveWorkflowCallbackAccess(
         {
           method: 'HEAD',
           pathname: '/.well-known/workflow/v1/flow',
@@ -40,7 +40,7 @@ describe('workflow callback auth', () => {
     ).toEqual({ status: 'allow' });
 
     expect(
-      resolveWorkflowCallbackAccess(
+      await resolveWorkflowCallbackAccess(
         {
           method: 'POST',
           pathname: '/.well-known/workflow/v1/flow',
@@ -52,9 +52,9 @@ describe('workflow callback auth', () => {
     ).toEqual({ status: 'deny' });
   });
 
-  it('allows webhook resume routes without callback token auth', () => {
+  it('allows webhook resume routes without callback token auth', async () => {
     expect(
-      resolveWorkflowCallbackAccess(
+      await resolveWorkflowCallbackAccess(
         {
           method: 'POST',
           pathname: '/.well-known/workflow/v1/webhook/resume-token',
@@ -66,9 +66,9 @@ describe('workflow callback auth', () => {
     ).toEqual({ status: 'allow' });
   });
 
-  it('allows Vercel-hosted callbacks without a configured token', () => {
+  it('allows Vercel-hosted callbacks without a configured token', async () => {
     expect(
-      resolveWorkflowCallbackAccess(
+      await resolveWorkflowCallbackAccess(
         {
           method: 'POST',
           pathname: '/.well-known/workflow/v1/flow',
@@ -80,14 +80,14 @@ describe('workflow callback auth', () => {
     ).toEqual({ status: 'allow' });
   });
 
-  it('requires a matching token when configured', () => {
+  it('requires a matching token when configured', async () => {
     const config = {
       ...baseConfig,
       callbackToken: 'secret-token',
     };
 
     expect(
-      resolveWorkflowCallbackAccess(
+      await resolveWorkflowCallbackAccess(
         {
           method: 'POST',
           pathname: '/.well-known/workflow/v1/flow',
@@ -101,7 +101,7 @@ describe('workflow callback auth', () => {
     ).toEqual({ status: 'allow' });
 
     expect(
-      resolveWorkflowCallbackAccess(
+      await resolveWorkflowCallbackAccess(
         {
           method: 'POST',
           pathname: '/.well-known/workflow/v1/step',
@@ -115,7 +115,7 @@ describe('workflow callback auth', () => {
     ).toEqual({ status: 'allow' });
 
     expect(
-      resolveWorkflowCallbackAccess(
+      await resolveWorkflowCallbackAccess(
         {
           method: 'POST',
           pathname: '/.well-known/workflow/v1/flow',
@@ -127,9 +127,9 @@ describe('workflow callback auth', () => {
     ).toEqual({ status: 'deny' });
   });
 
-  it('rejects requests that supply both bearer and custom callback tokens', () => {
+  it('rejects requests that supply both bearer and custom callback tokens', async () => {
     expect(
-      resolveWorkflowCallbackAccess(
+      await resolveWorkflowCallbackAccess(
         {
           method: 'POST',
           pathname: '/.well-known/workflow/v1/flow',
@@ -144,9 +144,9 @@ describe('workflow callback auth', () => {
     ).toEqual({ status: 'deny' });
   });
 
-  it('allows local-world queue callbacks in non-production without a token', () => {
+  it('allows local-world queue callbacks in non-production without a token', async () => {
     expect(
-      resolveWorkflowCallbackAccess(
+      await resolveWorkflowCallbackAccess(
         {
           method: 'POST',
           pathname: '/.well-known/workflow/v1/flow',
@@ -162,9 +162,9 @@ describe('workflow callback auth', () => {
     ).toEqual({ status: 'allow' });
   });
 
-  it('denies forged local callback POSTs without queue headers or token', () => {
+  it('denies forged local callback POSTs without queue headers or token', async () => {
     expect(
-      resolveWorkflowCallbackAccess(
+      await resolveWorkflowCallbackAccess(
         {
           method: 'POST',
           pathname: '/.well-known/workflow/v1/flow',
@@ -176,7 +176,7 @@ describe('workflow callback auth', () => {
     ).toEqual({ status: 'deny' });
 
     expect(
-      resolveWorkflowCallbackAccess(
+      await resolveWorkflowCallbackAccess(
         {
           method: 'POST',
           pathname: '/.well-known/workflow/v1/step',
@@ -188,9 +188,9 @@ describe('workflow callback auth', () => {
     ).toEqual({ status: 'deny' });
   });
 
-  it('fails closed in non-Vercel production when no token is configured', () => {
+  it('fails closed in non-Vercel production when no token is configured', async () => {
     expect(
-      resolveWorkflowCallbackAccess(
+      await resolveWorkflowCallbackAccess(
         {
           method: 'POST',
           pathname: '/.well-known/workflow/v1/flow',
@@ -218,10 +218,10 @@ describe('workflow callback auth', () => {
     expect(readWorkflowCallbackToken(customHeaders)).toBe('custom-token');
   });
 
-  it('matches callback tokens with timing-safe equality', () => {
-    expect(workflowCallbackTokensMatch('secret', 'secret')).toBe(true);
-    expect(workflowCallbackTokensMatch('secret', 'other')).toBe(false);
-    expect(workflowCallbackTokensMatch('secret', 'secre')).toBe(false);
+  it('matches callback tokens with timing-safe equality', async () => {
+    expect(await workflowCallbackTokensMatch('secret', 'secret')).toBe(true);
+    expect(await workflowCallbackTokensMatch('secret', 'other')).toBe(false);
+    expect(await workflowCallbackTokensMatch('secret', 'secre')).toBe(false);
   });
 
   it('detects local-world queue headers', () => {

--- a/tests/unit/lib/proxy-workflow-callback-auth.spec.ts
+++ b/tests/unit/lib/proxy-workflow-callback-auth.spec.ts
@@ -1,0 +1,260 @@
+import {
+  hasLocalWorldQueueHeaders,
+  isWorkflowCallbackPath,
+  isWorkflowHealthCheck,
+  readWorkflowCallbackToken,
+  resolveWorkflowCallbackAccess,
+  WORKFLOW_CALLBACK_TOKEN_HEADER,
+  workflowCallbackTokensMatch,
+} from '@/lib/proxy/workflow-callback-auth';
+import { describe, expect, it } from 'vitest';
+
+const baseConfig = {
+  isProduction: false,
+  isHostedVercelDeploy: false,
+  callbackToken: undefined,
+} as const;
+
+function createHeaders(values: Record<string, string> = {}): Headers {
+  return new Headers(values);
+}
+
+describe('workflow callback auth', () => {
+  it('detects workflow callback paths', () => {
+    expect(isWorkflowCallbackPath('/.well-known/workflow/v1/flow')).toBe(true);
+    expect(isWorkflowCallbackPath('/.well-known/workflow/v1/step')).toBe(true);
+    expect(isWorkflowCallbackPath('/.well-known/vercel/flags')).toBe(false);
+  });
+
+  it('allows workflow health checks', () => {
+    expect(
+      resolveWorkflowCallbackAccess(
+        {
+          method: 'HEAD',
+          pathname: '/.well-known/workflow/v1/flow',
+          searchParams: new URLSearchParams('__health'),
+          headers: createHeaders(),
+        },
+        baseConfig,
+      ),
+    ).toEqual({ status: 'allow' });
+
+    expect(
+      resolveWorkflowCallbackAccess(
+        {
+          method: 'POST',
+          pathname: '/.well-known/workflow/v1/flow',
+          searchParams: new URLSearchParams('__health'),
+          headers: createHeaders(),
+        },
+        baseConfig,
+      ),
+    ).toEqual({ status: 'deny' });
+  });
+
+  it('allows webhook resume routes without callback token auth', () => {
+    expect(
+      resolveWorkflowCallbackAccess(
+        {
+          method: 'POST',
+          pathname: '/.well-known/workflow/v1/webhook/resume-token',
+          searchParams: new URLSearchParams(),
+          headers: createHeaders(),
+        },
+        baseConfig,
+      ),
+    ).toEqual({ status: 'allow' });
+  });
+
+  it('allows Vercel-hosted callbacks without a configured token', () => {
+    expect(
+      resolveWorkflowCallbackAccess(
+        {
+          method: 'POST',
+          pathname: '/.well-known/workflow/v1/flow',
+          searchParams: new URLSearchParams(),
+          headers: createHeaders(),
+        },
+        { ...baseConfig, isProduction: true, isHostedVercelDeploy: true },
+      ),
+    ).toEqual({ status: 'allow' });
+  });
+
+  it('requires a matching token when configured', () => {
+    const config = {
+      ...baseConfig,
+      callbackToken: 'secret-token',
+    };
+
+    expect(
+      resolveWorkflowCallbackAccess(
+        {
+          method: 'POST',
+          pathname: '/.well-known/workflow/v1/flow',
+          searchParams: new URLSearchParams(),
+          headers: createHeaders({
+            authorization: 'Bearer secret-token',
+          }),
+        },
+        config,
+      ),
+    ).toEqual({ status: 'allow' });
+
+    expect(
+      resolveWorkflowCallbackAccess(
+        {
+          method: 'POST',
+          pathname: '/.well-known/workflow/v1/step',
+          searchParams: new URLSearchParams(),
+          headers: createHeaders({
+            [WORKFLOW_CALLBACK_TOKEN_HEADER]: 'secret-token',
+          }),
+        },
+        config,
+      ),
+    ).toEqual({ status: 'allow' });
+
+    expect(
+      resolveWorkflowCallbackAccess(
+        {
+          method: 'POST',
+          pathname: '/.well-known/workflow/v1/flow',
+          searchParams: new URLSearchParams(),
+          headers: createHeaders(),
+        },
+        config,
+      ),
+    ).toEqual({ status: 'deny' });
+  });
+
+  it('rejects requests that supply both bearer and custom callback tokens', () => {
+    expect(
+      resolveWorkflowCallbackAccess(
+        {
+          method: 'POST',
+          pathname: '/.well-known/workflow/v1/flow',
+          searchParams: new URLSearchParams(),
+          headers: createHeaders({
+            authorization: 'Bearer secret-token',
+            [WORKFLOW_CALLBACK_TOKEN_HEADER]: 'secret-token',
+          }),
+        },
+        { ...baseConfig, callbackToken: 'secret-token' },
+      ),
+    ).toEqual({ status: 'deny' });
+  });
+
+  it('allows local-world queue callbacks in non-production without a token', () => {
+    expect(
+      resolveWorkflowCallbackAccess(
+        {
+          method: 'POST',
+          pathname: '/.well-known/workflow/v1/flow',
+          searchParams: new URLSearchParams(),
+          headers: createHeaders({
+            'x-vqs-queue-name': '__wkf_workflow_default',
+            'x-vqs-message-id': 'msg_123',
+            'x-vqs-message-attempt': '1',
+          }),
+        },
+        baseConfig,
+      ),
+    ).toEqual({ status: 'allow' });
+  });
+
+  it('denies forged local callback POSTs without queue headers or token', () => {
+    expect(
+      resolveWorkflowCallbackAccess(
+        {
+          method: 'POST',
+          pathname: '/.well-known/workflow/v1/flow',
+          searchParams: new URLSearchParams(),
+          headers: createHeaders(),
+        },
+        baseConfig,
+      ),
+    ).toEqual({ status: 'deny' });
+
+    expect(
+      resolveWorkflowCallbackAccess(
+        {
+          method: 'POST',
+          pathname: '/.well-known/workflow/v1/step',
+          searchParams: new URLSearchParams(),
+          headers: createHeaders(),
+        },
+        baseConfig,
+      ),
+    ).toEqual({ status: 'deny' });
+  });
+
+  it('fails closed in non-Vercel production when no token is configured', () => {
+    expect(
+      resolveWorkflowCallbackAccess(
+        {
+          method: 'POST',
+          pathname: '/.well-known/workflow/v1/flow',
+          searchParams: new URLSearchParams(),
+          headers: createHeaders({
+            'x-vqs-queue-name': '__wkf_workflow_default',
+            'x-vqs-message-id': 'msg_123',
+            'x-vqs-message-attempt': '1',
+          }),
+        },
+        { ...baseConfig, isProduction: true },
+      ),
+    ).toEqual({ status: 'misconfigured' });
+  });
+
+  it('parses callback tokens from bearer or custom header only', () => {
+    const headers = createHeaders({
+      authorization: 'Bearer bearer-token',
+    });
+    expect(readWorkflowCallbackToken(headers)).toBe('bearer-token');
+
+    const customHeaders = createHeaders({
+      [WORKFLOW_CALLBACK_TOKEN_HEADER]: 'custom-token',
+    });
+    expect(readWorkflowCallbackToken(customHeaders)).toBe('custom-token');
+  });
+
+  it('matches callback tokens with timing-safe equality', () => {
+    expect(workflowCallbackTokensMatch('secret', 'secret')).toBe(true);
+    expect(workflowCallbackTokensMatch('secret', 'other')).toBe(false);
+    expect(workflowCallbackTokensMatch('secret', 'secre')).toBe(false);
+  });
+
+  it('detects local-world queue headers', () => {
+    expect(
+      hasLocalWorldQueueHeaders(
+        createHeaders({
+          'x-vqs-queue-name': '__wkf_step_default',
+          'x-vqs-message-id': 'msg_123',
+          'x-vqs-message-attempt': '1',
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      hasLocalWorldQueueHeaders(
+        createHeaders({
+          'x-vqs-queue-name': '__wkf_step_default',
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('recognizes health-check methods', () => {
+    expect(
+      isWorkflowHealthCheck({
+        method: 'GET',
+        searchParams: new URLSearchParams('__health'),
+      }),
+    ).toBe(true);
+    expect(
+      isWorkflowHealthCheck({
+        method: 'POST',
+        searchParams: new URLSearchParams('__health'),
+      }),
+    ).toBe(false);
+  });
+});

--- a/tests/unit/lib/proxy-workflow-callback-auth.spec.ts
+++ b/tests/unit/lib/proxy-workflow-callback-auth.spec.ts
@@ -26,7 +26,7 @@ describe('workflow callback auth', () => {
     expect(isWorkflowCallbackPath('/.well-known/vercel/flags')).toBe(false);
   });
 
-  it('allows workflow health checks', async () => {
+  it('allows workflow health checks in non-production', async () => {
     expect(
       await resolveWorkflowCallbackAccess(
         {
@@ -50,6 +50,40 @@ describe('workflow callback auth', () => {
         baseConfig,
       ),
     ).toEqual({ status: 'deny' });
+  });
+
+  it('requires token for health checks in self-hosted production', async () => {
+    const config = {
+      ...baseConfig,
+      isProduction: true,
+      callbackToken: 'secret-token',
+    };
+
+    expect(
+      await resolveWorkflowCallbackAccess(
+        {
+          method: 'HEAD',
+          pathname: '/.well-known/workflow/v1/flow',
+          searchParams: new URLSearchParams('__health'),
+          headers: createHeaders(),
+        },
+        config,
+      ),
+    ).toEqual({ status: 'deny' });
+
+    expect(
+      await resolveWorkflowCallbackAccess(
+        {
+          method: 'HEAD',
+          pathname: '/.well-known/workflow/v1/flow',
+          searchParams: new URLSearchParams('__health'),
+          headers: createHeaders({
+            authorization: 'Bearer secret-token',
+          }),
+        },
+        config,
+      ),
+    ).toEqual({ status: 'allow' });
   });
 
   it('allows webhook resume routes without callback token auth', async () => {

--- a/tests/unit/lib/proxy-workflow-callback-proxy.spec.ts
+++ b/tests/unit/lib/proxy-workflow-callback-proxy.spec.ts
@@ -1,0 +1,73 @@
+import { WORKFLOW_CALLBACK_TOKEN_HEADER } from '@/lib/proxy/workflow-callback-auth';
+import { resolveWorkflowCallbackProxyAccess } from '@/lib/proxy/workflow-callback-proxy';
+import { describe, expect, it } from 'vitest';
+
+const baseConfig = {
+  isProduction: false,
+  isHostedVercelDeploy: false,
+  callbackToken: undefined,
+} as const;
+
+function createHeaders(values: Record<string, string> = {}): Headers {
+  return new Headers(values);
+}
+
+describe('resolveWorkflowCallbackProxyAccess', () => {
+  it('maps policy outcomes to proxy status codes', async () => {
+    expect(
+      await resolveWorkflowCallbackProxyAccess(
+        {
+          method: 'POST',
+          pathname: '/.well-known/workflow/v1/flow',
+          searchParams: new URLSearchParams(),
+          headers: createHeaders({
+            'x-vqs-queue-name': '__wkf_workflow_default',
+            'x-vqs-message-id': 'msg_123',
+            'x-vqs-message-attempt': '1',
+          }),
+        },
+        baseConfig,
+      ),
+    ).toBe('allow');
+
+    expect(
+      await resolveWorkflowCallbackProxyAccess(
+        {
+          method: 'POST',
+          pathname: '/.well-known/workflow/v1/flow',
+          searchParams: new URLSearchParams(),
+          headers: createHeaders(),
+        },
+        baseConfig,
+      ),
+    ).toBe('deny');
+
+    expect(
+      await resolveWorkflowCallbackProxyAccess(
+        {
+          method: 'POST',
+          pathname: '/.well-known/workflow/v1/flow',
+          searchParams: new URLSearchParams(),
+          headers: createHeaders(),
+        },
+        { ...baseConfig, isProduction: true },
+      ),
+    ).toBe('misconfigured');
+  });
+
+  it('accepts trimmed custom callback header tokens', async () => {
+    expect(
+      await resolveWorkflowCallbackProxyAccess(
+        {
+          method: 'POST',
+          pathname: '/.well-known/workflow/v1/flow',
+          searchParams: new URLSearchParams(),
+          headers: createHeaders({
+            [WORKFLOW_CALLBACK_TOKEN_HEADER]: '  secret-token  ',
+          }),
+        },
+        { ...baseConfig, callbackToken: 'secret-token' },
+      ),
+    ).toBe('allow');
+  });
+});


### PR DESCRIPTION
## Summary

- Add an Edge-safe proxy auth branch for `/.well-known/workflow/*` before Clerk, maintenance mode, and CSP decoration.
- **Vercel-hosted deploys:** trust Workflow SDK queue consumer security (`experimentalTriggers`); proxy allows callbacks through without an app token.
- **Local dev:** allow health checks (`HEAD`/`GET`/`OPTIONS` with `?__health`) and local-world queue callbacks with `x-vqs-*` headers; reject bare forged POSTs with `401`.
- **Self-hosted / non-Vercel production:** require `WORKFLOW_CALLBACK_TOKEN` via Bearer or `x-workflow-callback-token`; missing configuration returns `503`.
- Webhook resume routes (`/.well-known/workflow/v1/webhook/:token`) keep SDK URL-token auth and bypass the callback token gate.

## Approach / tradeoffs

Chose a hybrid model over a universal shared-secret guard because Vercel Queue callbacks do not carry an app-defined bearer token. Local dev works without `WORKFLOW_CALLBACK_TOKEN` via the local-world header heuristic; token enforcement is for self-hosted production only.

## Test plan

- [x] Unit tests for callback auth helper, proxy matcher, and `WORKFLOW_CALLBACK_TOKEN` env parsing
- [x] `pnpm next build`
- [x] `pnpm test:changed`
- [x] `pnpm check:full`
- [ ] Manual: `curl -I "http://127.0.0.1:3000/.well-known/workflow/v1/flow?__health"` on `pnpm dev:workflow`
- [ ] Manual: unauthenticated `POST` to flow/step on a Vercel preview URL to confirm platform consumer security

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication for durable workflow execution callbacks—a security-sensitive surface—and misconfiguration could block workflows or leave routes exposed on self-hosted production.
> 
> **Overview**
> Adds **proxy-level protection** for Workflow SDK machine routes under `/.well-known/workflow/` before Clerk, maintenance, and CSP. **Vercel** deploys still pass callbacks through without an app token; **local dev** allows `?__health` and `x-vqs-*` queue headers; **self-hosted production** requires `WORKFLOW_CALLBACK_TOKEN` (Bearer or `x-workflow-callback-token`) with timing-safe compare, returning **401** / **503** when denied or misconfigured. Webhook resume URLs stay on SDK token auth. The proxy **matcher** now includes workflow paths; allowed callbacks use a slim `next` path without CSP/nonce.
> 
> Also moves plan/module page loads from server actions into **`loadPlanForPage` / `loadModuleForPage`** via `requestBoundary.component()` and `finalizePageBoundaryResult`. Task progress batch actions surface **`revalidateFailed`** when best-effort `revalidatePath` fails, with client toasts; **`useTaskStatusBatcher`** flushes on scope changes and warns when out-of-scope updates are dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a7a9c6657b55bc7769e4bebffd1d2d5d58bd073. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->