### PR TITLE
fix(regeneration): terminalize drain-launched workflow rejections

### DIFF
--- a/docs/architecture/regeneration-worker-runbook.md
+++ b/docs/architecture/regeneration-worker-runbook.md
@@ -25,8 +25,9 @@ This endpoint drains up to `REGENERATION_MAX_JOBS_PER_DRAIN` jobs by calling `dr
 
 When `PLAN_REGENERATION_WORKFLOW_ENABLED=true`:
 
-- Successful enqueue calls `startPlanRegenerationWorkflow()` (fire-and-forget).
+- Both enqueue and drain launch via `startPlanRegenerationWorkflow()` (fire-and-forget after the run is created).
 - The drain endpoint may start a workflow per job and return `workflow-in-flight` while `job_queue.data.workflow.runId` is set.
+- Rejected workflow runs are terminalized via `failJob(..., { retryable: false })` when `run.returnValue` rejects, even if finalization never runs.
 - Terminal queue outcomes are still written by workflow finalization steps (`completed`, `retryable-failure`, `permanent-failure`, `already-finalized`).
 
 Correlate failures using `job_queue.data.workflow.runId` and logs tagged with `workflowRunId`. See [Workflow SDK](./workflow-sdk.md) (correlation metadata and local dev). Env flags: [environment variables](../development/environment.md#workflow-sdk). Local workflow testing: [development commands](../development/commands.md) (`pnpm dev:workflow`).

--- a/src/features/plans/regeneration-orchestration/process.ts
+++ b/src/features/plans/regeneration-orchestration/process.ts
@@ -12,10 +12,9 @@ import {
 } from './process-workflow-support';
 import { planRegenerationJobPayloadSchema } from './schema';
 import { JOB_TYPES } from '@/features/jobs/types';
-import { planRegenerationWorkflow } from '@/features/plans/workflows/plan-regeneration.workflow';
+import { startPlanRegenerationWorkflow } from '@/features/plans/start-plan-regeneration-workflow';
 import { workflowEnv } from '@/lib/config/env/workflow';
 import { db as serviceRoleDb } from '@supabase/service-role';
-import { start } from 'workflow/api';
 
 const UNSAFE_WORKER_FAILURE_MESSAGE = 'Queued plan regeneration failed.';
 
@@ -70,20 +69,32 @@ export async function processPlanRegenerationJob(
         };
       }
 
-      const run = await start(planRegenerationWorkflow, [
+      const workflowStart = await startPlanRegenerationWorkflow(
         {
           jobId: job.id,
           planId: payload.planId,
           userId: job.userId,
           correlationId: `regen-drain-${job.id}`,
         },
-      ]);
+        { failJob: d.queue.failJob },
+      );
+
+      if (!workflowStart.started) {
+        await d.queue.failJob(job.id, UNSAFE_WORKER_FAILURE_MESSAGE, {
+          retryable: false,
+        });
+        return {
+          kind: 'permanent-failure',
+          jobId: job.id,
+          planId: payload.planId,
+        };
+      }
 
       const launchedPayload = planRegenerationJobPayloadSchema.parse({
         ...payload,
         workflow: {
           provider: 'workflow-sdk' as const,
-          runId: run.runId,
+          runId: workflowStart.runId,
           startedAt: payload.workflow?.startedAt ?? new Date().toISOString(),
         },
       });

--- a/tests/unit/features/plans/regeneration-orchestration/process.spec.ts
+++ b/tests/unit/features/plans/regeneration-orchestration/process.spec.ts
@@ -494,7 +494,14 @@ describe('processPlanRegenerationJob', () => {
     beforeEach(() => {
       vi.stubEnv('PLAN_REGENERATION_WORKFLOW_ENABLED', 'true');
       workflowStartMock.mockReset();
-      workflowStartMock.mockResolvedValue({ runId: 'wrun_drain' });
+      workflowStartMock.mockResolvedValue({
+        runId: 'wrun_drain',
+        returnValue: Promise.resolve({
+          kind: 'completed',
+          jobId: 'job-1',
+          planId: planRow.id,
+        }),
+      });
     });
 
     afterEach(() => {
@@ -584,6 +591,35 @@ describe('processPlanRegenerationJob', () => {
         'Queued plan regeneration failed.',
         { retryable: false },
       );
+    });
+
+    it('terminalizes the job when drain-launched workflow returnValue rejects', async () => {
+      const rejection = new Error('workflow-fatal');
+      workflowStartMock.mockResolvedValue({
+        runId: 'wrun_drain',
+        returnValue: Promise.reject(rejection),
+      });
+      const failJob = vi.fn(async () => null);
+      const updateRegenerationJobPayload = vi.fn(async () => null);
+      const deps = buildProcessDeps({
+        queue: { failJob, updateRegenerationJobPayload },
+      });
+      const job = makeJob();
+
+      const result = await processPlanRegenerationJob(job, deps);
+
+      expect(result).toEqual({
+        kind: 'workflow-in-flight',
+        jobId: job.id,
+        planId: planRow.id,
+      });
+      await vi.waitFor(() => {
+        expect(failJob).toHaveBeenCalledWith(
+          job.id,
+          'Queued plan regeneration failed.',
+          { retryable: false },
+        );
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

- Terminalize regeneration workflow runs when drain-launched workflows reject, so stuck in-progress states do not linger after failures.
- Update the regeneration worker runbook and add unit coverage for the rejection path.

## Test plan

- [x] `tests/unit/features/plans/regeneration-orchestration/process.spec.ts`
- [x] `pnpm test:changed`
- [x] `pnpm check:full`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes queued regeneration job lifecycle on the internal drain path when workflows fail asynchronously; incorrect terminalization could mark jobs failed or leave them stuck, but scope is limited to workflow-enabled regeneration processing.
> 
> **Overview**
> When workflow-backed regeneration is enabled, the **drain worker** now starts runs through **`startPlanRegenerationWorkflow`** (same as enqueue) instead of calling the Workflow SDK `start` API directly. That wires in **`failJob`** so if the run’s **`returnValue` promise rejects**—without workflow finalization—the queue job is **failed non-retryably** instead of staying stuck in-flight.
> 
> Drain also treats a **failed workflow start** (`started: false`) as a **permanent failure** before persisting `runId`. The regeneration worker runbook documents enqueue/drain launch and this rejection terminalization; unit tests cover the async rejection path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7206590b11023da1dc12bb94aba5e6808f331f42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->