### PR TITLE
fix(plans): maintenance cleanup, polling refactor, and settings smoke fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,9 @@ MAINTENANCE_WORKER_TOKEN=
 # Master switch for the manual retention cleanup HTTP route; Supabase Cron is separate
 RETENTION_CLEANUP_ENABLED=
 
+# Master switch for the manual plan cleanup HTTP route (stuck plans + orphaned attempts)
+PLAN_CLEANUP_ENABLED=
+
 # Local billing: canonical price ids + in-process Stripe mock (development/test only; refused in production)
 STRIPE_LOCAL_MODE=
 

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -89,7 +89,10 @@ REGENERATION_WORKER_TOKEN=replace-with-strong-production-secret
 # Disable the manual app retention route in production; Supabase Cron owns scheduled retention.
 RETENTION_CLEANUP_ENABLED=false
 
-# Future shared bearer token for production manual retention route access.
+# Enable after the GitHub Actions plan cleanup scheduler is configured.
+PLAN_CLEANUP_ENABLED=false
+
+# Shared bearer token for production maintenance routes and the plan cleanup scheduler.
 MAINTENANCE_WORKER_TOKEN=replace-with-strong-production-secret
 
 # Production log verbosity.

--- a/.github/workflows/plan-cleanup-scheduler.yml
+++ b/.github/workflows/plan-cleanup-scheduler.yml
@@ -1,0 +1,79 @@
+name: Plan Cleanup Scheduler
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: plan-cleanup-scheduler
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Trigger production plan cleanup
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Trigger plan cleanup
+        env:
+          MAINTENANCE_WORKER_TOKEN: ${{ secrets.MAINTENANCE_WORKER_TOKEN }}
+          PLAN_CLEANUP_URL: https://atlaris.app/api/internal/maintenance/plans/cleanup
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${MAINTENANCE_WORKER_TOKEN}" ]]; then
+            echo "::error title=Plan cleanup scheduler misconfigured::MAINTENANCE_WORKER_TOKEN is not configured."
+            exit 1
+          fi
+
+          response_file="$(mktemp)"
+          trap 'rm -f "${response_file}"' EXIT
+
+          status_code="$(
+            curl \
+              --silent \
+              --show-error \
+              --output "${response_file}" \
+              --write-out '%{http_code}' \
+              --request POST \
+              --max-time 120 \
+              --retry 2 \
+              --retry-delay 5 \
+              --header "Authorization: Bearer ${MAINTENANCE_WORKER_TOKEN}" \
+              --header 'User-Agent: atlaris-plan-cleanup-scheduler' \
+              "${PLAN_CLEANUP_URL}"
+          )"
+
+          case "${status_code}" in
+            200)
+              if ! jq -e '.ok == true' "${response_file}" >/dev/null; then
+                echo "::error title=Plan cleanup invalid response::Endpoint returned 200 without ok=true."
+                exit 1
+              fi
+              ;;
+            401)
+              echo "::error title=Plan cleanup unauthorized (401)::Production and GitHub worker tokens do not match."
+              exit 1
+              ;;
+            500)
+              echo "::error title=Plan cleanup failed (500)::Cleanup logic failed. Inspect Vercel and Sentry logs."
+              exit 1
+              ;;
+            503)
+              echo "::error title=Plan cleanup unavailable (503)::PLAN_CLEANUP_ENABLED is false or the production worker token is missing."
+              exit 1
+              ;;
+            *)
+              echo "::error title=Plan cleanup unexpected response::Endpoint returned HTTP ${status_code}."
+              exit 1
+              ;;
+          esac
+
+          jq -c \
+            '{ok, stuckPlansCleaned, orphanedAttemptsCleaned}' \
+            "${response_file}"

--- a/docs/architecture/internal-worker-routes.md
+++ b/docs/architecture/internal-worker-routes.md
@@ -11,7 +11,7 @@ Three POST routes live under `/api/internal/`. They bypass Clerk middleware and 
 | -------------------------------------------------- | ----------------------------------- | ---------------------- | ---------- |
 | `POST /api/internal/jobs/regeneration/process`     | Drain queued plan regeneration jobs | `regenerationQueueEnv` | External scheduler required |
 | `POST /api/internal/maintenance/retention/cleanup` | Retention cleanup (manual fallback) | `maintenanceEnv`       | Supabase `pg_cron` daily; HTTP route is manual fallback |
-| `POST /api/internal/maintenance/plans/cleanup`     | Stuck-plan and orphaned-attempt cleanup | `maintenanceEnv`       | External scheduler required (no `pg_cron`) |
+| `POST /api/internal/maintenance/plans/cleanup`     | Stuck-plan and orphaned-attempt cleanup | `maintenanceEnv`       | GitHub Actions every 15 minutes |
 
 Maintenance cleanup routes share `assertMaintenanceWorkerAccess()` in `src/lib/api/internal/internal-worker-access.ts`. The regeneration drain uses `assertInternalWorkerAccess()` directly.
 

--- a/docs/architecture/internal-worker-routes.md
+++ b/docs/architecture/internal-worker-routes.md
@@ -1,19 +1,19 @@
 # Internal Worker Routes
 
 **Audience:** Developers and operators triggering internal worker or manual maintenance routes.
-**Last Updated:** May 2026
+**Last Updated:** June 2026
 
 ## Overview
 
 Three POST routes live under `/api/internal/`. They bypass Clerk middleware and authenticate callers with shared worker tokens when enabled.
 
-| Route                                              | Purpose                             | Env config             |
-| -------------------------------------------------- | ----------------------------------- | ---------------------- |
-| `POST /api/internal/jobs/regeneration/process`     | Drain queued plan regeneration jobs | `regenerationQueueEnv` |
-| `POST /api/internal/maintenance/retention/cleanup` | Manual retention cleanup fallback   | `maintenanceEnv`       |
-| `POST /api/internal/maintenance/plans/cleanup`     | Manual stuck-plan and orphaned-attempt cleanup | `maintenanceEnv` |
+| Route                                              | Purpose                             | Env config             | Scheduling |
+| -------------------------------------------------- | ----------------------------------- | ---------------------- | ---------- |
+| `POST /api/internal/jobs/regeneration/process`     | Drain queued plan regeneration jobs | `regenerationQueueEnv` | External scheduler required |
+| `POST /api/internal/maintenance/retention/cleanup` | Retention cleanup (manual fallback) | `maintenanceEnv`       | Supabase `pg_cron` daily; HTTP route is manual fallback |
+| `POST /api/internal/maintenance/plans/cleanup`     | Stuck-plan and orphaned-attempt cleanup | `maintenanceEnv`       | External scheduler required (no `pg_cron`) |
 
-Both routes share `assertInternalWorkerAccess()` in `src/lib/api/internal/internal-worker-access.ts`.
+Maintenance cleanup routes share `assertMaintenanceWorkerAccess()` in `src/lib/api/internal/internal-worker-access.ts`. The regeneration drain uses `assertInternalWorkerAccess()` directly.
 
 ## Authentication
 
@@ -43,4 +43,5 @@ Requests that supply both Bearer and the custom header are rejected.
 
 - [Regeneration worker runbook](./regeneration-worker-runbook.md)
 - [Retention cleanup runbook](./retention-cleanup-runbook.md)
+- [Plan cleanup runbook](./plan-cleanup-runbook.md)
 - [Environment variables](../development/environment.md)

--- a/docs/architecture/internal-worker-routes.md
+++ b/docs/architecture/internal-worker-routes.md
@@ -5,12 +5,13 @@
 
 ## Overview
 
-Two POST routes live under `/api/internal/`. They bypass Clerk middleware and authenticate callers with shared worker tokens when enabled.
+Three POST routes live under `/api/internal/`. They bypass Clerk middleware and authenticate callers with shared worker tokens when enabled.
 
 | Route                                              | Purpose                             | Env config             |
 | -------------------------------------------------- | ----------------------------------- | ---------------------- |
 | `POST /api/internal/jobs/regeneration/process`     | Drain queued plan regeneration jobs | `regenerationQueueEnv` |
 | `POST /api/internal/maintenance/retention/cleanup` | Manual retention cleanup fallback   | `maintenanceEnv`       |
+| `POST /api/internal/maintenance/plans/cleanup`     | Manual stuck-plan and orphaned-attempt cleanup | `maintenanceEnv` |
 
 Both routes share `assertInternalWorkerAccess()` in `src/lib/api/internal/internal-worker-access.ts`.
 
@@ -25,6 +26,7 @@ Each route accepts **one** of:
 | ------------------ | ----------------------------- | --------------------------- |
 | Regeneration drain | `x-regeneration-worker-token` | `REGENERATION_WORKER_TOKEN` |
 | Retention cleanup  | `x-maintenance-worker-token`  | `MAINTENANCE_WORKER_TOKEN`  |
+| Plan cleanup       | `x-maintenance-worker-token`  | `MAINTENANCE_WORKER_TOKEN`  |
 
 Requests that supply both Bearer and the custom header are rejected.
 

--- a/docs/architecture/plan-cleanup-runbook.md
+++ b/docs/architecture/plan-cleanup-runbook.md
@@ -16,16 +16,18 @@ Cleanup operations:
 
 | Variable                   | Purpose                                                                                      | Production expectation                 |
 | -------------------------- | -------------------------------------------------------------------------------------------- | -------------------------------------- |
-| `PLAN_CLEANUP_ENABLED`     | Master switch for the plan cleanup HTTP endpoint (defaults to `false` when unset)            | Set `true` in environments where cleanup runs |
-| `MAINTENANCE_WORKER_TOKEN` | Bearer token for internal route auth                                                         | Required when `PLAN_CLEANUP_ENABLED=true` in production |
+| `PLAN_CLEANUP_ENABLED`     | Master switch for the plan cleanup HTTP endpoint (defaults to `false` when unset)            | Set `true` in Vercel Production |
+| `MAINTENANCE_WORKER_TOKEN` | Bearer token for internal route auth                                                         | Set to the same secret in Vercel Production and GitHub Actions |
 
 ## Scheduled Cleanup
 
-Plan cleanup has **no** `pg_cron` schedule. Production must configure an external scheduler (Vercel Cron, GitHub Actions, or equivalent) to POST to the internal route.
+Plan cleanup has **no** `pg_cron` schedule. Production is scheduled by `.github/workflows/plan-cleanup-scheduler.yml`, which POSTs to `https://atlaris.app/api/internal/maintenance/plans/cleanup` every 15 minutes.
 
-Recommended cadence: **every 5–15 minutes**. Stuck thresholds are 15 minutes, so a 5–15 minute schedule ensures abandoned plans are recovered promptly without excessive load.
+The workflow uses the `MAINTENANCE_WORKER_TOKEN` GitHub Actions secret as a Bearer token. The same value must be configured in Vercel Production. The workflow fails with a status-specific annotation for `401`, `500`, and `503`, and it rejects a `200` response unless the JSON body contains `"ok": true`.
 
-Example scheduler request:
+Vercel Cron is intentionally not used: the project is on the Hobby plan, which only supports one cron invocation per day. The 15-minute recovery target therefore uses GitHub Actions.
+
+Equivalent scheduler request:
 
 ```bash
 curl -X POST "https://<app-host>/api/internal/maintenance/plans/cleanup" \
@@ -59,13 +61,53 @@ Success shape:
 
 Failure shape follows the canonical API error contract (`docs/api/error-contract.md`). A partial bulk update during stuck-plan cleanup throws and returns `500`.
 
+## Production Scheduler Verification
+
+| Check | Expected |
+| ----- | -------- |
+| Workflow | `.github/workflows/plan-cleanup-scheduler.yml` |
+| Target URL | `https://atlaris.app/api/internal/maintenance/plans/cleanup` |
+| HTTP method | `POST` |
+| Cadence | Every **15 minutes** |
+| Auth mechanism | `Authorization: Bearer <token>` |
+| Token source | GitHub Actions and Vercel Production use the same `MAINTENANCE_WORKER_TOKEN` value |
+| Scheduler history | At least one recent run shows **HTTP 200** |
+| Response body | `{ "ok": true, "stuckPlansCleaned": <number>, "orphanedAttemptsCleaned": <number> }` |
+
+Manual spot-check (replace host; use the same header the scheduler uses):
+
+```bash
+curl -sS -o /tmp/plan-cleanup.json -w "%{http_code}" \
+  -X POST "https://<production-host>/api/internal/maintenance/plans/cleanup" \
+  -H "Authorization: Bearer ${MAINTENANCE_WORKER_TOKEN}"
+```
+
+Success evidence: exit prints `200` and `/tmp/plan-cleanup.json` contains `"ok":true`.
+
+## Alerting
+
+Authenticated cleanup executions are wrapped in the Sentry Cron monitor `plan-cleanup-maintenance`. The monitor runs on the same 15-minute schedule, creates an issue after one failed or missed check-in, and resolves after one successful recovery check-in.
+
+| Status | Meaning | Alert expectation | Log / signal hints |
+| ------ | ------- | ----------------- | ------------------ |
+| **401** | Worker token missing, wrong, or mismatched | GitHub workflow fails immediately; Sentry monitor becomes missed if authentication remains broken | `Unauthorized plan cleanup trigger attempt` with `hasToken: true/false` |
+| **503** | Route disabled or production missing `MAINTENANCE_WORKER_TOKEN` | GitHub workflow fails immediately; Sentry monitor becomes missed while cleanup is unavailable | `Plan cleanup is currently unavailable.`; `Maintenance worker token missing in production` |
+| **500** | Cleanup logic failed after auth | GitHub workflow fails immediately and Sentry records an error check-in | `stuck_plans_cleanup_partial_failure` |
+| **200 with a full batch** | At least 1,000 stuck plans were eligible in one run | Investigate recurring full batches before recovery falls behind | `stuck_plans_cleanup_batch_full` |
+
+Verification steps:
+
+1. Confirm the GitHub Actions workflow history contains a recent successful scheduled run.
+2. Confirm Sentry monitor `plan-cleanup-maintenance` has a recent successful check-in.
+3. After rotating the token, update GitHub Actions and Vercel Production before the next scheduled run.
+4. For 500 triage, search logs for `stuck_plans_cleanup_partial_failure` and correlate with plans stuck in `generating` past the 15-minute threshold.
+
 ## Operational Checks
 
-- Verify the external scheduler is active and posting on the expected cadence.
+- Verify the GitHub Actions scheduler is active and posting every 15 minutes.
 - Monitor plans stuck in `generating` status for longer than the 15-minute threshold.
 - Monitor orphaned `in_progress` generation attempts with null classification.
-- Alert on `401` responses from the internal cleanup endpoint (token mismatch/absence).
-- Alert on `503` responses (`PLAN_CLEANUP_ENABLED=false` or missing worker token in production).
+- Verify GitHub workflow failure notifications and the Sentry Cron monitor remain enabled.
 
 ## Incident Response
 

--- a/docs/architecture/plan-cleanup-runbook.md
+++ b/docs/architecture/plan-cleanup-runbook.md
@@ -1,0 +1,75 @@
+# Plan Cleanup Runbook
+
+**Audience:** Developers and operators running stuck-plan and orphaned-attempt maintenance.
+**Last Updated:** June 2026
+
+## Overview
+
+Plans stuck in `generating` status and orphaned `in_progress` generation attempts are cleaned up by application code in `src/features/plans/cleanup.ts`. Unlike retention cleanup, this logic is **not** duplicated in a database function or `pg_cron` job — the canonical production path is an external scheduler that POSTs to the internal maintenance route.
+
+Cleanup operations:
+
+- **Stuck plans:** Plans in `generating` status with `updated_at` older than 15 minutes are marked `failed`.
+- **Orphaned attempts:** `in_progress` generation attempts with no classification and `created_at` older than 15 minutes are finalized with `status=failure` and `classification=timeout`.
+
+## Required Environment
+
+| Variable                   | Purpose                                                                                      | Production expectation                 |
+| -------------------------- | -------------------------------------------------------------------------------------------- | -------------------------------------- |
+| `PLAN_CLEANUP_ENABLED`     | Master switch for the plan cleanup HTTP endpoint (defaults to `false` when unset)            | Set `true` in environments where cleanup runs |
+| `MAINTENANCE_WORKER_TOKEN` | Bearer token for internal route auth                                                         | Required when `PLAN_CLEANUP_ENABLED=true` in production |
+
+## Scheduled Cleanup
+
+Plan cleanup has **no** `pg_cron` schedule. Production must configure an external scheduler (Vercel Cron, GitHub Actions, or equivalent) to POST to the internal route.
+
+Recommended cadence: **every 5–15 minutes**. Stuck thresholds are 15 minutes, so a 5–15 minute schedule ensures abandoned plans are recovered promptly without excessive load.
+
+Example scheduler request:
+
+```bash
+curl -X POST "https://<app-host>/api/internal/maintenance/plans/cleanup" \
+  -H "Authorization: Bearer ${MAINTENANCE_WORKER_TOKEN}"
+```
+
+Alternate auth (Bearer and custom header are mutually exclusive):
+
+```bash
+curl -X POST "https://<app-host>/api/internal/maintenance/plans/cleanup" \
+  -H "x-maintenance-worker-token: ${MAINTENANCE_WORKER_TOKEN}"
+```
+
+In non-production environments, if the route is enabled and no worker token is configured, auth is not required.
+
+## Manual Cleanup
+
+Operators can trigger the same cleanup through the internal route when `PLAN_CLEANUP_ENABLED=true` (see curl examples above).
+
+## Expected Response
+
+Success shape:
+
+```json
+{
+  "ok": true,
+  "stuckPlansCleaned": 0,
+  "orphanedAttemptsCleaned": 0
+}
+```
+
+Failure shape follows the canonical API error contract (`docs/api/error-contract.md`). A partial bulk update during stuck-plan cleanup throws and returns `500`.
+
+## Operational Checks
+
+- Verify the external scheduler is active and posting on the expected cadence.
+- Monitor plans stuck in `generating` status for longer than the 15-minute threshold.
+- Monitor orphaned `in_progress` generation attempts with null classification.
+- Alert on `401` responses from the internal cleanup endpoint (token mismatch/absence).
+- Alert on `503` responses (`PLAN_CLEANUP_ENABLED=false` or missing worker token in production).
+
+## Incident Response
+
+1. **Plans stuck in generating:** verify the external scheduler is running, manually trigger the internal endpoint, and inspect application logs for `stuck_plans_cleanup_partial_failure` errors.
+2. **401 unauthorized:** rotate/redeploy `MAINTENANCE_WORKER_TOKEN`; confirm Bearer or `x-maintenance-worker-token` on scheduler/manual triggers.
+3. **Emergency pause:** set `PLAN_CLEANUP_ENABLED=false` while investigating. Stuck plans will accumulate until cleanup is re-enabled.
+4. **Partial cleanup failure (500):** inspect logs for `stuck_plans_cleanup_partial_failure`; this indicates a locked plan was not updated — investigate concurrent generation state changes or DB issues before re-triggering.

--- a/docs/development/commands.md
+++ b/docs/development/commands.md
@@ -4,6 +4,11 @@ Quick reference for all common development commands.
 
 See [deploy.md](./deploy.md) for rollout notes that need ordered app-vs-migration deploys.
 
+## Package manager
+
+- CI pins **pnpm 9** (see `.github/workflows/ci-pr.yml`).
+- Supply-chain release-age policy (`minimumReleaseAge`) is **deferred** until a pnpm 10.16+ upgrade — see [supply-chain policy](../security/supply-chain-policy.md).
+
 ## Development Server
 
 > **Note**: Do not auto-run these commands; listed for reference only.

--- a/docs/development/deploy.md
+++ b/docs/development/deploy.md
@@ -21,8 +21,12 @@ After deploying a release that includes new Supabase migrations:
 2. If the CLI reports out-of-order local migrations, use `supabase db push --include-all` against the target project (see `docs/architecture/retention-cleanup-runbook.md`).
 3. Set worker tokens in the target environment for enabled internal routes:
    - `REGENERATION_WORKER_TOKEN` for regeneration drains
-   - `RETENTION_CLEANUP_ENABLED=true` and/or `PLAN_CLEANUP_ENABLED=true` plus `MAINTENANCE_WORKER_TOKEN` only when enabling manual maintenance routes
-4. Verify scheduled retention cleanup after migration `20260522223908_schedule_retention_cleanup.sql`:
+   - `RETENTION_CLEANUP_ENABLED=true` and/or `PLAN_CLEANUP_ENABLED=true` plus `MAINTENANCE_WORKER_TOKEN` only when enabling maintenance routes
+4. Verify plan cleanup scheduler when `PLAN_CLEANUP_ENABLED=true`:
+   - Configure an external scheduler (Vercel Cron, GitHub Actions, or equivalent) to `POST /api/internal/maintenance/plans/cleanup` every 5–15 minutes with `x-maintenance-worker-token` or `Authorization: Bearer`.
+   - Confirm the first scheduled run returns `200` with `ok: true`.
+   - See `docs/architecture/plan-cleanup-runbook.md`.
+5. Verify scheduled retention cleanup after migration `20260522223908_schedule_retention_cleanup.sql`:
 
 ```sql
 SELECT jobid, jobname, schedule, active
@@ -37,3 +41,4 @@ See also:
 - `docs/architecture/internal-worker-routes.md`
 - `docs/architecture/regeneration-worker-runbook.md`
 - `docs/architecture/retention-cleanup-runbook.md`
+- `docs/architecture/plan-cleanup-runbook.md`

--- a/docs/development/deploy.md
+++ b/docs/development/deploy.md
@@ -21,7 +21,7 @@ After deploying a release that includes new Supabase migrations:
 2. If the CLI reports out-of-order local migrations, use `supabase db push --include-all` against the target project (see `docs/architecture/retention-cleanup-runbook.md`).
 3. Set worker tokens in the target environment for enabled internal routes:
    - `REGENERATION_WORKER_TOKEN` for regeneration drains
-   - `RETENTION_CLEANUP_ENABLED=true` plus `MAINTENANCE_WORKER_TOKEN` only when enabling the manual retention route
+   - `RETENTION_CLEANUP_ENABLED=true` and/or `PLAN_CLEANUP_ENABLED=true` plus `MAINTENANCE_WORKER_TOKEN` only when enabling manual maintenance routes
 4. Verify scheduled retention cleanup after migration `20260522223908_schedule_retention_cleanup.sql`:
 
 ```sql

--- a/docs/development/deploy.md
+++ b/docs/development/deploy.md
@@ -22,10 +22,10 @@ After deploying a release that includes new Supabase migrations:
 3. Set worker tokens in the target environment for enabled internal routes:
    - `REGENERATION_WORKER_TOKEN` for regeneration drains
    - `RETENTION_CLEANUP_ENABLED=true` and/or `PLAN_CLEANUP_ENABLED=true` plus `MAINTENANCE_WORKER_TOKEN` only when enabling maintenance routes
-4. Verify plan cleanup scheduler when `PLAN_CLEANUP_ENABLED=true`:
-   - Configure an external scheduler (Vercel Cron, GitHub Actions, or equivalent) to `POST /api/internal/maintenance/plans/cleanup` every 5–15 minutes with `x-maintenance-worker-token` or `Authorization: Bearer`.
-   - Confirm the first scheduled run returns `200` with `ok: true`.
-   - See `docs/architecture/plan-cleanup-runbook.md`.
+4. Verify plan cleanup scheduler and alerting when `PLAN_CLEANUP_ENABLED=true`:
+   - Set the same `MAINTENANCE_WORKER_TOKEN` value in Vercel Production and the GitHub Actions repository secret.
+   - Confirm `.github/workflows/plan-cleanup-scheduler.yml` runs every 15 minutes and returns `200` with `ok: true`.
+   - Confirm Sentry monitor `plan-cleanup-maintenance` receives successful check-ins; GitHub workflow failures identify `401`, `503`, and `500` responses.
 5. Verify scheduled retention cleanup after migration `20260522223908_schedule_retention_cleanup.sql`:
 
 ```sql

--- a/docs/development/environment.md
+++ b/docs/development/environment.md
@@ -97,7 +97,8 @@ Shared bearer tokens for scheduler-triggered POST routes under `/api/internal/`.
 | --------------------------- | ------------------------------------------------------------------ | ---------------------------------------------- |
 | `REGENERATION_WORKER_TOKEN` | Auth for `POST /api/internal/jobs/regeneration/process`            | Yes                                            |
 | `RETENTION_CLEANUP_ENABLED` | Master switch for the **manual** retention cleanup HTTP route only | Set `true` only when enabling the manual route |
-| `MAINTENANCE_WORKER_TOKEN`  | Auth for `POST /api/internal/maintenance/retention/cleanup`        | Yes only when manual route is enabled          |
+| `PLAN_CLEANUP_ENABLED`      | Master switch for the **manual** plan cleanup HTTP route only        | Set `true` only when enabling the manual route |
+| `MAINTENANCE_WORKER_TOKEN`  | Auth for manual maintenance cleanup routes                           | Yes when any manual maintenance route is enabled |
 
 Scheduled retention cleanup runs via Supabase Cron (`private.cleanup_retained_db_rows()`) and does not use these HTTP env vars. See `docs/architecture/retention-cleanup-runbook.md`.
 

--- a/docs/development/environment.md
+++ b/docs/development/environment.md
@@ -97,10 +97,12 @@ Shared bearer tokens for scheduler-triggered POST routes under `/api/internal/`.
 | --------------------------- | ------------------------------------------------------------------ | ---------------------------------------------- |
 | `REGENERATION_WORKER_TOKEN` | Auth for `POST /api/internal/jobs/regeneration/process`            | Yes                                            |
 | `RETENTION_CLEANUP_ENABLED` | Master switch for the **manual** retention cleanup HTTP route only | Set `true` only when enabling the manual route |
-| `PLAN_CLEANUP_ENABLED`      | Master switch for the **manual** plan cleanup HTTP route only        | Set `true` only when enabling the manual route |
-| `MAINTENANCE_WORKER_TOKEN`  | Auth for manual maintenance cleanup routes                           | Yes when any manual maintenance route is enabled |
+| `PLAN_CLEANUP_ENABLED`      | Master switch for the plan cleanup HTTP route                        | Set `true` when scheduled cleanup is enabled |
+| `MAINTENANCE_WORKER_TOKEN`  | Auth for maintenance cleanup routes and the plan cleanup scheduler   | Yes when any maintenance route is enabled |
 
 Scheduled retention cleanup runs via Supabase Cron (`private.cleanup_retained_db_rows()`) and does not use these HTTP env vars. See `docs/architecture/retention-cleanup-runbook.md`.
+
+Scheduled plan cleanup runs from `.github/workflows/plan-cleanup-scheduler.yml`. Configure the same `MAINTENANCE_WORKER_TOKEN` value in Vercel Production and the GitHub Actions repository secret.
 
 ### Local product testing (development / test)
 

--- a/docs/security/security-audit-checklist.md
+++ b/docs/security/security-audit-checklist.md
@@ -221,6 +221,7 @@
 - [ ] Lockfile integrity: pinned versions, no untrusted git dependencies.
 - [ ] Watch for malicious install scripts (postinstall) and CI execution risks.
 - [ ] `pnpm audit` runs in CI and blocks on high/critical vulnerabilities.
+- [ ] `minimumReleaseAge` supply-chain policy documented in [supply-chain-policy.md](./supply-chain-policy.md) (deferred until pnpm 10.16+ upgrade).
 - [ ] Dependabot or similar enabled for security updates.
 - [ ] Review new dependencies before adding (check maintainer, download count, last update).
 

--- a/docs/security/supply-chain-policy.md
+++ b/docs/security/supply-chain-policy.md
@@ -1,0 +1,41 @@
+# Supply-chain policy: pnpm `minimumReleaseAge`
+
+## Current decision (2026-06-08)
+
+**Deferred** until the repo completes a coordinated **pnpm 10.16+** (or pnpm 11) toolchain upgrade.
+
+### Rationale
+
+- `minimumReleaseAge` is supported in **pnpm 10.16+** and is configured in **`pnpm-workspace.yaml`** per upstream docs.
+- Atlaris currently pins **pnpm 9** in CI (`.github/workflows/ci-pr.yml`, `.github/workflows/ci-trunk.yml`) and stores pnpm settings under the **`pnpm`** key in `package.json`.
+- Adding the setting now would be **inert or misleading** on pnpm 9 and could give a false sense of enforcement.
+
+### Intended policy when adopted
+
+| Setting | Value | Notes |
+| --- | --- | --- |
+| `minimumReleaseAge` | `10080` (7 days) | Blocks installs of packages published within the window |
+| `minimumReleaseAgeStrict` | `true` (explicit) | Fail when only fresh versions satisfy semver ranges |
+| Config location | `pnpm-workspace.yaml` | After pnpm upgrade; migrate existing `package.json` pnpm config as needed |
+
+### CVE exception workflow
+
+1. Maintainer opens a PR adding the package/version to `minimumReleaseAgeExclude` in `pnpm-workspace.yaml`.
+2. PR description must cite the CVE/advisory and why waiting 7 days is unacceptable.
+3. At least one repo maintainer approves the exclusion.
+4. Remove the exclusion in a follow-up PR once a stable release clears the age window, unless the exclusion is documented as long-lived.
+
+### Adoption sequence (two PRs)
+
+1. **Toolchain PR:** bump `packageManager`, CI pnpm setup, dev docs, verify `pnpm install --frozen-lockfile` and CI.
+2. **Policy PR:** add `pnpm-workspace.yaml` policy, update this doc and `docs/security/security-audit-checklist.md` §20.
+
+### Verification checklist (when adopted)
+
+```bash
+pnpm install --frozen-lockfile
+pnpm audit --prod --audit-level=high
+pnpm check:full
+```
+
+Attempt installing a package published within the configured window and confirm it is blocked per strictness settings.

--- a/src/app/(app)/plans/[id]/components/PlanDetails.tsx
+++ b/src/app/(app)/plans/[id]/components/PlanDetails.tsx
@@ -18,11 +18,32 @@ import { getLoggableErrorDetails } from '@/lib/errors';
 import { clientLogger } from '@/lib/logging/client';
 import { ArrowLeft, Trash2 } from 'lucide-react';
 import Link from 'next/link';
-import { type ReactElement, useCallback, useMemo } from 'react';
+import { type ReactElement } from 'react';
 import { toast } from 'sonner';
 
 interface PlanDetailClientProps {
   plan: ClientPlanDetail;
+}
+
+function handleTaskStatusError({
+  error,
+  taskId,
+  previousStatus,
+  nextStatus,
+}: {
+  error: unknown;
+  taskId: string;
+  previousStatus: ProgressStatus;
+  nextStatus: ProgressStatus;
+}) {
+  const { errorMessage, errorStack } = getLoggableErrorDetails(error);
+  clientLogger.error('Optimistic status revert', {
+    errorMessage,
+    errorStack,
+    taskId,
+    previousStatus,
+    nextStatus,
+  });
 }
 
 /**
@@ -31,48 +52,21 @@ interface PlanDetailClientProps {
 export function PlanDetails({ plan }: PlanDetailClientProps): ReactElement {
   const modules = plan.modules;
   const initialStatuses = getStatusesFromModules(modules);
-  const scopedTaskIds = useMemo(
-    () =>
-      new Set(modules.flatMap((module) => module.tasks.map((task) => task.id))),
-    [modules],
+  const scopedTaskIds = new Set(
+    modules.flatMap((module) => module.tasks.map((task) => task.id)),
   );
 
-  const flushTaskProgress = useCallback(
-    async (updates: Array<{ taskId: string; status: ProgressStatus }>) => {
-      const result = await batchUpdateTaskProgressAction({
-        planId: plan.id,
-        updates,
-      });
-      if (result?.revalidateFailed) {
-        toast.message('Progress saved. Refresh if the page looks stale.');
-      }
-    },
-    [plan.id],
-  );
-
-  const handleTaskStatusError = useCallback(
-    ({
-      error,
-      taskId,
-      previousStatus,
-      nextStatus,
-    }: {
-      error: unknown;
-      taskId: string;
-      previousStatus: ProgressStatus;
-      nextStatus: ProgressStatus;
-    }) => {
-      const { errorMessage, errorStack } = getLoggableErrorDetails(error);
-      clientLogger.error('Optimistic status revert', {
-        errorMessage,
-        errorStack,
-        taskId,
-        previousStatus,
-        nextStatus,
-      });
-    },
-    [],
-  );
+  async function flushTaskProgress(
+    updates: Array<{ taskId: string; status: ProgressStatus }>,
+  ) {
+    const result = await batchUpdateTaskProgressAction({
+      planId: plan.id,
+      updates,
+    });
+    if (result?.revalidateFailed) {
+      toast.message('Progress saved. Refresh if the page looks stale.');
+    }
+  }
 
   const { statuses, handleStatusChange } = useOptimisticTaskStatusUpdates({
     initialStatuses,
@@ -81,10 +75,7 @@ export function PlanDetails({ plan }: PlanDetailClientProps): ReactElement {
     onError: handleTaskStatusError,
   });
 
-  const overviewStats = useMemo(
-    () => computeOverviewStats(plan, statuses),
-    [plan, statuses],
-  );
+  const overviewStats = computeOverviewStats(plan, statuses);
 
   const isPendingOrProcessing =
     plan.status === 'pending' || plan.status === 'processing';

--- a/src/app/(app)/plans/[id]/components/PlanDetails.tsx
+++ b/src/app/(app)/plans/[id]/components/PlanDetails.tsx
@@ -12,38 +12,16 @@ import {
   getStatusesFromModules,
 } from '@/app/(app)/plans/[id]/helpers';
 import { useOptimisticTaskStatusUpdates } from '@/app/(app)/plans/[id]/hooks/useOptimisticTaskStatusUpdates';
+import { logTaskStatusError } from '@/app/(app)/plans/[id]/log-task-status-error';
 import { DeletePlanDialog } from '@/app/(app)/plans/components/DeletePlanDialog';
 import { Button } from '@/components/ui/button';
-import { getLoggableErrorDetails } from '@/lib/errors';
-import { clientLogger } from '@/lib/logging/client';
 import { ArrowLeft, Trash2 } from 'lucide-react';
 import Link from 'next/link';
-import { type ReactElement } from 'react';
+import { type ReactElement, useMemo } from 'react';
 import { toast } from 'sonner';
 
 interface PlanDetailClientProps {
   plan: ClientPlanDetail;
-}
-
-function handleTaskStatusError({
-  error,
-  taskId,
-  previousStatus,
-  nextStatus,
-}: {
-  error: unknown;
-  taskId: string;
-  previousStatus: ProgressStatus;
-  nextStatus: ProgressStatus;
-}) {
-  const { errorMessage, errorStack } = getLoggableErrorDetails(error);
-  clientLogger.error('Optimistic status revert', {
-    errorMessage,
-    errorStack,
-    taskId,
-    previousStatus,
-    nextStatus,
-  });
 }
 
 /**
@@ -52,8 +30,10 @@ function handleTaskStatusError({
 export function PlanDetails({ plan }: PlanDetailClientProps): ReactElement {
   const modules = plan.modules;
   const initialStatuses = getStatusesFromModules(modules);
-  const scopedTaskIds = new Set(
-    modules.flatMap((module) => module.tasks.map((task) => task.id)),
+  const scopedTaskIds = useMemo(
+    () =>
+      new Set(modules.flatMap((module) => module.tasks.map((task) => task.id))),
+    [modules],
   );
 
   async function flushTaskProgress(
@@ -72,7 +52,7 @@ export function PlanDetails({ plan }: PlanDetailClientProps): ReactElement {
     initialStatuses,
     scopedTaskIds,
     flushAction: flushTaskProgress,
-    onError: handleTaskStatusError,
+    onError: logTaskStatusError,
   });
 
   const overviewStats = computeOverviewStats(plan, statuses);

--- a/src/app/(app)/plans/[id]/components/PlanTimeline.tsx
+++ b/src/app/(app)/plans/[id]/components/PlanTimeline.tsx
@@ -15,7 +15,7 @@ import { getStatusesFromModules } from '@/app/(app)/plans/[id]/helpers';
 import { Accordion } from '@/components/ui/accordion';
 import { Card, CardContent } from '@/components/ui/card';
 import { deriveActiveModuleId } from '@/features/plans/task-progress/client';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 
 interface ModuleTimelineProps {
   planId: string;
@@ -30,24 +30,12 @@ export function PlanTimeline({
   statuses,
   onStatusChange,
 }: ModuleTimelineProps) {
-  const effectiveStatuses = useMemo(
-    () => statuses ?? getStatusesFromModules(modules),
-    [statuses, modules],
-  );
+  const effectiveStatuses = statuses ?? getStatusesFromModules(modules);
 
-  const timelineModules = useMemo(
-    () => deriveTimelineModules(modules, effectiveStatuses),
-    [modules, effectiveStatuses],
-  );
+  const timelineModules = deriveTimelineModules(modules, effectiveStatuses);
 
-  const activeModuleId = useMemo(
-    () => deriveActiveModuleId(modules, effectiveStatuses),
-    [modules, effectiveStatuses],
-  );
-  const isPlanComplete = useMemo(
-    () => isPlanTimelineComplete(modules, effectiveStatuses),
-    [modules, effectiveStatuses],
-  );
+  const activeModuleId = deriveActiveModuleId(modules, effectiveStatuses);
+  const isPlanComplete = isPlanTimelineComplete(modules, effectiveStatuses);
 
   const [expandedModuleIds, setExpandedModuleIds] = useState<string[]>(() => {
     return activeModuleId ? [activeModuleId] : [];

--- a/src/app/(app)/plans/[id]/components/PlanTimeline.tsx
+++ b/src/app/(app)/plans/[id]/components/PlanTimeline.tsx
@@ -15,7 +15,7 @@ import { getStatusesFromModules } from '@/app/(app)/plans/[id]/helpers';
 import { Accordion } from '@/components/ui/accordion';
 import { Card, CardContent } from '@/components/ui/card';
 import { deriveActiveModuleId } from '@/features/plans/task-progress/client';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 interface ModuleTimelineProps {
   planId: string;
@@ -30,12 +30,24 @@ export function PlanTimeline({
   statuses,
   onStatusChange,
 }: ModuleTimelineProps) {
-  const effectiveStatuses = statuses ?? getStatusesFromModules(modules);
+  const effectiveStatuses = useMemo(
+    () => statuses ?? getStatusesFromModules(modules),
+    [statuses, modules],
+  );
 
-  const timelineModules = deriveTimelineModules(modules, effectiveStatuses);
+  const timelineModules = useMemo(
+    () => deriveTimelineModules(modules, effectiveStatuses),
+    [modules, effectiveStatuses],
+  );
 
-  const activeModuleId = deriveActiveModuleId(modules, effectiveStatuses);
-  const isPlanComplete = isPlanTimelineComplete(modules, effectiveStatuses);
+  const activeModuleId = useMemo(
+    () => deriveActiveModuleId(modules, effectiveStatuses),
+    [modules, effectiveStatuses],
+  );
+  const isPlanComplete = useMemo(
+    () => isPlanTimelineComplete(modules, effectiveStatuses),
+    [modules, effectiveStatuses],
+  );
 
   const [expandedModuleIds, setExpandedModuleIds] = useState<string[]>(() => {
     return activeModuleId ? [activeModuleId] : [];

--- a/src/app/(app)/plans/[id]/log-task-status-error.ts
+++ b/src/app/(app)/plans/[id]/log-task-status-error.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import type { ProgressStatus } from '@/shared/types/db.types';
+
+import { getLoggableErrorDetails } from '@/lib/errors';
+import { clientLogger } from '@/lib/logging/client';
+
+export function logTaskStatusError({
+  error,
+  taskId,
+  previousStatus,
+  nextStatus,
+  context,
+}: {
+  error: unknown;
+  taskId: string;
+  previousStatus?: ProgressStatus;
+  nextStatus?: ProgressStatus;
+  context?: Record<string, unknown>;
+}): void {
+  const { errorMessage, errorStack } = getLoggableErrorDetails(error);
+  clientLogger.error('Task status update failed', {
+    errorMessage,
+    errorStack,
+    taskId,
+    ...(previousStatus !== undefined ? { previousStatus } : {}),
+    ...(nextStatus !== undefined ? { nextStatus } : {}),
+    ...context,
+  });
+}

--- a/src/app/(app)/plans/[id]/modules/[moduleId]/components/ModuleDetailClient.tsx
+++ b/src/app/(app)/plans/[id]/modules/[moduleId]/components/ModuleDetailClient.tsx
@@ -8,7 +8,6 @@ import { batchUpdateModuleTaskProgressAction } from '@/app/(app)/plans/[id]/modu
 import { ModuleHeader } from '@/app/(app)/plans/[id]/modules/[moduleId]/components/ModuleHeader';
 import { ModuleLessonsClient } from '@/app/(app)/plans/[id]/modules/[moduleId]/components/ModuleLessonsClient';
 import { clientLogger } from '@/lib/logging/client';
-import { useCallback } from 'react';
 import { toast } from 'sonner';
 
 interface ModuleDetailClientProps {
@@ -34,31 +33,33 @@ export function ModuleDetailClient({
   const lessons = module.tasks;
   const scopedTaskIds = new Set(lessons.map((lesson) => lesson.id));
 
-  const flushModuleTaskProgress = useCallback(
-    async (updates: Array<{ taskId: string; status: ProgressStatus }>) => {
-      const result = await batchUpdateModuleTaskProgressAction({
-        planId,
-        moduleId: module.id,
-        updates,
-      });
-      if (result?.revalidateFailed) {
-        toast.message('Progress saved. Refresh if the page looks stale.');
-      }
-    },
-    [module.id, planId],
-  );
+  async function flushModuleTaskProgress(
+    updates: Array<{ taskId: string; status: ProgressStatus }>,
+  ) {
+    const result = await batchUpdateModuleTaskProgressAction({
+      planId,
+      moduleId: module.id,
+      updates,
+    });
+    if (result?.revalidateFailed) {
+      toast.message('Progress saved. Refresh if the page looks stale.');
+    }
+  }
 
-  const handleTaskStatusError = useCallback(
-    ({ error, taskId }: { error: unknown; taskId: string }) => {
-      clientLogger.error('Module task status batch failed', {
-        error,
-        moduleId: module.id,
-        planId,
-        taskId,
-      });
-    },
-    [module.id, planId],
-  );
+  function handleTaskStatusError({
+    error,
+    taskId,
+  }: {
+    error: unknown;
+    taskId: string;
+  }) {
+    clientLogger.error('Module task status batch failed', {
+      error,
+      moduleId: module.id,
+      planId,
+      taskId,
+    });
+  }
 
   const { statuses, handleStatusChange } = useOptimisticTaskStatusUpdates({
     initialStatuses,

--- a/src/app/(app)/plans/[id]/modules/[moduleId]/components/ModuleDetailClient.tsx
+++ b/src/app/(app)/plans/[id]/modules/[moduleId]/components/ModuleDetailClient.tsx
@@ -4,10 +4,10 @@ import type { ModuleDetailReadModel } from '@/features/plans/read-projection/typ
 import type { ProgressStatus } from '@/shared/types/db.types';
 
 import { useOptimisticTaskStatusUpdates } from '@/app/(app)/plans/[id]/hooks/useOptimisticTaskStatusUpdates';
+import { logTaskStatusError } from '@/app/(app)/plans/[id]/log-task-status-error';
 import { batchUpdateModuleTaskProgressAction } from '@/app/(app)/plans/[id]/modules/[moduleId]/actions';
 import { ModuleHeader } from '@/app/(app)/plans/[id]/modules/[moduleId]/components/ModuleHeader';
 import { ModuleLessonsClient } from '@/app/(app)/plans/[id]/modules/[moduleId]/components/ModuleLessonsClient';
-import { clientLogger } from '@/lib/logging/client';
 import { toast } from 'sonner';
 
 interface ModuleDetailClientProps {
@@ -46,26 +46,15 @@ export function ModuleDetailClient({
     }
   }
 
-  function handleTaskStatusError({
-    error,
-    taskId,
-  }: {
-    error: unknown;
-    taskId: string;
-  }) {
-    clientLogger.error('Module task status batch failed', {
-      error,
-      moduleId: module.id,
-      planId,
-      taskId,
-    });
-  }
-
   const { statuses, handleStatusChange } = useOptimisticTaskStatusUpdates({
     initialStatuses,
     scopedTaskIds,
     flushAction: flushModuleTaskProgress,
-    onError: handleTaskStatusError,
+    onError: (context) =>
+      logTaskStatusError({
+        ...context,
+        context: { moduleId: module.id, planId },
+      }),
   });
 
   return (

--- a/src/app/(app)/plans/[id]/modules/[moduleId]/components/ModuleLessonsClient.tsx
+++ b/src/app/(app)/plans/[id]/modules/[moduleId]/components/ModuleLessonsClient.tsx
@@ -13,7 +13,6 @@ import { useModuleLessonGeneration } from '@/app/(app)/plans/[id]/modules/[modul
 import { Accordion } from '@/components/ui/accordion';
 import { Surface } from '@/components/ui/surface';
 import { deriveLessonState } from '@/features/plans/task-progress/client';
-import { useMemo } from 'react';
 
 interface ModuleLessonsClientProps {
   planId: string;
@@ -44,26 +43,18 @@ export function ModuleLessonsClient({
       previousModulesComplete,
     });
 
-  const { completedLessons, totalLessons, isModuleComplete } = useMemo(() => {
-    const total = lessons.length;
-    let completed = 0;
-    for (const lesson of lessons) {
-      if ((statuses[lesson.id] ?? lesson.status) === 'completed') {
-        completed++;
-      }
+  const totalLessons = lessons.length;
+  let completedLessons = 0;
+  for (const lesson of lessons) {
+    if ((statuses[lesson.id] ?? lesson.status) === 'completed') {
+      completedLessons++;
     }
+  }
+  const isModuleComplete =
+    totalLessons > 0 && completedLessons === totalLessons;
 
-    return {
-      completedLessons: completed,
-      totalLessons: total,
-      isModuleComplete: total > 0 && completed === total,
-    };
-  }, [lessons, statuses]);
-
-  const { locks: lessonLocks, firstUnlockedIncompleteLessonId } = useMemo(
-    () => deriveLessonState(lessons, statuses, previousModulesComplete),
-    [lessons, previousModulesComplete, statuses],
-  );
+  const { locks: lessonLocks, firstUnlockedIncompleteLessonId } =
+    deriveLessonState(lessons, statuses, previousModulesComplete);
 
   return (
     <>

--- a/src/app/(app)/plans/components/PlansList.tsx
+++ b/src/app/(app)/plans/components/PlansList.tsx
@@ -15,7 +15,7 @@ import { Input } from '@/components/ui/input';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { cn } from '@/lib/utils';
 import { Search } from 'lucide-react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 interface PlansListProps {
   summaries: PlanSummary[];
@@ -47,34 +47,47 @@ export function PlansList({
   const [filterStatus, setFilterStatus] = useState<FilterStatus>('all');
 
   const normalizedSearchQuery = searchQuery.toLowerCase();
-  const filteredPlans = summaries.filter((summary) => {
-    const matchesSearch =
-      searchQuery === '' ||
-      summary.plan.topic.toLowerCase().includes(normalizedSearchQuery);
-
-    const status = getPlanStatus(summary, effectiveReferenceTimestamp);
-    const matchesStatus =
-      filterStatus === 'all' ||
-      status === filterStatus ||
-      (filterStatus === 'inactive' && status === 'paused');
-
-    return matchesSearch && matchesStatus;
-  });
-
-  const statusCounts = summaries.reduce(
-    (acc, summary) => {
-      const status = getPlanStatus(summary, effectiveReferenceTimestamp);
-      acc[status] = (acc[status] || 0) + 1;
-      return acc;
-    },
-    {
+  const { filteredPlans, statusCounts } = useMemo(() => {
+    const statusCounts = {
       active: 0,
       paused: 0,
       completed: 0,
       generating: 0,
       failed: 0,
-    } as Record<PlanReadStatus, number>,
-  );
+    } as Record<PlanReadStatus, number>;
+
+    const plansWithStatus = summaries.map((summary) => ({
+      summary,
+      status: getPlanStatus(summary, effectiveReferenceTimestamp),
+    }));
+
+    for (const { status } of plansWithStatus) {
+      statusCounts[status] = (statusCounts[status] || 0) + 1;
+    }
+
+    const filteredPlans = plansWithStatus
+      .filter(({ summary, status }) => {
+        const matchesSearch =
+          searchQuery === '' ||
+          summary.plan.topic.toLowerCase().includes(normalizedSearchQuery);
+
+        const matchesStatus =
+          filterStatus === 'all' ||
+          status === filterStatus ||
+          (filterStatus === 'inactive' && status === 'paused');
+
+        return matchesSearch && matchesStatus;
+      })
+      .map(({ summary }) => summary);
+
+    return { filteredPlans, statusCounts };
+  }, [
+    summaries,
+    effectiveReferenceTimestamp,
+    searchQuery,
+    normalizedSearchQuery,
+    filterStatus,
+  ]);
 
   function getFilterCount(tab: (typeof FILTER_TABS)[number]): number | null {
     if (tab.id === 'all') return summaries.length;

--- a/src/app/(app)/plans/components/PlansList.tsx
+++ b/src/app/(app)/plans/components/PlansList.tsx
@@ -15,7 +15,7 @@ import { Input } from '@/components/ui/input';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { cn } from '@/lib/utils';
 import { Search } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 
 interface PlansListProps {
   summaries: PlanSummary[];
@@ -46,39 +46,35 @@ export function PlansList({
   const [searchQuery, setSearchQuery] = useState('');
   const [filterStatus, setFilterStatus] = useState<FilterStatus>('all');
 
-  const filteredPlans = useMemo(() => {
-    const normalizedSearchQuery = searchQuery.toLowerCase();
-    return summaries.filter((summary) => {
-      const matchesSearch =
-        searchQuery === '' ||
-        summary.plan.topic.toLowerCase().includes(normalizedSearchQuery);
+  const normalizedSearchQuery = searchQuery.toLowerCase();
+  const filteredPlans = summaries.filter((summary) => {
+    const matchesSearch =
+      searchQuery === '' ||
+      summary.plan.topic.toLowerCase().includes(normalizedSearchQuery);
 
+    const status = getPlanStatus(summary, effectiveReferenceTimestamp);
+    const matchesStatus =
+      filterStatus === 'all' ||
+      status === filterStatus ||
+      (filterStatus === 'inactive' && status === 'paused');
+
+    return matchesSearch && matchesStatus;
+  });
+
+  const statusCounts = summaries.reduce(
+    (acc, summary) => {
       const status = getPlanStatus(summary, effectiveReferenceTimestamp);
-      const matchesStatus =
-        filterStatus === 'all' ||
-        status === filterStatus ||
-        (filterStatus === 'inactive' && status === 'paused');
-
-      return matchesSearch && matchesStatus;
-    });
-  }, [summaries, searchQuery, filterStatus, effectiveReferenceTimestamp]);
-
-  const statusCounts = useMemo(() => {
-    return summaries.reduce(
-      (acc, summary) => {
-        const status = getPlanStatus(summary, effectiveReferenceTimestamp);
-        acc[status] = (acc[status] || 0) + 1;
-        return acc;
-      },
-      {
-        active: 0,
-        paused: 0,
-        completed: 0,
-        generating: 0,
-        failed: 0,
-      } as Record<PlanReadStatus, number>,
-    );
-  }, [summaries, effectiveReferenceTimestamp]);
+      acc[status] = (acc[status] || 0) + 1;
+      return acc;
+    },
+    {
+      active: 0,
+      paused: 0,
+      completed: 0,
+      generating: 0,
+      failed: 0,
+    } as Record<PlanReadStatus, number>,
+  );
 
   function getFilterCount(tab: (typeof FILTER_TABS)[number]): number | null {
     if (tab.id === 'all') return summaries.length;

--- a/src/app/(app)/plans/new/components/plan-form/UnifiedPlanInput.tsx
+++ b/src/app/(app)/plans/new/components/plan-form/UnifiedPlanInput.tsx
@@ -16,6 +16,12 @@ import { cn } from '@/lib/utils';
 import { ArrowRight, Loader2 } from 'lucide-react';
 import { useEffect, useId, useReducer, useRef } from 'react';
 
+const IS_MAC =
+  typeof navigator !== 'undefined' &&
+  ((navigator as Navigator & { userAgentData?: { platform?: string } })
+    .userAgentData?.platform === 'macOS' ||
+    /Mac|iPod|iPhone|iPad/.test(navigator.userAgent));
+
 interface UnifiedPlanInputProps {
   onSubmit: (data: PlanFormData) => void;
   isSubmitting?: boolean;
@@ -115,12 +121,6 @@ export function UnifiedPlanInput({
     }
   };
 
-  const isMac =
-    typeof navigator !== 'undefined' &&
-    ((navigator as Navigator & { userAgentData?: { platform?: string } })
-      .userAgentData?.platform === 'macOS' ||
-      /Mac|iPod|iPhone|iPad/.test(navigator.userAgent));
-
   return (
     <div className='w-full max-w-5xl'>
       <Surface
@@ -196,7 +196,7 @@ export function UnifiedPlanInput({
           className='rounded bg-muted px-1.5 py-0.5 text-xs font-medium'
           suppressHydrationWarning
         >
-          {isMac ? '⌘' : 'Ctrl'}+Enter
+          {IS_MAC ? '⌘' : 'Ctrl'}+Enter
         </kbd>{' '}
         to submit.
       </p>

--- a/src/app/(app)/plans/new/components/plan-form/UnifiedPlanInput.tsx
+++ b/src/app/(app)/plans/new/components/plan-form/UnifiedPlanInput.tsx
@@ -14,7 +14,7 @@ import { isDevelopment } from '@/lib/config/client-env';
 import { clientLogger } from '@/lib/logging/client';
 import { cn } from '@/lib/utils';
 import { ArrowRight, Loader2 } from 'lucide-react';
-import { useEffect, useId, useMemo, useReducer, useRef } from 'react';
+import { useEffect, useId, useReducer, useRef } from 'react';
 
 interface UnifiedPlanInputProps {
   onSubmit: (data: PlanFormData) => void;
@@ -115,14 +115,11 @@ export function UnifiedPlanInput({
     }
   };
 
-  const isMac = useMemo(() => {
-    if (typeof navigator === 'undefined') return false;
-    return (
-      (navigator as Navigator & { userAgentData?: { platform?: string } })
-        .userAgentData?.platform === 'macOS' ||
-      /Mac|iPod|iPhone|iPad/.test(navigator.userAgent)
-    );
-  }, []);
+  const isMac =
+    typeof navigator !== 'undefined' &&
+    ((navigator as Navigator & { userAgentData?: { platform?: string } })
+      .userAgentData?.platform === 'macOS' ||
+      /Mac|iPod|iPhone|iPad/.test(navigator.userAgent));
 
   return (
     <div className='w-full max-w-5xl'>

--- a/src/app/(app)/settings/ai/components/ModelSelectionCard.tsx
+++ b/src/app/(app)/settings/ai/components/ModelSelectionCard.tsx
@@ -53,7 +53,7 @@ export async function ModelSelectionCard() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Model Selection</CardTitle>
+        <CardTitle as='h3'>Model Selection</CardTitle>
         <CardDescription>
           {currentModel !== null ? (
             <>

--- a/src/app/(app)/settings/ai/page.tsx
+++ b/src/app/(app)/settings/ai/page.tsx
@@ -37,7 +37,7 @@ export default function AISettingsPage(): ReactElement {
         {/* Static content - renders immediately */}
         <Card>
           <CardHeader>
-            <CardTitle>About AI Models</CardTitle>
+            <CardTitle as='h3'>About AI Models</CardTitle>
           </CardHeader>
           <CardContent className='space-y-4 text-sm text-muted-foreground'>
             <p>

--- a/src/app/(app)/settings/ai/page.tsx
+++ b/src/app/(app)/settings/ai/page.tsx
@@ -17,6 +17,7 @@ export default function AISettingsPage(): ReactElement {
     <>
       <PageHeader
         title='AI Preferences'
+        titleAs='h2'
         subtitle={
           <>
             Save the model Atlaris should use for future plan generations. If

--- a/src/app/(app)/settings/billing/components/BillingCards.tsx
+++ b/src/app/(app)/settings/billing/components/BillingCards.tsx
@@ -45,7 +45,7 @@ export async function BillingCards({ locale }: { locale?: string }) {
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Billing unavailable</CardTitle>
+          <CardTitle as='h3'>Billing unavailable</CardTitle>
           <CardDescription>
             We couldn&apos;t load your billing details right now.
           </CardDescription>
@@ -87,7 +87,7 @@ export async function BillingCards({ locale }: { locale?: string }) {
       <Card>
         <CardHeader>
           <div className='space-y-1'>
-            <CardTitle>Current Plan</CardTitle>
+            <CardTitle as='h3'>Current Plan</CardTitle>
             <CardDescription>Manage your subscription</CardDescription>
           </div>
           <CardAction>
@@ -122,7 +122,7 @@ export async function BillingCards({ locale }: { locale?: string }) {
 
       <Card>
         <CardHeader>
-          <CardTitle>Usage</CardTitle>
+          <CardTitle as='h3'>Usage</CardTitle>
         </CardHeader>
         <CardContent className='space-y-5'>
           <div>

--- a/src/app/(app)/settings/billing/page.tsx
+++ b/src/app/(app)/settings/billing/page.tsx
@@ -20,6 +20,7 @@ export default async function BillingSettingsPage(): Promise<ReactElement> {
     <>
       <PageHeader
         title='Billing'
+        titleAs='h2'
         subtitle='Manage your subscription and view usage'
       />
 

--- a/src/app/(app)/settings/components/SettingsErrorContent.tsx
+++ b/src/app/(app)/settings/components/SettingsErrorContent.tsx
@@ -34,7 +34,7 @@ export function SettingsErrorContent({
 
   return (
     <>
-      <PageHeader title={title} subtitle={subtitle} />
+      <PageHeader title={title} titleAs='h2' subtitle={subtitle} />
       <RouteErrorState
         title={errorTitle}
         message={errorMessage}

--- a/src/app/(app)/settings/integrations/page.tsx
+++ b/src/app/(app)/settings/integrations/page.tsx
@@ -13,6 +13,7 @@ export default function SettingsIntegrationsPage() {
     <>
       <PageHeader
         title='Integrations'
+        titleAs='h2'
         subtitle='Connect your favorite tools to supercharge your learning workflow'
       />
 

--- a/src/app/(app)/settings/layout.tsx
+++ b/src/app/(app)/settings/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import type { ReactElement, ReactNode } from 'react';
 
 import { SettingsSidebar } from '@/app/(app)/settings/components/SettingsSidebar';
+import { PageHeader } from '@/components/ui/page-header';
 import { PageShell } from '@/components/ui/page-shell';
 
 export const metadata: Metadata = {
@@ -23,6 +24,8 @@ export default function SettingsLayout({
 }): ReactElement {
   return (
     <PageShell>
+      <PageHeader title='Settings' />
+
       <div className='flex flex-col gap-6 md:flex-row md:gap-7'>
         {/* Sidebar */}
         <aside className='w-full shrink-0 md:w-52'>

--- a/src/app/(app)/settings/notifications/page.tsx
+++ b/src/app/(app)/settings/notifications/page.tsx
@@ -38,6 +38,7 @@ export default function NotificationsSettingsPage() {
     <>
       <PageHeader
         title='Notifications'
+        titleAs='h2'
         subtitle='Manage how you stay informed about your learning progress and account activity'
       />
 

--- a/src/app/(app)/settings/profile/page.tsx
+++ b/src/app/(app)/settings/profile/page.tsx
@@ -19,6 +19,7 @@ export default async function ProfileSettingsPage(): Promise<ReactElement> {
     <>
       <PageHeader
         title='Profile'
+        titleAs='h2'
         subtitle='Manage your personal information and view your account details'
       />
 

--- a/src/app/api/internal/maintenance/plans/cleanup/route.ts
+++ b/src/app/api/internal/maintenance/plans/cleanup/route.ts
@@ -1,0 +1,42 @@
+import type { PlainHandler } from '@/lib/api/auth';
+
+import { runPlanCleanupMaintenance } from '@/features/plans/cleanup';
+import { assertInternalWorkerAccess } from '@/lib/api/internal/internal-worker-access';
+import { checkIpRateLimit } from '@/lib/api/ip-rate-limit';
+import { json } from '@/lib/api/response';
+import { withErrorBoundary } from '@/lib/api/route-wrappers';
+import { maintenanceEnv } from '@/lib/config/env';
+import { getLoggingRequestContext } from '@/lib/logging/request-context';
+
+const MAINTENANCE_WORKER_HEADER = 'x-maintenance-worker-token';
+
+export const POST: PlainHandler = withErrorBoundary(async (request) => {
+  const { logger } = getLoggingRequestContext(request);
+  const pathname = new URL(request.url).pathname;
+
+  checkIpRateLimit(request, 'internal');
+
+  assertInternalWorkerAccess({
+    request,
+    pathname,
+    logger,
+    enabled: maintenanceEnv.planCleanupEnabled,
+    workerToken: maintenanceEnv.workerToken,
+    headerName: MAINTENANCE_WORKER_HEADER,
+    unavailableMessage: 'Plan cleanup is currently unavailable.',
+    unauthorizedLogMessage: 'Unauthorized plan cleanup trigger attempt',
+    missingWorkerTokenLogMessage:
+      'Maintenance worker token missing in production',
+  });
+
+  logger.info('Starting plan cleanup');
+
+  const result = await runPlanCleanupMaintenance();
+
+  logger.info(result, 'Completed plan cleanup');
+
+  return json({
+    ok: true,
+    ...result,
+  });
+});

--- a/src/app/api/internal/maintenance/plans/cleanup/route.ts
+++ b/src/app/api/internal/maintenance/plans/cleanup/route.ts
@@ -7,8 +7,20 @@ import { json } from '@/lib/api/response';
 import { withErrorBoundary } from '@/lib/api/route-wrappers';
 import { maintenanceEnv } from '@/lib/config/env';
 import { getLoggingRequestContext } from '@/lib/logging/request-context';
+import * as Sentry from '@sentry/nextjs';
 
-export const POST: PlainHandler = withErrorBoundary(async (request) => {
+const PLAN_CLEANUP_MONITOR_SLUG = 'plan-cleanup-maintenance';
+const PLAN_CLEANUP_MONITOR_CONFIG = {
+  schedule: { type: 'crontab', value: '*/15 * * * *' },
+  checkinMargin: 5,
+  maxRuntime: 5,
+  timezone: 'UTC',
+  failureIssueThreshold: 1,
+  recoveryThreshold: 1,
+  isolateTrace: true,
+} as const;
+
+const runPlanCleanup: PlainHandler = async (request) => {
   const { logger } = getLoggingRequestContext(request);
   const pathname = new URL(request.url).pathname;
 
@@ -23,14 +35,22 @@ export const POST: PlainHandler = withErrorBoundary(async (request) => {
     unauthorizedLogMessage: 'Unauthorized plan cleanup trigger attempt',
   });
 
-  logger.info('Starting plan cleanup');
+  return Sentry.withMonitor(
+    PLAN_CLEANUP_MONITOR_SLUG,
+    async () => {
+      logger.info('Starting plan cleanup');
 
-  const result = await runPlanCleanupMaintenance();
+      const result = await runPlanCleanupMaintenance();
 
-  logger.info(result, 'Completed plan cleanup');
+      logger.info(result, 'Completed plan cleanup');
 
-  return json({
-    ok: true,
-    ...result,
-  });
-});
+      return json({
+        ...result,
+        ok: true,
+      });
+    },
+    PLAN_CLEANUP_MONITOR_CONFIG,
+  );
+};
+
+export const POST: PlainHandler = withErrorBoundary(runPlanCleanup);

--- a/src/app/api/internal/maintenance/plans/cleanup/route.ts
+++ b/src/app/api/internal/maintenance/plans/cleanup/route.ts
@@ -1,14 +1,12 @@
 import type { PlainHandler } from '@/lib/api/auth';
 
 import { runPlanCleanupMaintenance } from '@/features/plans/cleanup';
-import { assertInternalWorkerAccess } from '@/lib/api/internal/internal-worker-access';
+import { assertMaintenanceWorkerAccess } from '@/lib/api/internal/internal-worker-access';
 import { checkIpRateLimit } from '@/lib/api/ip-rate-limit';
 import { json } from '@/lib/api/response';
 import { withErrorBoundary } from '@/lib/api/route-wrappers';
 import { maintenanceEnv } from '@/lib/config/env';
 import { getLoggingRequestContext } from '@/lib/logging/request-context';
-
-const MAINTENANCE_WORKER_HEADER = 'x-maintenance-worker-token';
 
 export const POST: PlainHandler = withErrorBoundary(async (request) => {
   const { logger } = getLoggingRequestContext(request);
@@ -16,17 +14,13 @@ export const POST: PlainHandler = withErrorBoundary(async (request) => {
 
   checkIpRateLimit(request, 'internal');
 
-  assertInternalWorkerAccess({
+  assertMaintenanceWorkerAccess({
     request,
     pathname,
     logger,
     enabled: maintenanceEnv.planCleanupEnabled,
-    workerToken: maintenanceEnv.workerToken,
-    headerName: MAINTENANCE_WORKER_HEADER,
     unavailableMessage: 'Plan cleanup is currently unavailable.',
     unauthorizedLogMessage: 'Unauthorized plan cleanup trigger attempt',
-    missingWorkerTokenLogMessage:
-      'Maintenance worker token missing in production',
   });
 
   logger.info('Starting plan cleanup');

--- a/src/app/api/internal/maintenance/retention/cleanup/route.ts
+++ b/src/app/api/internal/maintenance/retention/cleanup/route.ts
@@ -1,6 +1,6 @@
 import type { PlainHandler } from '@/lib/api/auth';
 
-import { assertInternalWorkerAccess } from '@/lib/api/internal/internal-worker-access';
+import { assertMaintenanceWorkerAccess } from '@/lib/api/internal/internal-worker-access';
 import { checkIpRateLimit } from '@/lib/api/ip-rate-limit';
 import { json } from '@/lib/api/response';
 import { withErrorBoundary } from '@/lib/api/route-wrappers';
@@ -8,25 +8,19 @@ import { maintenanceEnv } from '@/lib/config/env';
 import { cleanupRetainedDbRows } from '@/lib/db/queries/admin/retention';
 import { getLoggingRequestContext } from '@/lib/logging/request-context';
 
-const MAINTENANCE_WORKER_HEADER = 'x-maintenance-worker-token';
-
 export const POST: PlainHandler = withErrorBoundary(async (request) => {
   const { logger } = getLoggingRequestContext(request);
   const pathname = new URL(request.url).pathname;
 
   checkIpRateLimit(request, 'internal');
 
-  assertInternalWorkerAccess({
+  assertMaintenanceWorkerAccess({
     request,
     pathname,
     logger,
     enabled: maintenanceEnv.retentionCleanupEnabled,
-    workerToken: maintenanceEnv.workerToken,
-    headerName: MAINTENANCE_WORKER_HEADER,
     unavailableMessage: 'Retention cleanup is currently unavailable.',
     unauthorizedLogMessage: 'Unauthorized retention cleanup trigger attempt',
-    missingWorkerTokenLogMessage:
-      'Maintenance worker token missing in production',
   });
 
   logger.info('Starting retention cleanup');

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -27,9 +27,16 @@ function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
+function CardTitle({
+  className,
+  as: TitleTag = 'div',
+  ...props
+}: React.ComponentProps<'div'> & {
+  /** Use `h3` for section titles under a page `h2` (e.g. settings billing cards). */
+  as?: 'div' | 'h2' | 'h3' | 'h4';
+}) {
   return (
-    <div
+    <TitleTag
       data-slot='card-title'
       className={cn('leading-none font-semibold', className)}
       {...props}

--- a/src/features/plans/cleanup.ts
+++ b/src/features/plans/cleanup.ts
@@ -3,7 +3,7 @@ import { and, eq, isNull, lt, sql } from 'drizzle-orm';
 // updates run on the same transaction handle as SELECT … FOR UPDATE.
 import type { DbClient } from '@/lib/db/types';
 
-import { markPlanGenerationFailure } from '@/features/plans/lifecycle/adapters/plan-persistence-store';
+import { markPlanGenerationFailuresInTx } from '@/features/plans/lifecycle/adapters/plan-persistence-store';
 import { logger } from '@/lib/logging/logger';
 import { generationAttempts, learningPlans } from '@supabase/schema';
 
@@ -20,7 +20,7 @@ export const ORPHANED_ATTEMPT_THRESHOLD_MS = 15 * 60 * 1000; // 15 minutes
  * does not race concurrent generation state updates.
  */
 type CleanupStuckPlansDependencies = {
-  markFailure?: typeof markPlanGenerationFailure;
+  markFailuresInTx?: typeof markPlanGenerationFailuresInTx;
 };
 
 export async function cleanupStuckPlans(
@@ -29,7 +29,8 @@ export async function cleanupStuckPlans(
   deps: CleanupStuckPlansDependencies = {},
 ): Promise<{ cleaned: number }> {
   const cutoff = new Date(Date.now() - thresholdMs);
-  const markFailure = deps.markFailure ?? markPlanGenerationFailure;
+  const markFailuresInTx =
+    deps.markFailuresInTx ?? markPlanGenerationFailuresInTx;
 
   return dbClient.transaction(async (tx) => {
     const stuckPlans = await tx
@@ -44,14 +45,13 @@ export async function cleanupStuckPlans(
       .limit(Number.MAX_SAFE_INTEGER)
       .for('update');
 
-    const timestamp = new Date();
-
-    for (const plan of stuckPlans) {
-      // Reuse a single timestamp so the batch gets a consistent failed-at moment.
-      await markFailure(plan.id, tx, () => timestamp);
+    if (stuckPlans.length === 0) {
+      return { cleaned: 0 };
     }
 
-    const cleaned = stuckPlans.length;
+    const timestamp = new Date();
+    const planIds = stuckPlans.map((plan) => plan.id);
+    const cleaned = await markFailuresInTx(tx, planIds, timestamp);
 
     if (cleaned > 0) {
       logger.info(

--- a/src/features/plans/cleanup.ts
+++ b/src/features/plans/cleanup.ts
@@ -54,6 +54,21 @@ export async function cleanupStuckPlans(
     const planIds = stuckPlans.map((plan) => plan.id);
     const cleaned = await markFailuresInTx(tx, planIds, timestamp);
 
+    if (cleaned !== planIds.length) {
+      logger.error(
+        {
+          source: 'cleanup',
+          event: 'stuck_plans_cleanup_partial_failure',
+          expected: planIds.length,
+          cleaned,
+        },
+        'Plan cleanup failed to mark all locked stuck plans as failed',
+      );
+      throw new Error(
+        'Plan cleanup failed to mark all locked stuck plans as failed',
+      );
+    }
+
     if (cleaned > 0) {
       logger.info(
         { source: 'cleanup', event: 'stuck_plans_cleaned', count: cleaned },
@@ -115,10 +130,8 @@ export async function runPlanCleanupMaintenance(): Promise<{
   stuckPlansCleaned: number;
   orphanedAttemptsCleaned: number;
 }> {
-  const [stuckPlans, orphanedAttempts] = await Promise.all([
-    cleanupStuckPlans(serviceRoleDb),
-    cleanupOrphanedAttempts(serviceRoleDb),
-  ]);
+  const stuckPlans = await cleanupStuckPlans(serviceRoleDb);
+  const orphanedAttempts = await cleanupOrphanedAttempts(serviceRoleDb);
 
   return {
     stuckPlansCleaned: stuckPlans.cleaned,

--- a/src/features/plans/cleanup.ts
+++ b/src/features/plans/cleanup.ts
@@ -11,6 +11,12 @@ import { db as serviceRoleDb } from '@supabase/service-role';
 /** Plans stuck in 'generating' longer than this are considered abandoned. */
 export const STUCK_PLAN_THRESHOLD_MS = 15 * 60 * 1000; // 15 minutes
 
+/**
+ * Max stuck plans processed per cleanup run. At the 15-minute scheduler cadence
+ * this drains up to 4,000 plans/hour while keeping each transaction bounded.
+ */
+export const STUCK_PLAN_CLEANUP_BATCH_SIZE = 1000;
+
 /** In-progress attempts older than this are considered orphaned. */
 export const ORPHANED_ATTEMPT_THRESHOLD_MS = 15 * 60 * 1000; // 15 minutes
 
@@ -22,6 +28,7 @@ export const ORPHANED_ATTEMPT_THRESHOLD_MS = 15 * 60 * 1000; // 15 minutes
  */
 type CleanupStuckPlansDependencies = {
   markFailuresInTx?: typeof markPlanGenerationFailuresInTx;
+  batchSize?: number;
 };
 
 export async function cleanupStuckPlans(
@@ -32,6 +39,7 @@ export async function cleanupStuckPlans(
   const cutoff = new Date(Date.now() - thresholdMs);
   const markFailuresInTx =
     deps.markFailuresInTx ?? markPlanGenerationFailuresInTx;
+  const batchSize = deps.batchSize ?? STUCK_PLAN_CLEANUP_BATCH_SIZE;
 
   return dbClient.transaction(async (tx) => {
     const stuckPlans = await tx
@@ -43,7 +51,7 @@ export async function cleanupStuckPlans(
           lt(learningPlans.updatedAt, cutoff),
         ),
       )
-      .limit(Number.MAX_SAFE_INTEGER)
+      .limit(batchSize)
       .for('update');
 
     if (stuckPlans.length === 0) {
@@ -73,6 +81,17 @@ export async function cleanupStuckPlans(
       logger.info(
         { source: 'cleanup', event: 'stuck_plans_cleaned', count: cleaned },
         `Marked ${cleaned} stuck plan(s) as failed`,
+      );
+    }
+
+    if (cleaned === batchSize) {
+      logger.warn(
+        {
+          source: 'cleanup',
+          event: 'stuck_plans_cleanup_batch_full',
+          batchSize,
+        },
+        'Plan cleanup filled its stuck-plan batch; backlog may remain',
       );
     }
 

--- a/src/features/plans/cleanup.ts
+++ b/src/features/plans/cleanup.ts
@@ -6,6 +6,7 @@ import type { DbClient } from '@/lib/db/types';
 import { markPlanGenerationFailuresInTx } from '@/features/plans/lifecycle/adapters/plan-persistence-store';
 import { logger } from '@/lib/logging/logger';
 import { generationAttempts, learningPlans } from '@supabase/schema';
+import { db as serviceRoleDb } from '@supabase/service-role';
 
 /** Plans stuck in 'generating' longer than this are considered abandoned. */
 export const STUCK_PLAN_THRESHOLD_MS = 15 * 60 * 1000; // 15 minutes
@@ -105,4 +106,22 @@ export async function cleanupOrphanedAttempts(
   }
 
   return { cleaned };
+}
+
+/**
+ * Service-role entrypoint for the internal plan cleanup maintenance route.
+ */
+export async function runPlanCleanupMaintenance(): Promise<{
+  stuckPlansCleaned: number;
+  orphanedAttemptsCleaned: number;
+}> {
+  const [stuckPlans, orphanedAttempts] = await Promise.all([
+    cleanupStuckPlans(serviceRoleDb),
+    cleanupOrphanedAttempts(serviceRoleDb),
+  ]);
+
+  return {
+    stuckPlansCleaned: stuckPlans.cleaned,
+    orphanedAttemptsCleaned: orphanedAttempts.cleaned,
+  };
 }

--- a/src/features/plans/lifecycle/adapters/plan-persistence-store.ts
+++ b/src/features/plans/lifecycle/adapters/plan-persistence-store.ts
@@ -17,7 +17,7 @@ import { PLAN_GENERATING_INSERT_DEFAULTS } from '@/lib/db/queries/helpers/plan-g
 import { logger } from '@/lib/logging/logger';
 import { TIER_LIMITS } from '@/shared/constants/tier-limits';
 import { generationAttempts, learningPlans, modules } from '@supabase/schema';
-import { and, count, eq, gte, notExists, sql } from 'drizzle-orm';
+import { and, count, eq, gte, inArray, notExists, sql } from 'drizzle-orm';
 
 /** Window (in seconds) for detecting duplicate plan submissions. */
 const DUPLICATE_DETECTION_WINDOW_SECONDS = 60;
@@ -57,6 +57,32 @@ export async function markPlanGenerationFailureInTx(
   planId: string,
   timestamp: Date,
 ): Promise<void> {
+  const updatedCount = await markPlanGenerationFailuresInTx(
+    tx,
+    [planId],
+    timestamp,
+  );
+
+  if (updatedCount === 0) {
+    logger.error(
+      { planId, timestamp, updatedCount },
+      'markPlanGenerationFailureInTx: no learningPlans rows updated in PlanUpdateTx',
+    );
+    throw new Error(
+      `markPlanGenerationFailureInTx: no plan updated for id ${planId}`,
+    );
+  }
+}
+
+export async function markPlanGenerationFailuresInTx(
+  tx: PlanUpdateTx,
+  planIds: readonly string[],
+  timestamp: Date,
+): Promise<number> {
+  if (planIds.length === 0) {
+    return 0;
+  }
+
   const updated = await tx
     .update(learningPlans)
     .set({
@@ -64,18 +90,10 @@ export async function markPlanGenerationFailureInTx(
       isQuotaEligible: false,
       updatedAt: timestamp,
     })
-    .where(eq(learningPlans.id, planId))
+    .where(inArray(learningPlans.id, planIds))
     .returning({ id: learningPlans.id });
 
-  if (updated.length === 0) {
-    logger.error(
-      { planId, timestamp, updatedCount: updated.length },
-      'markPlanGenerationFailureInTx: no learningPlans rows updated in PlanUpdateTx',
-    );
-    throw new Error(
-      `markPlanGenerationFailureInTx: no plan updated for id ${planId}`,
-    );
-  }
+  return updated.length;
 }
 
 export async function atomicCheckAndInsertPlan(

--- a/src/features/plans/status-polling/plan-status-machine.ts
+++ b/src/features/plans/status-polling/plan-status-machine.ts
@@ -1,0 +1,150 @@
+import type { PlanStatus } from '@/shared/types/client.types';
+
+import { computeNextDelay, INITIAL_POLL_MS } from '@/shared/constants/polling';
+
+export const MAX_CONSECUTIVE_FAILURES = 3;
+
+export type PlanPollPhase = 'polling' | 'stopped' | 'terminal';
+
+export interface PlanPollState {
+  planId: string;
+  phase: PlanPollPhase;
+  status: PlanStatus;
+  attempts: number;
+  error: string | null;
+  pollingError: string | null;
+  consecutiveFailures: number;
+  delayMs: number;
+}
+
+export type PlanPollEvent =
+  | {
+      type: 'response';
+      status: PlanStatus;
+      attempts: number;
+      error: string | null;
+      backoffMode: 'immediate' | 'scheduled';
+    }
+  | { type: 'transient_failure'; message: string }
+  | { type: 'fatal_failure'; message: string }
+  | { type: 'revalidate' }
+  | { type: 'plan_changed'; planId: string; initialStatus: PlanStatus };
+
+function isTerminalStatus(status: PlanStatus): boolean {
+  return status === 'ready' || status === 'failed';
+}
+
+function initialPhase(initialStatus: PlanStatus): PlanPollPhase {
+  return isTerminalStatus(initialStatus) ? 'terminal' : 'polling';
+}
+
+export function createInitialPlanPollState(
+  planId: string,
+  initialStatus: PlanStatus,
+): PlanPollState {
+  return {
+    planId,
+    phase: initialPhase(initialStatus),
+    status: initialStatus,
+    attempts: 0,
+    error: null,
+    pollingError: null,
+    consecutiveFailures: 0,
+    delayMs: INITIAL_POLL_MS,
+  };
+}
+
+function nextDelayAfterResponse(
+  state: PlanPollState,
+  newStatus: PlanStatus,
+  backoffMode: 'immediate' | 'scheduled',
+  randomFn: () => number,
+): number {
+  if (backoffMode === 'immediate') {
+    return computeNextDelay(state.delayMs, randomFn);
+  }
+  if (newStatus !== state.status) {
+    return INITIAL_POLL_MS;
+  }
+  return computeNextDelay(state.delayMs, randomFn);
+}
+
+export function transitionPlanPollState(
+  state: PlanPollState,
+  event: PlanPollEvent,
+  randomFn: () => number = Math.random,
+): PlanPollState {
+  switch (event.type) {
+    case 'plan_changed':
+      return createInitialPlanPollState(event.planId, event.initialStatus);
+
+    case 'revalidate':
+      if (state.phase === 'terminal') {
+        return state;
+      }
+      return {
+        ...state,
+        phase: 'polling',
+        pollingError: null,
+        consecutiveFailures: 0,
+        delayMs: INITIAL_POLL_MS,
+      };
+
+    case 'response': {
+      const nextPhase: PlanPollPhase = isTerminalStatus(event.status)
+        ? 'terminal'
+        : state.phase === 'stopped'
+          ? 'stopped'
+          : 'polling';
+
+      return {
+        ...state,
+        phase: isTerminalStatus(event.status) ? 'terminal' : nextPhase,
+        status: event.status,
+        attempts: event.attempts,
+        error: event.error,
+        consecutiveFailures: 0,
+        delayMs: nextDelayAfterResponse(
+          state,
+          event.status,
+          event.backoffMode,
+          randomFn,
+        ),
+      };
+    }
+
+    case 'fatal_failure':
+      return {
+        ...state,
+        phase: 'stopped',
+        pollingError: event.message,
+      };
+
+    case 'transient_failure': {
+      if (state.phase === 'terminal') {
+        return state;
+      }
+      const consecutiveFailures = state.consecutiveFailures + 1;
+      if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+        return {
+          ...state,
+          phase: 'stopped',
+          consecutiveFailures,
+          pollingError: event.message,
+        };
+      }
+      return {
+        ...state,
+        consecutiveFailures,
+        delayMs: computeNextDelay(state.delayMs, randomFn),
+      };
+    }
+
+    default:
+      return state;
+  }
+}
+
+export function shouldContinuePolling(state: PlanPollState): boolean {
+  return state.phase === 'polling';
+}

--- a/src/features/plans/status-polling/plan-status-poller.ts
+++ b/src/features/plans/status-polling/plan-status-poller.ts
@@ -91,6 +91,7 @@ export class PlanStatusPoller {
     this.syncSnapshot();
     this.emit();
     if (shouldContinuePolling(this.state)) {
+      this.clearScheduledPoll();
       await this.fetchOnce('immediate');
       this.scheduleNextPoll();
     }
@@ -123,6 +124,10 @@ export class PlanStatusPoller {
   dispose(): void {
     this.cancelled = true;
     this.started = false;
+    this.clearScheduledPoll();
+  }
+
+  private clearScheduledPoll(): void {
     if (this.pollTimeoutId !== null) {
       clearTimeout(this.pollTimeoutId);
       this.pollTimeoutId = null;

--- a/src/features/plans/status-polling/plan-status-poller.ts
+++ b/src/features/plans/status-polling/plan-status-poller.ts
@@ -51,7 +51,9 @@ export class PlanStatusPoller {
   private listeners = new Set<() => void>();
   private pollTimeoutId: ReturnType<typeof setTimeout> | null = null;
   private inFlightFetch: Promise<void> | null = null;
+  private activeFetchController: AbortController | null = null;
   private pollingToken = 0;
+  private disposalToken = 0;
   private cancelled = false;
   private started = false;
   private readonly fetcher: typeof fetch;
@@ -96,6 +98,10 @@ export class PlanStatusPoller {
   }
 
   revalidate = async (): Promise<void> => {
+    if (this.cancelled) {
+      return;
+    }
+
     this.state = transitionPlanPollState(this.state, { type: 'revalidate' });
     this.syncSnapshot();
     this.emit();
@@ -147,7 +153,10 @@ export class PlanStatusPoller {
   dispose(): void {
     this.cancelled = true;
     this.started = false;
+    this.disposalToken += 1;
     this.clearScheduledPoll();
+    this.activeFetchController?.abort();
+    this.activeFetchController = null;
   }
 
   private clearScheduledPoll(): void {
@@ -162,6 +171,10 @@ export class PlanStatusPoller {
     for (const listener of this.listeners) {
       listener();
     }
+  }
+
+  private isStaleFetch(disposalToken: number): boolean {
+    return this.cancelled || disposalToken !== this.disposalToken;
   }
 
   private scheduleNextPoll(): void {
@@ -219,24 +232,35 @@ export class PlanStatusPoller {
     backoffMode: 'immediate' | 'scheduled',
   ): Promise<void> {
     const { planId } = this.state;
+    const disposalToken = this.disposalToken;
     const controller = new AbortController();
+    this.activeFetchController = controller;
     const timeoutId = setTimeout(() => controller.abort(), this.fetchTimeoutMs);
 
     try {
       const response = await this.fetcher(`/api/v1/plans/${planId}/status`, {
         signal: controller.signal,
       });
+      if (this.isStaleFetch(disposalToken)) {
+        return;
+      }
 
       if (!response.ok) {
         const parsed = await parseApiErrorResponse(
           response,
           `Failed to fetch plan status: ${response.status}`,
         );
+        if (this.isStaleFetch(disposalToken)) {
+          return;
+        }
         const retriable = isRetriableFromResponse(response.status);
         throw new RetriableError(parsed.error, retriable);
       }
 
       const raw = (await response.json()) as unknown;
+      if (this.isStaleFetch(disposalToken)) {
+        return;
+      }
       const parseResult = PlanStatusResponseSchema.safeParse(raw);
       if (!parseResult.success) {
         throw parseResult.error;
@@ -257,6 +281,10 @@ export class PlanStatusPoller {
       this.syncSnapshot();
       this.emit();
     } catch (err) {
+      if (this.isStaleFetch(disposalToken)) {
+        return;
+      }
+
       if (err instanceof Error && err.name === 'AbortError') {
         this.state = transitionPlanPollState(
           this.state,
@@ -319,6 +347,9 @@ export class PlanStatusPoller {
       }
     } finally {
       clearTimeout(timeoutId);
+      if (this.activeFetchController === controller) {
+        this.activeFetchController = null;
+      }
     }
   }
 }

--- a/src/features/plans/status-polling/plan-status-poller.ts
+++ b/src/features/plans/status-polling/plan-status-poller.ts
@@ -8,7 +8,10 @@ import {
 } from './plan-status-machine';
 import { parseApiErrorResponse } from '@/lib/api/error-response';
 import { clientLogger } from '@/lib/logging/client';
-import { INITIAL_POLL_MS } from '@/shared/constants/polling';
+import {
+  INITIAL_POLL_MS,
+  PLAN_STATUS_FETCH_TIMEOUT_MS,
+} from '@/shared/constants/polling';
 import { PlanStatusResponseSchema } from '@/shared/schemas/plan-status';
 import { ZodError } from 'zod';
 
@@ -31,6 +34,7 @@ export interface PlanStatusPollerConfig {
   initialStatus: PlanStatus;
   fetcher?: typeof fetch;
   randomFn?: () => number;
+  fetchTimeoutMs?: number;
 }
 
 export interface PlanStatusSnapshot {
@@ -46,19 +50,24 @@ export class PlanStatusPoller {
   private snapshot: PlanStatusSnapshot;
   private listeners = new Set<() => void>();
   private pollTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  private inFlightFetch: Promise<void> | null = null;
+  private pollingToken = 0;
   private cancelled = false;
   private started = false;
   private readonly fetcher: typeof fetch;
   private readonly randomFn: () => number;
+  private readonly fetchTimeoutMs: number;
 
   constructor({
     planId,
     initialStatus,
     fetcher = fetch,
     randomFn = Math.random,
+    fetchTimeoutMs = PLAN_STATUS_FETCH_TIMEOUT_MS,
   }: PlanStatusPollerConfig) {
     this.fetcher = fetcher;
     this.randomFn = randomFn;
+    this.fetchTimeoutMs = fetchTimeoutMs;
     this.state = createInitialPlanPollState(planId, initialStatus);
     this.snapshot = this.buildSnapshot(this.state);
   }
@@ -92,7 +101,15 @@ export class PlanStatusPoller {
     this.emit();
     if (shouldContinuePolling(this.state)) {
       this.clearScheduledPoll();
+      const token = this.pollingToken;
       await this.fetchOnce('immediate');
+      if (
+        token !== this.pollingToken ||
+        this.cancelled ||
+        !shouldContinuePolling(this.state)
+      ) {
+        return;
+      }
       this.scheduleNextPoll();
     }
   };
@@ -114,10 +131,16 @@ export class PlanStatusPoller {
     };
 
     void (async () => {
+      const token = this.pollingToken;
       await this.fetchOnce('immediate');
-      if (!this.cancelled && shouldContinuePolling(this.state)) {
-        this.scheduleNextPoll();
+      if (
+        token !== this.pollingToken ||
+        this.cancelled ||
+        !shouldContinuePolling(this.state)
+      ) {
+        return;
       }
+      this.scheduleNextPoll();
     })();
   }
 
@@ -128,6 +151,7 @@ export class PlanStatusPoller {
   }
 
   private clearScheduledPoll(): void {
+    this.pollingToken += 1;
     if (this.pollTimeoutId !== null) {
       clearTimeout(this.pollTimeoutId);
       this.pollTimeoutId = null;
@@ -141,33 +165,67 @@ export class PlanStatusPoller {
   }
 
   private scheduleNextPoll(): void {
-    if (this.cancelled || !shouldContinuePolling(this.state)) {
+    if (
+      this.pollTimeoutId !== null ||
+      this.cancelled ||
+      !shouldContinuePolling(this.state)
+    ) {
       return;
     }
 
     const delayMs = this.state.delayMs;
+    const token = this.pollingToken;
     this.pollTimeoutId = setTimeout(() => {
       this.pollTimeoutId = null;
-      if (this.cancelled || !shouldContinuePolling(this.state)) {
+      if (
+        token !== this.pollingToken ||
+        this.cancelled ||
+        !shouldContinuePolling(this.state)
+      ) {
         return;
       }
 
       void (async () => {
+        const fetchToken = this.pollingToken;
         await this.fetchOnce('scheduled');
-        if (!this.cancelled && shouldContinuePolling(this.state)) {
-          this.scheduleNextPoll();
+        if (
+          fetchToken !== this.pollingToken ||
+          this.cancelled ||
+          !shouldContinuePolling(this.state)
+        ) {
+          return;
         }
+        this.scheduleNextPoll();
       })();
     }, delayMs);
   }
 
-  private async fetchOnce(
+  private fetchOnce(backoffMode: 'immediate' | 'scheduled'): Promise<void> {
+    if (this.inFlightFetch) {
+      return this.inFlightFetch;
+    }
+
+    const request = this.performFetchOnce(backoffMode);
+    this.inFlightFetch = request;
+
+    return request.finally(() => {
+      if (this.inFlightFetch === request) {
+        this.inFlightFetch = null;
+      }
+    });
+  }
+
+  private async performFetchOnce(
     backoffMode: 'immediate' | 'scheduled',
   ): Promise<void> {
     const { planId } = this.state;
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.fetchTimeoutMs);
 
     try {
-      const response = await this.fetcher(`/api/v1/plans/${planId}/status`);
+      const response = await this.fetcher(`/api/v1/plans/${planId}/status`, {
+        signal: controller.signal,
+      });
 
       if (!response.ok) {
         const parsed = await parseApiErrorResponse(
@@ -199,6 +257,20 @@ export class PlanStatusPoller {
       this.syncSnapshot();
       this.emit();
     } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        this.state = transitionPlanPollState(
+          this.state,
+          {
+            type: 'transient_failure',
+            message: 'Plan status request timed out',
+          },
+          this.randomFn,
+        );
+        this.syncSnapshot();
+        this.emit();
+        return;
+      }
+
       if (err instanceof ZodError) {
         clientLogger.error('Plan status response validation failed', {
           planId,
@@ -245,6 +317,8 @@ export class PlanStatusPoller {
       } else {
         clientLogger.warn('Transient polling failure, will retry:', err);
       }
+    } finally {
+      clearTimeout(timeoutId);
     }
   }
 }

--- a/src/features/plans/status-polling/plan-status-poller.ts
+++ b/src/features/plans/status-polling/plan-status-poller.ts
@@ -1,0 +1,245 @@
+import type { PlanStatus } from '@/shared/types/client.types';
+
+import {
+  createInitialPlanPollState,
+  shouldContinuePolling,
+  transitionPlanPollState,
+  type PlanPollState,
+} from './plan-status-machine';
+import { parseApiErrorResponse } from '@/lib/api/error-response';
+import { clientLogger } from '@/lib/logging/client';
+import { INITIAL_POLL_MS } from '@/shared/constants/polling';
+import { PlanStatusResponseSchema } from '@/shared/schemas/plan-status';
+import { ZodError } from 'zod';
+
+function isRetriableFromResponse(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+class RetriableError extends Error {
+  constructor(
+    message: string,
+    public readonly isRetriable: boolean,
+  ) {
+    super(message);
+    this.name = 'RetriableError';
+  }
+}
+
+export interface PlanStatusPollerConfig {
+  planId: string;
+  initialStatus: PlanStatus;
+  fetcher?: typeof fetch;
+  randomFn?: () => number;
+}
+
+export interface PlanStatusSnapshot {
+  status: PlanStatus;
+  attempts: number;
+  error: string | null;
+  pollingError: string | null;
+  isPolling: boolean;
+}
+
+export class PlanStatusPoller {
+  private state: PlanPollState;
+  private snapshot: PlanStatusSnapshot;
+  private listeners = new Set<() => void>();
+  private pollTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  private cancelled = false;
+  private started = false;
+  private readonly fetcher: typeof fetch;
+  private readonly randomFn: () => number;
+
+  constructor({
+    planId,
+    initialStatus,
+    fetcher = fetch,
+    randomFn = Math.random,
+  }: PlanStatusPollerConfig) {
+    this.fetcher = fetcher;
+    this.randomFn = randomFn;
+    this.state = createInitialPlanPollState(planId, initialStatus);
+    this.snapshot = this.buildSnapshot(this.state);
+  }
+
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  getSnapshot = (): PlanStatusSnapshot => this.snapshot;
+
+  private buildSnapshot(state: PlanPollState): PlanStatusSnapshot {
+    return {
+      status: state.status,
+      attempts: state.attempts,
+      error: state.error,
+      pollingError: state.pollingError,
+      isPolling: state.phase === 'polling',
+    };
+  }
+
+  private syncSnapshot(): void {
+    this.snapshot = this.buildSnapshot(this.state);
+  }
+
+  revalidate = async (): Promise<void> => {
+    this.state = transitionPlanPollState(this.state, { type: 'revalidate' });
+    this.syncSnapshot();
+    this.emit();
+    if (shouldContinuePolling(this.state)) {
+      await this.fetchOnce('immediate');
+      this.scheduleNextPoll();
+    }
+  };
+
+  start(): void {
+    if (this.started) {
+      return;
+    }
+    this.started = true;
+    this.cancelled = false;
+
+    if (!shouldContinuePolling(this.state)) {
+      return;
+    }
+
+    this.state = {
+      ...this.state,
+      delayMs: INITIAL_POLL_MS,
+    };
+
+    void (async () => {
+      await this.fetchOnce('immediate');
+      if (!this.cancelled && shouldContinuePolling(this.state)) {
+        this.scheduleNextPoll();
+      }
+    })();
+  }
+
+  dispose(): void {
+    this.cancelled = true;
+    this.started = false;
+    if (this.pollTimeoutId !== null) {
+      clearTimeout(this.pollTimeoutId);
+      this.pollTimeoutId = null;
+    }
+  }
+
+  private emit(): void {
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+
+  private scheduleNextPoll(): void {
+    if (this.cancelled || !shouldContinuePolling(this.state)) {
+      return;
+    }
+
+    const delayMs = this.state.delayMs;
+    this.pollTimeoutId = setTimeout(() => {
+      this.pollTimeoutId = null;
+      if (this.cancelled || !shouldContinuePolling(this.state)) {
+        return;
+      }
+
+      void (async () => {
+        await this.fetchOnce('scheduled');
+        if (!this.cancelled && shouldContinuePolling(this.state)) {
+          this.scheduleNextPoll();
+        }
+      })();
+    }, delayMs);
+  }
+
+  private async fetchOnce(
+    backoffMode: 'immediate' | 'scheduled',
+  ): Promise<void> {
+    const { planId } = this.state;
+
+    try {
+      const response = await this.fetcher(`/api/v1/plans/${planId}/status`);
+
+      if (!response.ok) {
+        const parsed = await parseApiErrorResponse(
+          response,
+          `Failed to fetch plan status: ${response.status}`,
+        );
+        const retriable = isRetriableFromResponse(response.status);
+        throw new RetriableError(parsed.error, retriable);
+      }
+
+      const raw = (await response.json()) as unknown;
+      const parseResult = PlanStatusResponseSchema.safeParse(raw);
+      if (!parseResult.success) {
+        throw parseResult.error;
+      }
+
+      const data = parseResult.data;
+      this.state = transitionPlanPollState(
+        this.state,
+        {
+          type: 'response',
+          status: data.status,
+          attempts: data.attempts,
+          error: data.latestError,
+          backoffMode,
+        },
+        this.randomFn,
+      );
+      this.syncSnapshot();
+      this.emit();
+    } catch (err) {
+      if (err instanceof ZodError) {
+        clientLogger.error('Plan status response validation failed', {
+          planId,
+          error: err.flatten(),
+        });
+        this.state = transitionPlanPollState(this.state, {
+          type: 'fatal_failure',
+          message: 'Received invalid plan status response from server.',
+        });
+        this.syncSnapshot();
+        this.emit();
+        return;
+      }
+
+      const message =
+        err instanceof Error ? err.message : 'Failed to fetch plan status';
+      const isRetriable =
+        err instanceof RetriableError ? err.isRetriable : true;
+
+      if (!isRetriable) {
+        clientLogger.error('Failed to poll plan status (non-retriable):', err);
+        this.state = transitionPlanPollState(this.state, {
+          type: 'fatal_failure',
+          message,
+        });
+        this.syncSnapshot();
+        this.emit();
+        return;
+      }
+
+      this.state = transitionPlanPollState(
+        this.state,
+        { type: 'transient_failure', message },
+        this.randomFn,
+      );
+      this.syncSnapshot();
+      this.emit();
+
+      if (this.state.phase === 'stopped') {
+        clientLogger.error(
+          'Failed to poll plan status: max retries exhausted',
+          err,
+        );
+      } else {
+        clientLogger.warn('Transient polling failure, will retry:', err);
+      }
+    }
+  }
+}

--- a/src/hooks/usePlanStatus.ts
+++ b/src/hooks/usePlanStatus.ts
@@ -33,13 +33,29 @@ export function usePlanStatus(
   const [poller, setPoller] = useState(() =>
     createPoller(planId, initialStatus, fetcher),
   );
-  const previousPlanIdRef = useRef(planId);
+  const pollerRef = useRef(poller);
+  pollerRef.current = poller;
 
-  if (previousPlanIdRef.current !== planId) {
-    previousPlanIdRef.current = planId;
-    poller.dispose();
-    setPoller(createPoller(planId, initialStatusRef.current, fetcher));
-  }
+  const planIdRef = useRef(planId);
+  const fetcherRef = useRef(fetcher);
+
+  useEffect(() => {
+    const planIdChanged = planIdRef.current !== planId;
+    const fetcherChanged = fetcherRef.current !== fetcher;
+    planIdRef.current = planId;
+    fetcherRef.current = fetcher;
+
+    if (planIdChanged || fetcherChanged) {
+      pollerRef.current.dispose();
+      const nextPoller = createPoller(
+        planId,
+        initialStatusRef.current,
+        fetcher,
+      );
+      pollerRef.current = nextPoller;
+      setPoller(nextPoller);
+    }
+  }, [planId, fetcher]);
 
   const snapshot = useSyncExternalStore(
     poller.subscribe,

--- a/src/hooks/usePlanStatus.ts
+++ b/src/hooks/usePlanStatus.ts
@@ -2,28 +2,8 @@
 
 import type { PlanStatus } from '@/shared/types/client.types';
 
-import { parseApiErrorResponse } from '@/lib/api/error-response';
-import { clientLogger } from '@/lib/logging/client';
-import { computeNextDelay, INITIAL_POLL_MS } from '@/shared/constants/polling';
-import { PlanStatusResponseSchema } from '@/shared/schemas/plan-status';
-import { useCallback, useEffect, useReducer, useRef, useState } from 'react';
-import { ZodError } from 'zod';
-
-const MAX_CONSECUTIVE_FAILURES = 3;
-
-function isRetriableFromResponse(status: number): boolean {
-  return status === 429 || status >= 500;
-}
-
-class RetriableError extends Error {
-  constructor(
-    message: string,
-    public readonly isRetriable: boolean,
-  ) {
-    super(message);
-    this.name = 'RetriableError';
-  }
-}
+import { PlanStatusPoller } from '@/features/plans/status-polling/plan-status-poller';
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
 
 interface UsePlanStatusReturn {
   status: PlanStatus;
@@ -34,50 +14,12 @@ interface UsePlanStatusReturn {
   revalidate: () => Promise<void>;
 }
 
-type PlanPollState = {
-  status: PlanStatus;
-  attempts: number;
-  error: string | null;
-  pollingError: string | null;
-};
-
-type PlanPollAction =
-  | { type: 'reset'; initialStatus: PlanStatus }
-  | {
-      type: 'apply_response';
-      status: PlanStatus;
-      attempts: number;
-      error: string | null;
-    }
-  | { type: 'set_polling_error'; message: string }
-  | { type: 'clear_polling_error' };
-
-function planPollReducer(
-  state: PlanPollState,
-  action: PlanPollAction,
-): PlanPollState {
-  switch (action.type) {
-    case 'reset':
-      return {
-        status: action.initialStatus,
-        attempts: 0,
-        error: null,
-        pollingError: null,
-      };
-    case 'apply_response':
-      return {
-        ...state,
-        status: action.status,
-        attempts: action.attempts,
-        error: action.error,
-      };
-    case 'set_polling_error':
-      return { ...state, pollingError: action.message };
-    case 'clear_polling_error':
-      return { ...state, pollingError: null };
-    default:
-      return state;
-  }
+function createPoller(
+  planId: string,
+  initialStatus: PlanStatus,
+  fetcher: typeof fetch,
+): PlanStatusPoller {
+  return new PlanStatusPoller({ planId, initialStatus, fetcher });
 }
 
 export function usePlanStatus(
@@ -85,177 +27,39 @@ export function usePlanStatus(
   initialStatus: PlanStatus,
   fetcher: typeof fetch = fetch,
 ): UsePlanStatusReturn {
-  const [state, dispatch] = useReducer(planPollReducer, {
-    status: initialStatus,
-    attempts: 0,
-    error: null,
-    pollingError: null,
-  });
-  const [pollLoopRunning, setPollLoopRunning] = useState(false);
-  const consecutiveFailuresRef = useRef(0);
-  const previousStatusRef = useRef<PlanStatus>(initialStatus);
-  const delayRef = useRef(INITIAL_POLL_MS);
-  const previousPlanIdRef = useRef(planId);
-  // Track latest initialStatus without making planId-reset effect depend on it.
-  // This prevents a spurious full reset when initialStatus changes on the same plan.
   const initialStatusRef = useRef(initialStatus);
-  useEffect(() => {
-    initialStatusRef.current = initialStatus;
-  });
+  initialStatusRef.current = initialStatus;
 
-  const shouldPoll =
-    (state.status === 'pending' || state.status === 'processing') &&
-    state.pollingError === null;
-  const isPolling = shouldPoll && pollLoopRunning;
+  const [poller, setPoller] = useState(() =>
+    createPoller(planId, initialStatus, fetcher),
+  );
+  const previousPlanIdRef = useRef(planId);
 
-  const fetchStatus = useCallback(async () => {
-    try {
-      const response = await fetcher(`/api/v1/plans/${planId}/status`);
-
-      if (!response.ok) {
-        const parsed = await parseApiErrorResponse(
-          response,
-          `Failed to fetch plan status: ${response.status}`,
-        );
-        const retriable = isRetriableFromResponse(response.status);
-        throw new RetriableError(parsed.error, retriable);
-      }
-
-      consecutiveFailuresRef.current = 0;
-
-      const raw = (await response.json()) as unknown;
-      const parseResult = PlanStatusResponseSchema.safeParse(raw);
-      if (!parseResult.success) {
-        throw parseResult.error;
-      }
-
-      const data = parseResult.data;
-
-      previousStatusRef.current = data.status;
-      dispatch({
-        type: 'apply_response',
-        status: data.status,
-        attempts: data.attempts,
-        error: data.latestError,
-      });
-    } catch (err) {
-      if (err instanceof ZodError) {
-        clientLogger.error('Plan status response validation failed', {
-          planId,
-          error: err.flatten(),
-        });
-        consecutiveFailuresRef.current += 1;
-        dispatch({
-          type: 'set_polling_error',
-          message: 'Received invalid plan status response from server.',
-        });
-        setPollLoopRunning(false);
-        return;
-      }
-
-      const message =
-        err instanceof Error ? err.message : 'Failed to fetch plan status';
-      const isRetriable =
-        err instanceof RetriableError ? err.isRetriable : true;
-
-      if (!isRetriable) {
-        clientLogger.error('Failed to poll plan status (non-retriable):', err);
-        dispatch({ type: 'set_polling_error', message });
-        setPollLoopRunning(false);
-        return;
-      }
-
-      consecutiveFailuresRef.current += 1;
-      if (consecutiveFailuresRef.current >= MAX_CONSECUTIVE_FAILURES) {
-        clientLogger.error(
-          'Failed to poll plan status: max retries exhausted',
-          err,
-        );
-        dispatch({ type: 'set_polling_error', message });
-        setPollLoopRunning(false);
-        return;
-      }
-
-      clientLogger.warn('Transient polling failure, will retry:', err);
-    }
-  }, [planId, fetcher]);
-
-  const revalidate = useCallback(async (): Promise<void> => {
-    consecutiveFailuresRef.current = 0;
-    dispatch({ type: 'clear_polling_error' });
-    setPollLoopRunning(true);
-    await fetchStatus();
-  }, [fetchStatus]);
-
-  useEffect(() => {
-    if (!shouldPoll) {
-      setPollLoopRunning(false);
-      return;
-    }
-
-    setPollLoopRunning(true);
-    delayRef.current = INITIAL_POLL_MS;
-
-    let cancelled = false;
-    let pollTimeoutId: ReturnType<typeof setTimeout> | null = null;
-
-    const schedulePoll = () => {
-      if (cancelled) return;
-      pollTimeoutId = setTimeout(() => {
-        if (cancelled) return;
-        const prevStatus = previousStatusRef.current;
-        void fetchStatus().then(() => {
-          if (cancelled) return;
-          // Reset backoff when a status transition occurs
-          if (previousStatusRef.current !== prevStatus) {
-            delayRef.current = INITIAL_POLL_MS;
-          } else {
-            delayRef.current = computeNextDelay(delayRef.current);
-          }
-          schedulePoll();
-        });
-      }, delayRef.current);
-    };
-
-    // Fire the first poll immediately, then start the backoff loop
-    void (async () => {
-      await fetchStatus();
-      if (!cancelled) {
-        delayRef.current = computeNextDelay(delayRef.current);
-        schedulePoll();
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-      if (pollTimeoutId) {
-        clearTimeout(pollTimeoutId);
-        pollTimeoutId = null;
-      }
-      setPollLoopRunning(false);
-    };
-  }, [shouldPoll, fetchStatus]);
-
-  // When the planId changes, reset all per-plan state so the new plan starts fresh
-  // and stale state from the previous plan never leaks into the UI.
-  useEffect(() => {
-    if (previousPlanIdRef.current === planId) {
-      return;
-    }
-
+  if (previousPlanIdRef.current !== planId) {
     previousPlanIdRef.current = planId;
-    previousStatusRef.current = initialStatusRef.current;
-    delayRef.current = INITIAL_POLL_MS;
-    consecutiveFailuresRef.current = 0;
-    dispatch({ type: 'reset', initialStatus: initialStatusRef.current });
-  }, [planId]);
+    poller.dispose();
+    setPoller(createPoller(planId, initialStatusRef.current, fetcher));
+  }
+
+  const snapshot = useSyncExternalStore(
+    poller.subscribe,
+    poller.getSnapshot,
+    poller.getSnapshot,
+  );
+
+  useEffect(() => {
+    poller.start();
+    return () => {
+      poller.dispose();
+    };
+  }, [poller]);
 
   return {
-    status: state.status,
-    attempts: state.attempts,
-    error: state.error,
-    pollingError: state.pollingError,
-    isPolling,
-    revalidate,
+    status: snapshot.status,
+    attempts: snapshot.attempts,
+    error: snapshot.error,
+    pollingError: snapshot.pollingError,
+    isPolling: snapshot.isPolling,
+    revalidate: poller.revalidate,
   };
 }

--- a/src/hooks/usePlanStatus.ts
+++ b/src/hooks/usePlanStatus.ts
@@ -6,7 +6,7 @@ import { parseApiErrorResponse } from '@/lib/api/error-response';
 import { clientLogger } from '@/lib/logging/client';
 import { computeNextDelay, INITIAL_POLL_MS } from '@/shared/constants/polling';
 import { PlanStatusResponseSchema } from '@/shared/schemas/plan-status';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useReducer, useRef, useState } from 'react';
 import { ZodError } from 'zod';
 
 const MAX_CONSECUTIVE_FAILURES = 3;
@@ -34,16 +34,64 @@ interface UsePlanStatusReturn {
   revalidate: () => Promise<void>;
 }
 
+type PlanPollState = {
+  status: PlanStatus;
+  attempts: number;
+  error: string | null;
+  pollingError: string | null;
+};
+
+type PlanPollAction =
+  | { type: 'reset'; initialStatus: PlanStatus }
+  | {
+      type: 'apply_response';
+      status: PlanStatus;
+      attempts: number;
+      error: string | null;
+    }
+  | { type: 'set_polling_error'; message: string }
+  | { type: 'clear_polling_error' };
+
+function planPollReducer(
+  state: PlanPollState,
+  action: PlanPollAction,
+): PlanPollState {
+  switch (action.type) {
+    case 'reset':
+      return {
+        status: action.initialStatus,
+        attempts: 0,
+        error: null,
+        pollingError: null,
+      };
+    case 'apply_response':
+      return {
+        ...state,
+        status: action.status,
+        attempts: action.attempts,
+        error: action.error,
+      };
+    case 'set_polling_error':
+      return { ...state, pollingError: action.message };
+    case 'clear_polling_error':
+      return { ...state, pollingError: null };
+    default:
+      return state;
+  }
+}
+
 export function usePlanStatus(
   planId: string,
   initialStatus: PlanStatus,
   fetcher: typeof fetch = fetch,
 ): UsePlanStatusReturn {
-  const [status, setStatus] = useState<PlanStatus>(initialStatus);
-  const [attempts, setAttempts] = useState<number>(0);
-  const [error, setError] = useState<string | null>(null);
-  const [pollingError, setPollingError] = useState<string | null>(null);
-  const [isPolling, setIsPolling] = useState(false);
+  const [state, dispatch] = useReducer(planPollReducer, {
+    status: initialStatus,
+    attempts: 0,
+    error: null,
+    pollingError: null,
+  });
+  const [pollLoopRunning, setPollLoopRunning] = useState(false);
   const consecutiveFailuresRef = useRef(0);
   const previousStatusRef = useRef<PlanStatus>(initialStatus);
   const delayRef = useRef(INITIAL_POLL_MS);
@@ -56,7 +104,9 @@ export function usePlanStatus(
   });
 
   const shouldPoll =
-    (status === 'pending' || status === 'processing') && pollingError === null;
+    (state.status === 'pending' || state.status === 'processing') &&
+    state.pollingError === null;
+  const isPolling = shouldPoll && pollLoopRunning;
 
   const fetchStatus = useCallback(async () => {
     try {
@@ -82,15 +132,12 @@ export function usePlanStatus(
       const data = parseResult.data;
 
       previousStatusRef.current = data.status;
-      setStatus(data.status);
-      setAttempts(data.attempts);
-
-      setError(data.latestError);
-
-      // Stop polling if terminal state reached
-      if (data.status === 'ready' || data.status === 'failed') {
-        setIsPolling(false);
-      }
+      dispatch({
+        type: 'apply_response',
+        status: data.status,
+        attempts: data.attempts,
+        error: data.latestError,
+      });
     } catch (err) {
       if (err instanceof ZodError) {
         clientLogger.error('Plan status response validation failed', {
@@ -98,8 +145,11 @@ export function usePlanStatus(
           error: err.flatten(),
         });
         consecutiveFailuresRef.current += 1;
-        setPollingError('Received invalid plan status response from server.');
-        setIsPolling(false);
+        dispatch({
+          type: 'set_polling_error',
+          message: 'Received invalid plan status response from server.',
+        });
+        setPollLoopRunning(false);
         return;
       }
 
@@ -110,8 +160,8 @@ export function usePlanStatus(
 
       if (!isRetriable) {
         clientLogger.error('Failed to poll plan status (non-retriable):', err);
-        setPollingError(message);
-        setIsPolling(false);
+        dispatch({ type: 'set_polling_error', message });
+        setPollLoopRunning(false);
         return;
       }
 
@@ -121,8 +171,8 @@ export function usePlanStatus(
           'Failed to poll plan status: max retries exhausted',
           err,
         );
-        setPollingError(message);
-        setIsPolling(false);
+        dispatch({ type: 'set_polling_error', message });
+        setPollLoopRunning(false);
         return;
       }
 
@@ -132,18 +182,18 @@ export function usePlanStatus(
 
   const revalidate = useCallback(async (): Promise<void> => {
     consecutiveFailuresRef.current = 0;
-    setPollingError(null);
-    setIsPolling(true);
+    dispatch({ type: 'clear_polling_error' });
+    setPollLoopRunning(true);
     await fetchStatus();
   }, [fetchStatus]);
 
   useEffect(() => {
     if (!shouldPoll) {
-      setIsPolling(false);
+      setPollLoopRunning(false);
       return;
     }
 
-    setIsPolling(true);
+    setPollLoopRunning(true);
     delayRef.current = INITIAL_POLL_MS;
 
     let cancelled = false;
@@ -182,7 +232,7 @@ export function usePlanStatus(
         clearTimeout(pollTimeoutId);
         pollTimeoutId = null;
       }
-      setIsPolling(false);
+      setPollLoopRunning(false);
     };
   }, [shouldPoll, fetchStatus]);
 
@@ -194,12 +244,18 @@ export function usePlanStatus(
     }
 
     previousPlanIdRef.current = planId;
-    setStatus(initialStatusRef.current);
-    setAttempts(0);
-    setError(null);
-    setPollingError(null);
+    previousStatusRef.current = initialStatusRef.current;
+    delayRef.current = INITIAL_POLL_MS;
     consecutiveFailuresRef.current = 0;
+    dispatch({ type: 'reset', initialStatus: initialStatusRef.current });
   }, [planId]);
 
-  return { status, attempts, error, pollingError, isPolling, revalidate };
+  return {
+    status: state.status,
+    attempts: state.attempts,
+    error: state.error,
+    pollingError: state.pollingError,
+    isPolling,
+    revalidate,
+  };
 }

--- a/src/lib/api/internal/internal-worker-access.ts
+++ b/src/lib/api/internal/internal-worker-access.ts
@@ -5,7 +5,34 @@ import {
   readInternalWorkerToken,
   tokensMatch,
 } from '@/lib/api/internal/internal-worker-token';
-import { appEnv } from '@/lib/config/env';
+import { appEnv, maintenanceEnv } from '@/lib/config/env';
+
+const MAINTENANCE_WORKER_HEADER = 'x-maintenance-worker-token';
+const MISSING_MAINTENANCE_WORKER_TOKEN_LOG_MESSAGE =
+  'Maintenance worker token missing in production';
+
+export type AssertMaintenanceWorkerAccessArgs = {
+  request: Request;
+  pathname: string;
+  logger: Logger;
+  enabled: boolean;
+  unavailableMessage: string;
+  unauthorizedLogMessage: string;
+};
+
+/**
+ * Shared auth gate for maintenance cleanup POST routes.
+ */
+export function assertMaintenanceWorkerAccess(
+  args: AssertMaintenanceWorkerAccessArgs,
+): void {
+  assertInternalWorkerAccess({
+    ...args,
+    workerToken: maintenanceEnv.workerToken,
+    headerName: MAINTENANCE_WORKER_HEADER,
+    missingWorkerTokenLogMessage: MISSING_MAINTENANCE_WORKER_TOKEN_LOG_MESSAGE,
+  });
+}
 
 export type AssertInternalWorkerAccessArgs = {
   request: Request;

--- a/src/lib/config/env/maintenance.ts
+++ b/src/lib/config/env/maintenance.ts
@@ -7,10 +7,11 @@ import {
 } from '@/lib/config/env/shared';
 
 /**
- * Retention cleanup env flags consumed by the internal maintenance route.
+ * Maintenance cleanup env flags consumed by internal maintenance routes.
  */
 interface MaintenanceEnv {
   readonly retentionCleanupEnabled: boolean;
+  readonly planCleanupEnabled: boolean;
   readonly workerToken: string | undefined;
 }
 
@@ -29,10 +30,16 @@ export function createMaintenanceEnv(access: ServerEnvAccess): MaintenanceEnv {
       );
     },
     /**
-     * Bearer token for manual retention cleanup via the internal HTTP route.
+     * Master switch for the manual plan cleanup HTTP endpoint.
+     */
+    get planCleanupEnabled(): boolean {
+      return toBoolean(access.getServerOptional('PLAN_CLEANUP_ENABLED'), false);
+    },
+    /**
+     * Bearer token for manual maintenance cleanup via internal HTTP routes.
      */
     get workerToken(): string | undefined {
-      if (!this.retentionCleanupEnabled) {
+      if (!this.retentionCleanupEnabled && !this.planCleanupEnabled) {
         return undefined;
       }
       return access.getServerRequiredProdOnly('MAINTENANCE_WORKER_TOKEN');

--- a/src/lib/db/queries/module-lesson-generation.ts
+++ b/src/lib/db/queries/module-lesson-generation.ts
@@ -1,7 +1,6 @@
-import type { DbClient } from '@/lib/db/types';
+import type { DbClient, DbTransaction } from '@/lib/db/types';
 import type { CanonicalAIUsage } from '@/shared/types/ai-usage.types';
 import type {
-  LessonContent,
   ModuleLessonBatchProviderOutput,
   ModuleLessonGenerationMetadata,
 } from '@/shared/types/lesson-content.types';
@@ -377,6 +376,43 @@ export type CommitModuleLessonBatchSuccessInput = {
 };
 
 /**
+ * Updates all task lesson rows for a module in one statement so content and timestamp
+ * commit atomically with the module ready transition.
+ */
+async function updateTaskLessonsInTx(
+  tx: Pick<DbTransaction, 'execute'>,
+  moduleId: string,
+  parsedTasks: ModuleLessonBatchProviderOutput['tasks'],
+  finishedAt: Date,
+): Promise<void> {
+  if (parsedTasks.length === 0) {
+    return;
+  }
+
+  const valueRows = parsedTasks.map(
+    (task) =>
+      sql`(${task.taskId}::uuid, ${JSON.stringify(task.content)}::jsonb)`,
+  );
+
+  const updated = (await tx.execute(sql`
+    UPDATE tasks AS t
+    SET
+      lesson_content = v.content,
+      lesson_content_updated_at = ${finishedAt.toISOString()}::timestamptz
+    FROM (VALUES ${sql.join(valueRows, sql`, `)}) AS v(id, content)
+    WHERE t.id = v.id
+      AND t.module_id = ${moduleId}::uuid
+    RETURNING t.id
+  `)) as Array<{ id: string }>;
+
+  if (updated.length !== parsedTasks.length) {
+    throw new Error(
+      `Expected ${parsedTasks.length} task lesson rows updated, got ${updated.length}`,
+    );
+  }
+}
+
+/**
  * Persists all task lessons, module ready fields, metadata, and AI usage in one RLS-aware transaction.
  */
 export async function commitModuleLessonBatchSuccess(
@@ -400,24 +436,12 @@ export async function commitModuleLessonBatchSuccess(
 
     assertParsedTasksMatchCurrentTaskRows(input.parsed, currentTasks);
 
-    for (const task of input.parsed.tasks) {
-      const updated = await tx
-        .update(tasks)
-        .set({
-          lessonContent: task.content as LessonContent,
-          lessonContentUpdatedAt: finishedAt,
-        })
-        .where(
-          and(eq(tasks.id, task.taskId), eq(tasks.moduleId, input.moduleId)),
-        )
-        .returning({ id: tasks.id });
-
-      if (updated.length !== 1) {
-        throw new Error(
-          `Expected exactly one task lesson row updated for task ${task.taskId}`,
-        );
-      }
-    }
+    await updateTaskLessonsInTx(
+      tx,
+      input.moduleId,
+      input.parsed.tasks,
+      finishedAt,
+    );
 
     const moduleUpdated = await tx
       .update(modules)

--- a/src/shared/constants/polling.ts
+++ b/src/shared/constants/polling.ts
@@ -8,6 +8,9 @@
 /** Delay (ms) for the very first poll after mount. */
 export const INITIAL_POLL_MS = 1_000;
 
+/** Upper bound (ms) for a single plan-status fetch before aborting. */
+export const PLAN_STATUS_FETCH_TIMEOUT_MS = 30_000;
+
 /** Upper bound (ms) for any single poll delay. */
 export const MAX_POLL_MS = 10_000;
 

--- a/supabase/AGENTS.md
+++ b/supabase/AGENTS.md
@@ -41,6 +41,7 @@ Retention cleanup is database-owned through `private.cleanup_retained_db_rows()`
 
 - The manual HTTP fallback is `POST /api/internal/maintenance/retention/cleanup`.
 - Enable the manual route with `RETENTION_CLEANUP_ENABLED=true`.
+- Plan cleanup (stuck plans and orphaned attempts) is `POST /api/internal/maintenance/plans/cleanup` with `PLAN_CLEANUP_ENABLED=true`.
 - In production, the manual route requires `MAINTENANCE_WORKER_TOKEN`.
 - Cron does not use the HTTP route or worker token.
 - Cleanup must not run from user read paths.

--- a/tests/integration/api/plan-cleanup-process.spec.ts
+++ b/tests/integration/api/plan-cleanup-process.spec.ts
@@ -1,4 +1,5 @@
 import { POST as POST_PLAN_CLEANUP } from '@/app/api/internal/maintenance/plans/cleanup/route';
+import * as planCleanup from '@/features/plans/cleanup';
 import {
   ORPHANED_ATTEMPT_THRESHOLD_MS,
   STUCK_PLAN_THRESHOLD_MS,
@@ -8,59 +9,114 @@ import { db } from '@supabase/service-role';
 import { createTestPlan } from '@tests/fixtures/plans';
 import { createTestUser } from '@tests/fixtures/users';
 import { eq } from 'drizzle-orm';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const ORIGINAL_ENV = {
-  MAINTENANCE_WORKER_TOKEN: process.env.MAINTENANCE_WORKER_TOKEN,
-  PLAN_CLEANUP_ENABLED: process.env.PLAN_CLEANUP_ENABLED,
-};
+const CLEANUP_URL = 'http://localhost/api/internal/maintenance/plans/cleanup';
+const WORKER_TOKEN = 'maintenance-secret';
 
-function restoreEnvVar(name: keyof typeof ORIGINAL_ENV): void {
-  const originalValue = ORIGINAL_ENV[name];
-  if (originalValue === undefined) {
-    delete process.env[name];
-    return;
+function createCleanupRequest(
+  init: RequestInit & { token?: string; useBearer?: boolean } = {},
+): Request {
+  const { token, useBearer = true, ...requestInit } = init;
+  const headers = new Headers(requestInit.headers);
+
+  if (token) {
+    if (useBearer) {
+      headers.set('Authorization', `Bearer ${token}`);
+    } else {
+      headers.set('x-maintenance-worker-token', token);
+    }
   }
-  process.env[name] = originalValue;
+
+  return new Request(CLEANUP_URL, {
+    method: 'POST',
+    ...requestInit,
+    headers,
+  });
 }
 
 describe('POST /api/internal/maintenance/plans/cleanup', () => {
   afterEach(() => {
-    const envKeys: Array<keyof typeof ORIGINAL_ENV> = [
-      'MAINTENANCE_WORKER_TOKEN',
-      'PLAN_CLEANUP_ENABLED',
-    ];
-    envKeys.forEach(restoreEnvVar);
+    vi.unstubAllEnvs();
   });
 
   it('returns 503 when plan cleanup is disabled', async () => {
-    process.env.PLAN_CLEANUP_ENABLED = 'false';
+    vi.stubEnv('PLAN_CLEANUP_ENABLED', 'false');
 
-    const response = await POST_PLAN_CLEANUP(
-      new Request('http://localhost/api/internal/maintenance/plans/cleanup', {
-        method: 'POST',
-      }),
-    );
+    const response = await POST_PLAN_CLEANUP(createCleanupRequest());
 
     expect(response.status).toBe(503);
   });
 
   it('rejects unauthorized requests when a worker token is configured', async () => {
-    process.env.MAINTENANCE_WORKER_TOKEN = 'maintenance-secret';
-    process.env.PLAN_CLEANUP_ENABLED = 'true';
+    vi.stubEnv('MAINTENANCE_WORKER_TOKEN', WORKER_TOKEN);
+    vi.stubEnv('PLAN_CLEANUP_ENABLED', 'true');
 
-    const response = await POST_PLAN_CLEANUP(
-      new Request('http://localhost/api/internal/maintenance/plans/cleanup', {
-        method: 'POST',
-      }),
-    );
+    const response = await POST_PLAN_CLEANUP(createCleanupRequest());
 
     expect(response.status).toBe(401);
   });
 
+  it('returns 200 with ok:true when authenticated via Bearer token', async () => {
+    vi.stubEnv('MAINTENANCE_WORKER_TOKEN', WORKER_TOKEN);
+    vi.stubEnv('PLAN_CLEANUP_ENABLED', 'true');
+
+    const response = await POST_PLAN_CLEANUP(
+      createCleanupRequest({ token: WORKER_TOKEN }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      ok: boolean;
+      stuckPlansCleaned: number;
+      orphanedAttemptsCleaned: number;
+    };
+    expect(body.ok).toBe(true);
+    expect(body.stuckPlansCleaned).toEqual(expect.any(Number));
+    expect(body.orphanedAttemptsCleaned).toEqual(expect.any(Number));
+  });
+
+  it('returns 200 with ok:true when authenticated via x-maintenance-worker-token', async () => {
+    vi.stubEnv('MAINTENANCE_WORKER_TOKEN', WORKER_TOKEN);
+    vi.stubEnv('PLAN_CLEANUP_ENABLED', 'true');
+
+    const response = await POST_PLAN_CLEANUP(
+      createCleanupRequest({ token: WORKER_TOKEN, useBearer: false }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { ok: boolean };
+    expect(body.ok).toBe(true);
+  });
+
+  it('returns 500 when plan cleanup maintenance throws', async () => {
+    vi.stubEnv('MAINTENANCE_WORKER_TOKEN', WORKER_TOKEN);
+    vi.stubEnv('PLAN_CLEANUP_ENABLED', 'true');
+
+    const maintenanceSpy = vi
+      .spyOn(planCleanup, 'runPlanCleanupMaintenance')
+      .mockRejectedValue(
+        new Error(
+          'Plan cleanup failed to mark all locked stuck plans as failed',
+        ),
+      );
+
+    try {
+      const response = await POST_PLAN_CLEANUP(
+        createCleanupRequest({ token: WORKER_TOKEN }),
+      );
+
+      expect(response.status).toBe(500);
+      const body = (await response.json()) as { error?: string };
+      expect(body.error).toBeDefined();
+    } finally {
+      maintenanceSpy.mockRestore();
+    }
+  });
+
   it('runs plan cleanup and returns cleaned counts', async () => {
-    process.env.PLAN_CLEANUP_ENABLED = 'true';
-    delete process.env.MAINTENANCE_WORKER_TOKEN;
+    vi.stubEnv('PLAN_CLEANUP_ENABLED', 'true');
+    vi.stubEnv('MAINTENANCE_WORKER_TOKEN', '');
 
     const user = await createTestUser();
     const stuckCutoff = new Date(Date.now() - STUCK_PLAN_THRESHOLD_MS - 60_000);
@@ -100,11 +156,7 @@ describe('POST /api/internal/maintenance/plans/cleanup', () => {
       .set({ createdAt: staleAttemptCutoff })
       .where(eq(generationAttempts.id, orphanedAttempt.id));
 
-    const response = await POST_PLAN_CLEANUP(
-      new Request('http://localhost/api/internal/maintenance/plans/cleanup', {
-        method: 'POST',
-      }),
-    );
+    const response = await POST_PLAN_CLEANUP(createCleanupRequest());
 
     expect(response.status).toBe(200);
     const body = (await response.json()) as {

--- a/tests/integration/api/plan-cleanup-process.spec.ts
+++ b/tests/integration/api/plan-cleanup-process.spec.ts
@@ -1,0 +1,137 @@
+import { POST as POST_PLAN_CLEANUP } from '@/app/api/internal/maintenance/plans/cleanup/route';
+import {
+  ORPHANED_ATTEMPT_THRESHOLD_MS,
+  STUCK_PLAN_THRESHOLD_MS,
+} from '@/features/plans/cleanup';
+import { generationAttempts, learningPlans } from '@supabase/schema';
+import { db } from '@supabase/service-role';
+import { createTestPlan } from '@tests/fixtures/plans';
+import { createTestUser } from '@tests/fixtures/users';
+import { eq } from 'drizzle-orm';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const ORIGINAL_ENV = {
+  MAINTENANCE_WORKER_TOKEN: process.env.MAINTENANCE_WORKER_TOKEN,
+  PLAN_CLEANUP_ENABLED: process.env.PLAN_CLEANUP_ENABLED,
+};
+
+function restoreEnvVar(name: keyof typeof ORIGINAL_ENV): void {
+  const originalValue = ORIGINAL_ENV[name];
+  if (originalValue === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = originalValue;
+}
+
+describe('POST /api/internal/maintenance/plans/cleanup', () => {
+  afterEach(() => {
+    const envKeys: Array<keyof typeof ORIGINAL_ENV> = [
+      'MAINTENANCE_WORKER_TOKEN',
+      'PLAN_CLEANUP_ENABLED',
+    ];
+    envKeys.forEach(restoreEnvVar);
+  });
+
+  it('returns 503 when plan cleanup is disabled', async () => {
+    process.env.PLAN_CLEANUP_ENABLED = 'false';
+
+    const response = await POST_PLAN_CLEANUP(
+      new Request('http://localhost/api/internal/maintenance/plans/cleanup', {
+        method: 'POST',
+      }),
+    );
+
+    expect(response.status).toBe(503);
+  });
+
+  it('rejects unauthorized requests when a worker token is configured', async () => {
+    process.env.MAINTENANCE_WORKER_TOKEN = 'maintenance-secret';
+    process.env.PLAN_CLEANUP_ENABLED = 'true';
+
+    const response = await POST_PLAN_CLEANUP(
+      new Request('http://localhost/api/internal/maintenance/plans/cleanup', {
+        method: 'POST',
+      }),
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it('runs plan cleanup and returns cleaned counts', async () => {
+    process.env.PLAN_CLEANUP_ENABLED = 'true';
+    delete process.env.MAINTENANCE_WORKER_TOKEN;
+
+    const user = await createTestUser();
+    const stuckCutoff = new Date(Date.now() - STUCK_PLAN_THRESHOLD_MS - 60_000);
+    const staleAttemptCutoff = new Date(
+      Date.now() - ORPHANED_ATTEMPT_THRESHOLD_MS - 60_000,
+    );
+
+    const stuckPlan = await createTestPlan({
+      userId: user.id,
+      topic: 'Route stuck plan',
+      generationStatus: 'generating',
+    });
+    const attemptPlan = await createTestPlan({
+      userId: user.id,
+      topic: 'Route orphaned attempt plan',
+    });
+
+    await db
+      .update(learningPlans)
+      .set({ updatedAt: stuckCutoff })
+      .where(eq(learningPlans.id, stuckPlan.id));
+
+    const [orphanedAttempt] = await db
+      .insert(generationAttempts)
+      .values({
+        planId: attemptPlan.id,
+        status: 'in_progress',
+        classification: null,
+        durationMs: 0,
+        modulesCount: 0,
+        tasksCount: 0,
+      })
+      .returning();
+
+    await db
+      .update(generationAttempts)
+      .set({ createdAt: staleAttemptCutoff })
+      .where(eq(generationAttempts.id, orphanedAttempt.id));
+
+    const response = await POST_PLAN_CLEANUP(
+      new Request('http://localhost/api/internal/maintenance/plans/cleanup', {
+        method: 'POST',
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      ok: boolean;
+      stuckPlansCleaned: number;
+      orphanedAttemptsCleaned: number;
+    };
+    expect(body.ok).toBe(true);
+    expect(body.stuckPlansCleaned).toBeGreaterThanOrEqual(1);
+    expect(body.orphanedAttemptsCleaned).toBeGreaterThanOrEqual(1);
+
+    const [stuckRow] = await db
+      .select({ generationStatus: learningPlans.generationStatus })
+      .from(learningPlans)
+      .where(eq(learningPlans.id, stuckPlan.id));
+    expect(stuckRow?.generationStatus).toBe('failed');
+
+    const [attemptRow] = await db
+      .select({
+        status: generationAttempts.status,
+        classification: generationAttempts.classification,
+      })
+      .from(generationAttempts)
+      .where(eq(generationAttempts.id, orphanedAttempt.id));
+    expect(attemptRow).toMatchObject({
+      status: 'failure',
+      classification: 'timeout',
+    });
+  });
+});

--- a/tests/integration/api/plans.route-boundary.spec.ts
+++ b/tests/integration/api/plans.route-boundary.spec.ts
@@ -1,0 +1,183 @@
+import type { startModuleLessonGeneration } from '@/features/lesson-content/start-module-lesson-generation-workflow';
+
+import { createModuleLessonContentGenerateHandler } from '@/app/api/v1/plans/[planId]/modules/[moduleId]/lesson-content/generate/handler';
+import {
+  clearAllUserRateLimiters,
+  USER_RATE_LIMIT_CONFIGS,
+} from '@/lib/api/user-rate-limit';
+import { learningPlans } from '@supabase/schema';
+import { db } from '@supabase/service-role';
+import { clearTestUser, setTestUser } from '@tests/helpers/auth';
+import { ensureUser } from '@tests/helpers/db/users';
+import { mockServerSession } from '@tests/helpers/mock-server-auth';
+import { buildRouteHandlerContext } from '@tests/helpers/route-handler-context';
+import { buildTestAuthUserId, buildTestEmail } from '@tests/helpers/testIds';
+import { NextRequest } from 'next/server';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockedFunction,
+} from 'vitest';
+
+const serverAuth = vi.hoisted(() => {
+  const getSession = vi.fn();
+  return {
+    getSession,
+    module: () => ({ auth: { getSession } }),
+  };
+});
+vi.mock('@/lib/auth/server', () => serverAuth.module());
+
+const mockStartModuleLessonGeneration = vi.fn() as MockedFunction<
+  typeof startModuleLessonGeneration
+>;
+const POST_LESSON_GENERATE = createModuleLessonContentGenerateHandler(
+  mockStartModuleLessonGeneration,
+);
+
+const VALID_PLAN_ID = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+const VALID_MODULE_ID = '7f9c2f8d-1a9b-4f6e-9f6c-2b2c3d479abc';
+
+describe('plans API route boundary (integration)', () => {
+  const ownerAuthId = buildTestAuthUserId('plans-route-boundary-owner');
+  let ownerUserId: string;
+  let ownerPlanId: string;
+
+  beforeEach(async () => {
+    clearAllUserRateLimiters();
+    mockStartModuleLessonGeneration.mockReset();
+    mockServerSession(serverAuth.getSession, ownerAuthId);
+    setTestUser(ownerAuthId);
+
+    ownerUserId = await ensureUser({
+      authUserId: ownerAuthId,
+      email: buildTestEmail(ownerAuthId),
+      subscriptionTier: 'starter',
+    });
+
+    const [plan] = await db
+      .insert(learningPlans)
+      .values({
+        userId: ownerUserId,
+        topic: 'Route boundary plan',
+        skillLevel: 'beginner',
+        weeklyHours: 5,
+        learningStyle: 'mixed',
+        visibility: 'private',
+        origin: 'ai',
+        generationStatus: 'ready',
+      })
+      .returning();
+    ownerPlanId = plan.id;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    clearTestUser();
+  });
+
+  it('GET /status returns canonical 401 for unauthenticated requests', async () => {
+    clearTestUser();
+    serverAuth.getSession.mockResolvedValue({ data: { user: null } });
+
+    const { GET } = await import('@/app/api/v1/plans/[planId]/status/route');
+    const request = new NextRequest(
+      `http://localhost:3000/api/v1/plans/${ownerPlanId}/status`,
+      { method: 'GET' },
+    );
+    const response = await GET(
+      request,
+      buildRouteHandlerContext({ planId: ownerPlanId }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body).toMatchObject({
+      error: 'Unauthorized',
+      code: 'UNAUTHORIZED',
+    });
+  });
+
+  it('GET /status includes read rate-limit headers for authenticated requests', async () => {
+    const { GET } = await import('@/app/api/v1/plans/[planId]/status/route');
+    const request = new NextRequest(
+      `http://localhost:3000/api/v1/plans/${ownerPlanId}/status`,
+      { method: 'GET' },
+    );
+    const response = await GET(
+      request,
+      buildRouteHandlerContext({ planId: ownerPlanId }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('X-RateLimit-Limit')).toBe(
+      String(USER_RATE_LIMIT_CONFIGS.read.maxRequests),
+    );
+    expect(response.headers.get('X-RateLimit-Remaining')).not.toBeNull();
+    expect(response.headers.get('X-RateLimit-Reset')).not.toBeNull();
+  });
+
+  it('POST lesson-content/generate returns canonical 401 for unauthenticated requests', async () => {
+    clearTestUser();
+    serverAuth.getSession.mockResolvedValue({ data: { user: null } });
+
+    const request = new Request(
+      `http://localhost/api/v1/plans/${VALID_PLAN_ID}/modules/${VALID_MODULE_ID}/lesson-content/generate`,
+      { method: 'POST' },
+    );
+    const response = await POST_LESSON_GENERATE(request, {
+      params: Promise.resolve({
+        planId: VALID_PLAN_ID,
+        moduleId: VALID_MODULE_ID,
+      }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body).toMatchObject({
+      error: 'Unauthorized',
+      code: 'UNAUTHORIZED',
+    });
+    expect(mockStartModuleLessonGeneration).not.toHaveBeenCalled();
+  });
+
+  it('POST lesson-content/generate includes lessonGeneration rate-limit headers when authenticated', async () => {
+    await db.insert(learningPlans).values({
+      id: VALID_PLAN_ID,
+      userId: ownerUserId,
+      topic: 'Lesson boundary plan',
+      skillLevel: 'beginner',
+      weeklyHours: 5,
+      learningStyle: 'mixed',
+      visibility: 'private',
+      origin: 'ai',
+      generationStatus: 'ready',
+    });
+    mockStartModuleLessonGeneration.mockResolvedValue({
+      kind: 'success',
+      durationMs: 100,
+    });
+
+    const request = new Request(
+      `http://localhost/api/v1/plans/${VALID_PLAN_ID}/modules/${VALID_MODULE_ID}/lesson-content/generate`,
+      { method: 'POST' },
+    );
+    const response = await POST_LESSON_GENERATE(request, {
+      params: Promise.resolve({
+        planId: VALID_PLAN_ID,
+        moduleId: VALID_MODULE_ID,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('X-RateLimit-Limit')).toBe(
+      String(USER_RATE_LIMIT_CONFIGS.lessonGeneration.maxRequests),
+    );
+    expect(response.headers.get('X-RateLimit-Remaining')).not.toBeNull();
+    expect(response.headers.get('X-RateLimit-Reset')).not.toBeNull();
+  });
+});

--- a/tests/integration/api/retention-cleanup-process.spec.ts
+++ b/tests/integration/api/retention-cleanup-process.spec.ts
@@ -32,6 +32,19 @@ describe('POST /api/internal/maintenance/retention/cleanup', () => {
     envKeys.forEach(restoreEnvVar);
   });
 
+  it('returns 503 when retention cleanup is disabled', async () => {
+    process.env.RETENTION_CLEANUP_ENABLED = 'false';
+
+    const response = await POST_RETENTION_CLEANUP(
+      new Request(
+        'http://localhost/api/internal/maintenance/retention/cleanup',
+        { method: 'POST' },
+      ),
+    );
+
+    expect(response.status).toBe(503);
+  });
+
   it('rejects unauthorized requests when a worker token is configured', async () => {
     process.env.MAINTENANCE_WORKER_TOKEN = 'maintenance-secret';
     process.env.RETENTION_CLEANUP_ENABLED = 'true';

--- a/tests/integration/db/module-lesson-generation.boundary.spec.ts
+++ b/tests/integration/db/module-lesson-generation.boundary.spec.ts
@@ -2,6 +2,7 @@ import { MockGenerationProvider } from '@/features/ai/providers/mock';
 import { getCurrentMonth } from '@/features/billing/usage-metrics';
 import { generateModuleLessons } from '@/features/lesson-content/generate-module-lessons';
 import { modules, tasks, aiUsageEvents, usageMetrics } from '@supabase/schema';
+import { MAX_MODULE_LESSON_BATCH_TASKS } from '@supabase/schema/constants';
 import { db } from '@supabase/service-role';
 import { createTestModule, createTestTask } from '@tests/fixtures/modules';
 import { createTestPlan } from '@tests/fixtures/plans';
@@ -90,6 +91,70 @@ describe('module lesson generation boundary (integration)', () => {
     expect(rows[1]?.lessonContent?.version).toBe(1);
     expect(rows[0]?.id).toBe(task1.id);
     expect(rows[1]?.id).toBe(task2.id);
+  });
+
+  it('persists distinct lesson content for max-batch tasks in one commit', async () => {
+    const authUserId = buildTestAuthUserId('mod-lesson-max-batch');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+      subscriptionTier: 'free',
+    });
+    const plan = await createTestPlan({
+      userId,
+      topic: 'Max batch task coverage',
+    });
+    const mod = await createTestModule({ planId: plan.id });
+    const createdTasks = await Promise.all(
+      Array.from({ length: MAX_MODULE_LESSON_BATCH_TASKS }, (_, index) =>
+        createTestTask({
+          moduleId: mod.id,
+          order: index + 1,
+          title: `Task ${index + 1}`,
+        }),
+      ),
+    );
+
+    const rlsDb = await createRlsDbForUser(authUserId);
+    const result = await generateModuleLessons(
+      {
+        dbClient: rlsDb,
+        userId,
+        planId: plan.id,
+        moduleId: mod.id,
+        userTier: 'free',
+      },
+      {
+        provider: new MockGenerationProvider({
+          delayMs: 0,
+          deterministicSeed: 23,
+        }),
+      },
+    );
+
+    expect(result.kind).toBe('success');
+
+    const [modRow] = await db
+      .select()
+      .from(modules)
+      .where(eq(modules.id, mod.id));
+    expect(modRow?.lessonGenerationStatus).toBe('ready');
+
+    const rows = await db
+      .select({
+        id: tasks.id,
+        order: tasks.order,
+        lessonContent: tasks.lessonContent,
+      })
+      .from(tasks)
+      .where(eq(tasks.moduleId, mod.id))
+      .orderBy(asc(tasks.order));
+
+    expect(rows).toHaveLength(MAX_MODULE_LESSON_BATCH_TASKS);
+    expect(rows.map((row) => row.id)).toEqual(
+      createdTasks.map((task) => task.id),
+    );
+    expect(rows.every((row) => row.lessonContent?.version === 1)).toBe(true);
   });
 
   it('persists distinct lesson content for five tasks in one batch commit', async () => {

--- a/tests/integration/db/module-lesson-generation.boundary.spec.ts
+++ b/tests/integration/db/module-lesson-generation.boundary.spec.ts
@@ -92,6 +92,73 @@ describe('module lesson generation boundary (integration)', () => {
     expect(rows[1]?.id).toBe(task2.id);
   });
 
+  it('persists distinct lesson content for five tasks in one batch commit', async () => {
+    const authUserId = buildTestAuthUserId('mod-lesson-five-tasks');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+      subscriptionTier: 'free',
+    });
+    const plan = await createTestPlan({ userId, topic: 'Five task batch' });
+    const mod = await createTestModule({ planId: plan.id });
+    const createdTasks = await Promise.all(
+      Array.from({ length: 5 }, (_, index) =>
+        createTestTask({
+          moduleId: mod.id,
+          order: index + 1,
+          title: `Task ${index + 1}`,
+        }),
+      ),
+    );
+
+    const rlsDb = await createRlsDbForUser(authUserId);
+    const result = await generateModuleLessons(
+      {
+        dbClient: rlsDb,
+        userId,
+        planId: plan.id,
+        moduleId: mod.id,
+        userTier: 'free',
+      },
+      {
+        provider: new MockGenerationProvider({
+          delayMs: 0,
+          deterministicSeed: 19,
+        }),
+      },
+    );
+
+    expect(result.kind).toBe('success');
+
+    const rows = await db
+      .select({
+        id: tasks.id,
+        order: tasks.order,
+        lessonContent: tasks.lessonContent,
+        lessonContentUpdatedAt: tasks.lessonContentUpdatedAt,
+      })
+      .from(tasks)
+      .where(eq(tasks.moduleId, mod.id))
+      .orderBy(asc(tasks.order));
+
+    expect(rows).toHaveLength(5);
+    expect(rows.map((row) => row.id)).toEqual(
+      createdTasks.map((task) => task.id),
+    );
+
+    const serializedContents = rows.map((row) =>
+      JSON.stringify(row.lessonContent),
+    );
+    expect(new Set(serializedContents).size).toBe(5);
+
+    const sharedTimestamp = rows[0]?.lessonContentUpdatedAt?.toISOString();
+    expect(sharedTimestamp).toBeDefined();
+    for (const row of rows) {
+      expect(row.lessonContent?.version).toBe(1);
+      expect(row.lessonContentUpdatedAt?.toISOString()).toBe(sharedTimestamp);
+    }
+  });
+
   it('retrying a failed module generation clears the error and returns ready', async () => {
     const authUserId = buildTestAuthUserId('mod-lesson-retry-failed');
     const userId = await ensureUser({

--- a/tests/integration/db/plan-cleanup.spec.ts
+++ b/tests/integration/db/plan-cleanup.spec.ts
@@ -1,0 +1,139 @@
+import {
+  cleanupStuckPlans,
+  STUCK_PLAN_THRESHOLD_MS,
+} from '@/features/plans/cleanup';
+import { learningPlans } from '@supabase/schema';
+import { db } from '@supabase/service-role';
+import { createTestPlan } from '@tests/fixtures/plans';
+import { createTestUser } from '@tests/fixtures/users';
+import { eq, inArray } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+
+describe('cleanupStuckPlans (integration)', () => {
+  it('marks only old generating plans failed with a shared timestamp', async () => {
+    const user = await createTestUser();
+    const thresholdMs = STUCK_PLAN_THRESHOLD_MS;
+    const stuckCutoff = new Date(Date.now() - thresholdMs - 60_000);
+    const recentCutoff = new Date(Date.now() - 60_000);
+
+    const stuckOne = await createTestPlan({
+      userId: user.id,
+      topic: 'Stuck one',
+      generationStatus: 'generating',
+      isQuotaEligible: true,
+    });
+    const stuckTwo = await createTestPlan({
+      userId: user.id,
+      topic: 'Stuck two',
+      generationStatus: 'generating',
+      isQuotaEligible: true,
+    });
+    const recentGenerating = await createTestPlan({
+      userId: user.id,
+      topic: 'Recent generating',
+      generationStatus: 'generating',
+      isQuotaEligible: false,
+    });
+    const oldReady = await createTestPlan({
+      userId: user.id,
+      topic: 'Old ready',
+      generationStatus: 'ready',
+      isQuotaEligible: true,
+    });
+    const oldFailed = await createTestPlan({
+      userId: user.id,
+      topic: 'Old failed',
+      generationStatus: 'failed',
+      isQuotaEligible: false,
+    });
+
+    await db
+      .update(learningPlans)
+      .set({ updatedAt: stuckCutoff })
+      .where(inArray(learningPlans.id, [stuckOne.id, stuckTwo.id]));
+
+    await db
+      .update(learningPlans)
+      .set({ updatedAt: recentCutoff })
+      .where(
+        inArray(learningPlans.id, [
+          recentGenerating.id,
+          oldReady.id,
+          oldFailed.id,
+        ]),
+      );
+
+    const result = await cleanupStuckPlans(db, thresholdMs);
+
+    expect(result.cleaned).toBe(2);
+
+    const rows = await db
+      .select({
+        id: learningPlans.id,
+        generationStatus: learningPlans.generationStatus,
+        isQuotaEligible: learningPlans.isQuotaEligible,
+        updatedAt: learningPlans.updatedAt,
+      })
+      .from(learningPlans)
+      .where(
+        inArray(learningPlans.id, [
+          stuckOne.id,
+          stuckTwo.id,
+          recentGenerating.id,
+          oldReady.id,
+          oldFailed.id,
+        ]),
+      );
+
+    const byId = new Map(rows.map((row) => [row.id, row]));
+
+    expect(byId.get(stuckOne.id)).toMatchObject({
+      generationStatus: 'failed',
+      isQuotaEligible: false,
+    });
+    expect(byId.get(stuckTwo.id)).toMatchObject({
+      generationStatus: 'failed',
+      isQuotaEligible: false,
+    });
+    expect(byId.get(stuckOne.id)?.updatedAt?.toISOString()).toBe(
+      byId.get(stuckTwo.id)?.updatedAt?.toISOString(),
+    );
+
+    expect(byId.get(recentGenerating.id)).toMatchObject({
+      generationStatus: 'generating',
+      isQuotaEligible: false,
+    });
+    expect(byId.get(oldReady.id)).toMatchObject({
+      generationStatus: 'ready',
+      isQuotaEligible: true,
+    });
+    expect(byId.get(oldFailed.id)).toMatchObject({
+      generationStatus: 'failed',
+      isQuotaEligible: false,
+    });
+  });
+
+  it('returns 0 when no stuck generating plans exist', async () => {
+    const user = await createTestUser();
+    const plan = await createTestPlan({
+      userId: user.id,
+      generationStatus: 'generating',
+    });
+
+    await db
+      .update(learningPlans)
+      .set({ updatedAt: new Date() })
+      .where(eq(learningPlans.id, plan.id));
+
+    const result = await cleanupStuckPlans(db);
+
+    expect(result.cleaned).toBe(0);
+
+    const [row] = await db
+      .select({ generationStatus: learningPlans.generationStatus })
+      .from(learningPlans)
+      .where(eq(learningPlans.id, plan.id));
+
+    expect(row?.generationStatus).toBe('generating');
+  });
+});

--- a/tests/integration/db/plan-cleanup.spec.ts
+++ b/tests/integration/db/plan-cleanup.spec.ts
@@ -1,8 +1,10 @@
 import {
+  cleanupOrphanedAttempts,
   cleanupStuckPlans,
+  ORPHANED_ATTEMPT_THRESHOLD_MS,
   STUCK_PLAN_THRESHOLD_MS,
 } from '@/features/plans/cleanup';
-import { learningPlans } from '@supabase/schema';
+import { generationAttempts, learningPlans } from '@supabase/schema';
 import { db } from '@supabase/service-role';
 import { createTestPlan } from '@tests/fixtures/plans';
 import { createTestUser } from '@tests/fixtures/users';
@@ -135,5 +137,108 @@ describe('cleanupStuckPlans (integration)', () => {
       .where(eq(learningPlans.id, plan.id));
 
     expect(row?.generationStatus).toBe('generating');
+  });
+});
+
+describe('cleanupOrphanedAttempts (integration)', () => {
+  it('finalizes stale in_progress attempts and leaves recent attempts untouched', async () => {
+    const user = await createTestUser();
+    const staleCutoff = new Date(
+      Date.now() - ORPHANED_ATTEMPT_THRESHOLD_MS - 60_000,
+    );
+    const recentCutoff = new Date(Date.now() - 60_000);
+
+    const stalePlan = await createTestPlan({
+      userId: user.id,
+      topic: 'Stale attempt plan',
+    });
+    const recentPlan = await createTestPlan({
+      userId: user.id,
+      topic: 'Recent attempt plan',
+    });
+
+    const [staleAttempt] = await db
+      .insert(generationAttempts)
+      .values({
+        planId: stalePlan.id,
+        status: 'in_progress',
+        classification: null,
+        durationMs: 0,
+        modulesCount: 0,
+        tasksCount: 0,
+      })
+      .returning();
+    const [recentAttempt] = await db
+      .insert(generationAttempts)
+      .values({
+        planId: recentPlan.id,
+        status: 'in_progress',
+        classification: null,
+        durationMs: 0,
+        modulesCount: 0,
+        tasksCount: 0,
+      })
+      .returning();
+
+    await db
+      .update(generationAttempts)
+      .set({ createdAt: staleCutoff })
+      .where(eq(generationAttempts.id, staleAttempt.id));
+    await db
+      .update(generationAttempts)
+      .set({ createdAt: recentCutoff })
+      .where(eq(generationAttempts.id, recentAttempt.id));
+
+    const result = await cleanupOrphanedAttempts(db);
+
+    expect(result.cleaned).toBe(1);
+
+    const rows = await db
+      .select({
+        id: generationAttempts.id,
+        status: generationAttempts.status,
+        classification: generationAttempts.classification,
+      })
+      .from(generationAttempts)
+      .where(
+        inArray(generationAttempts.id, [staleAttempt.id, recentAttempt.id]),
+      );
+
+    const byId = new Map(rows.map((row) => [row.id, row]));
+    expect(byId.get(staleAttempt.id)).toMatchObject({
+      status: 'failure',
+      classification: 'timeout',
+    });
+    expect(byId.get(recentAttempt.id)).toMatchObject({
+      status: 'in_progress',
+      classification: null,
+    });
+  });
+
+  it('returns 0 when no orphaned in_progress attempts exist', async () => {
+    const user = await createTestUser();
+    const plan = await createTestPlan({ userId: user.id });
+    const recentCutoff = new Date(Date.now() - 60_000);
+
+    const [attempt] = await db
+      .insert(generationAttempts)
+      .values({
+        planId: plan.id,
+        status: 'in_progress',
+        classification: null,
+        durationMs: 0,
+        modulesCount: 0,
+        tasksCount: 0,
+      })
+      .returning();
+
+    await db
+      .update(generationAttempts)
+      .set({ createdAt: recentCutoff })
+      .where(eq(generationAttempts.id, attempt.id));
+
+    const result = await cleanupOrphanedAttempts(db);
+
+    expect(result.cleaned).toBe(0);
   });
 });

--- a/tests/playwright/smoke/auth.launch-blockers.spec.ts
+++ b/tests/playwright/smoke/auth.launch-blockers.spec.ts
@@ -24,12 +24,10 @@ const STANDARD_NAVIGATION_TIMEOUT_MS = 15_000;
 const CHECKOUT_TIMEOUT_MS = 20_000;
 
 async function expectBillingPage(page: Page): Promise<void> {
-  await expectHeading(page, 'Settings');
-  await expect(page.getByRole('heading', { name: 'Billing' })).toBeVisible();
-  await expect(
-    page.getByRole('heading', { name: 'Current Plan' }),
-  ).toBeVisible();
-  await expect(page.getByRole('heading', { name: 'Usage' })).toBeVisible();
+  await expectHeading(page, 'Settings', 1);
+  await expectHeading(page, 'Billing', 2);
+  await expectHeading(page, 'Current Plan', 3);
+  await expectHeading(page, 'Usage', 3);
   await expect(page.getByText('Status')).toBeVisible();
   await expect(page.getByText('Next billing date')).toBeVisible();
   await expect(page.getByText(/^active$/i)).toBeVisible();

--- a/tests/playwright/smoke/auth.settings-headings.spec.ts
+++ b/tests/playwright/smoke/auth.settings-headings.spec.ts
@@ -1,0 +1,46 @@
+import { expect, expectHeading, test } from './fixtures';
+
+test.describe.configure({ mode: 'serial' });
+
+const SETTINGS_SUBPAGES = [
+  { path: '/settings/profile', h2: 'Profile' },
+  { path: '/settings/billing', h2: 'Billing' },
+  { path: '/settings/ai', h2: 'AI Preferences' },
+  { path: '/settings/integrations', h2: 'Integrations' },
+  { path: '/settings/notifications', h2: 'Notifications' },
+] as const;
+
+const BILLING_CONTENT_TIMEOUT_MS = 15_000;
+
+test('settings subpages expose consistent heading hierarchy', async ({
+  page,
+}) => {
+  for (const { path, h2 } of SETTINGS_SUBPAGES) {
+    await test.step(`${path} headings`, async () => {
+      await page.goto(path);
+      await expect(page).toHaveURL(new RegExp(`${path}$`));
+      await expectHeading(page, 'Settings', 1);
+      await expectHeading(page, h2, 2);
+
+      if (path === '/settings/billing') {
+        await expectHeading(
+          page,
+          'Current Plan',
+          3,
+          BILLING_CONTENT_TIMEOUT_MS,
+        );
+        await expectHeading(page, 'Usage', 3, BILLING_CONTENT_TIMEOUT_MS);
+      }
+
+      if (path === '/settings/ai') {
+        await expectHeading(
+          page,
+          'Model Selection',
+          3,
+          BILLING_CONTENT_TIMEOUT_MS,
+        );
+        await expectHeading(page, 'About AI Models', 3);
+      }
+    });
+  }
+});

--- a/tests/playwright/smoke/fixtures.ts
+++ b/tests/playwright/smoke/fixtures.ts
@@ -63,8 +63,14 @@ export function assertRedirectToSignIn(
 export async function expectHeading(
   page: Page,
   name: HeadingName,
+  level?: 1 | 2 | 3 | 4 | 5 | 6,
+  timeout?: number,
 ): Promise<void> {
-  await expect(page.getByRole('heading', { name })).toBeVisible();
+  const locator =
+    level === undefined
+      ? page.getByRole('heading', { name })
+      : page.getByRole('heading', { name, level });
+  await expect(locator).toBeVisible({ timeout });
 }
 
 export async function selectInlineDropdown(

--- a/tests/unit/architecture/import-boundaries.spec.ts
+++ b/tests/unit/architecture/import-boundaries.spec.ts
@@ -7,6 +7,7 @@ const REPO_ROOT = join(import.meta.dirname, '..', '..', '..');
 const SRC_ROOT = join(REPO_ROOT, 'src');
 const FEATURES_ROOT = join(SRC_ROOT, 'features');
 const APP_ROOT = join(SRC_ROOT, 'app');
+const PLANS_API_ROOT = join(APP_ROOT, 'api/v1/plans');
 
 const PLANS_QUERIES_MODULE = '@/lib/db/queries/plans';
 
@@ -250,6 +251,40 @@ describe('import boundaries (Slice B)', () => {
           }
         }
       }
+    }
+
+    expect(violations, violations.join('\n')).toEqual([]);
+  });
+
+  it('requires plans API route entrypoints to use requestBoundary.route', () => {
+    const violations: string[] = [];
+    const routeFiles = walkSourceFiles(PLANS_API_ROOT).filter((filePath) => {
+      const rel = relative(PLANS_API_ROOT, filePath).split('\\').join('/');
+      return rel.endsWith('/route.ts');
+    });
+
+    for (const filePath of routeFiles) {
+      const rel = relative(PLANS_API_ROOT, filePath).split('\\').join('/');
+      if (rel === 'plan-creation-failure.ts') {
+        continue;
+      }
+
+      const source = readFileSync(filePath, 'utf8');
+      if (source.includes('requestBoundary.route')) {
+        continue;
+      }
+
+      const handlerPath = join(filePath, '..', 'handler.ts');
+      if (existsSync(handlerPath)) {
+        const handlerSource = readFileSync(handlerPath, 'utf8');
+        if (handlerSource.includes('requestBoundary.route')) {
+          continue;
+        }
+      }
+
+      violations.push(
+        `${relative(REPO_ROOT, filePath)}: plans API route must wrap handlers with requestBoundary.route`,
+      );
     }
 
     expect(violations, violations.join('\n')).toEqual([]);

--- a/tests/unit/components/ui/card.spec.tsx
+++ b/tests/unit/components/ui/card.spec.tsx
@@ -1,0 +1,19 @@
+import { CardTitle } from '@/components/ui/card';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+describe('CardTitle', () => {
+  it('renders as a div by default', () => {
+    render(<CardTitle>Plan details</CardTitle>);
+    const title = screen.getByText('Plan details');
+    expect(title.tagName).toBe('DIV');
+    expect(title).toHaveAttribute('data-slot', 'card-title');
+  });
+
+  it('can render as a heading for nested section titles', () => {
+    render(<CardTitle as='h3'>Current Plan</CardTitle>);
+    expect(
+      screen.getByRole('heading', { name: 'Current Plan', level: 3 }),
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/unit/config/env.spec.ts
+++ b/tests/unit/config/env.spec.ts
@@ -603,6 +603,28 @@ describe('Environment Configuration', () => {
       expect(maintenance.retentionCleanupEnabled).toBe(true);
       expect(() => maintenance.workerToken).toThrow(EnvValidationError);
     });
+
+    it('does not require a worker token when plan cleanup is disabled in production', () => {
+      vi.stubGlobal('window', undefined);
+      const maintenance = createMaintenanceEnvForTests({
+        NODE_ENV: 'production',
+        PLAN_CLEANUP_ENABLED: 'false',
+      });
+
+      expect(maintenance.planCleanupEnabled).toBe(false);
+      expect(maintenance.workerToken).toBeUndefined();
+    });
+
+    it('requires a worker token when manual plan cleanup is enabled in production', () => {
+      vi.stubGlobal('window', undefined);
+      const maintenance = createMaintenanceEnvForTests({
+        NODE_ENV: 'production',
+        PLAN_CLEANUP_ENABLED: 'true',
+      });
+
+      expect(maintenance.planCleanupEnabled).toBe(true);
+      expect(() => maintenance.workerToken).toThrow(EnvValidationError);
+    });
   });
 
   describe('parseEnvNumber', () => {

--- a/tests/unit/features/plans/cleanup.spec.ts
+++ b/tests/unit/features/plans/cleanup.spec.ts
@@ -6,6 +6,7 @@ import {
   ORPHANED_ATTEMPT_THRESHOLD_MS,
   STUCK_PLAN_THRESHOLD_MS,
 } from '@/features/plans/cleanup';
+import { logger } from '@/lib/logging/logger';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock the logger to avoid console noise and allow assertion
@@ -68,43 +69,53 @@ describe('cleanupStuckPlans', () => {
     vi.clearAllMocks();
   });
 
-  it('marks stuck generating plans as failed and returns count', async () => {
+  it('marks stuck generating plans as failed with one bulk update', async () => {
     mockDb = createMockDbClient(3);
-    const markFailure = vi.fn().mockResolvedValue(undefined);
+    const markFailuresInTx = vi.fn().mockResolvedValue(3);
+    markFailuresInTx.mockImplementation(
+      (_tx, planIds: string[], timestamp: Date) => {
+        expect(planIds).toEqual(['id-0', 'id-1', 'id-2']);
+        expect(timestamp).toBeInstanceOf(Date);
+        return Promise.resolve(planIds.length);
+      },
+    );
 
     const result = await cleanupStuckPlans(mockDb.client, undefined, {
-      markFailure,
+      markFailuresInTx,
     });
 
     expect(result.cleaned).toBe(3);
     expect(mockDb.spies.transactionFn).toHaveBeenCalledTimes(1);
-    expect(markFailure).toHaveBeenCalledTimes(3);
-    expect(markFailure).toHaveBeenNthCalledWith(
-      1,
-      'id-0',
+    expect(markFailuresInTx).toHaveBeenCalledTimes(1);
+    expect(markFailuresInTx).toHaveBeenCalledWith(
       mockDb.client,
-      expect.any(Function),
+      ['id-0', 'id-1', 'id-2'],
+      expect.any(Date),
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'cleanup',
+        event: 'stuck_plans_cleaned',
+        count: 3,
+      }),
+      expect.stringContaining('3'),
     );
 
-    const firstClock = markFailure.mock.calls[0]?.[2] as
-      | (() => Date)
-      | undefined;
-    const secondClock = markFailure.mock.calls[1]?.[2] as
-      | (() => Date)
-      | undefined;
-
-    expect(firstClock).toBeDefined();
-    expect(secondClock).toBeDefined();
-    expect(firstClock?.()).toBeInstanceOf(Date);
-    expect(secondClock?.()).toBe(firstClock?.());
+    const timestampArg = markFailuresInTx.mock.calls[0]?.[2] as Date;
+    expect(timestampArg).toBeInstanceOf(Date);
   });
 
-  it('returns 0 when no stuck plans exist', async () => {
+  it('returns 0 and skips bulk update when no stuck plans exist', async () => {
     mockDb = createMockDbClient(0);
+    const markFailuresInTx = vi.fn();
 
-    const result = await cleanupStuckPlans(mockDb.client);
+    const result = await cleanupStuckPlans(mockDb.client, undefined, {
+      markFailuresInTx,
+    });
 
     expect(result.cleaned).toBe(0);
+    expect(markFailuresInTx).not.toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalled();
   });
 
   it('has a reasonable stuck plan threshold', () => {
@@ -116,11 +127,19 @@ describe('cleanupStuckPlans', () => {
 
   it('accepts a custom threshold', async () => {
     mockDb = createMockDbClient(1);
+    const markFailuresInTx = vi.fn().mockResolvedValue(1);
     const customThreshold = 5 * 60 * 1000; // 5 minutes
 
-    const result = await cleanupStuckPlans(mockDb.client, customThreshold);
+    const result = await cleanupStuckPlans(mockDb.client, customThreshold, {
+      markFailuresInTx,
+    });
 
     expect(result.cleaned).toBe(1);
+    expect(markFailuresInTx).toHaveBeenCalledWith(
+      mockDb.client,
+      ['id-0'],
+      expect.any(Date),
+    );
   });
 });
 

--- a/tests/unit/features/plans/cleanup.spec.ts
+++ b/tests/unit/features/plans/cleanup.spec.ts
@@ -4,6 +4,7 @@ import {
   cleanupOrphanedAttempts,
   cleanupStuckPlans,
   ORPHANED_ATTEMPT_THRESHOLD_MS,
+  STUCK_PLAN_CLEANUP_BATCH_SIZE,
   STUCK_PLAN_THRESHOLD_MS,
 } from '@/features/plans/cleanup';
 import { logger } from '@/lib/logging/logger';
@@ -23,8 +24,11 @@ function createMockDbClient(resultCount: number) {
   const rows = Array.from({ length: resultCount }, (_, i) => ({
     id: `id-${i}`,
   }));
-  const forFn = vi.fn().mockResolvedValue(rows);
-  const limitFn = vi.fn().mockReturnValue({ for: forFn });
+  const forFn = vi.fn();
+  const limitFn = vi.fn().mockImplementation((limit: number) => {
+    forFn.mockResolvedValue(rows.slice(0, limit));
+    return { for: forFn };
+  });
   const whereSelectFn = vi.fn().mockReturnValue({ limit: limitFn });
   const transactionFn = vi.fn();
   const fromFn = vi.fn().mockReturnValue({ where: whereSelectFn });
@@ -86,6 +90,9 @@ describe('cleanupStuckPlans', () => {
 
     expect(result.cleaned).toBe(3);
     expect(mockDb.spies.transactionFn).toHaveBeenCalledTimes(1);
+    expect(mockDb.spies.limitFn).toHaveBeenCalledWith(
+      STUCK_PLAN_CLEANUP_BATCH_SIZE,
+    );
     expect(markFailuresInTx).toHaveBeenCalledTimes(1);
     expect(markFailuresInTx).toHaveBeenCalledWith(
       mockDb.client,
@@ -139,6 +146,32 @@ describe('cleanupStuckPlans', () => {
       mockDb.client,
       ['id-0'],
       expect.any(Date),
+    );
+  });
+
+  it('processes only one bounded batch per run', async () => {
+    mockDb = createMockDbClient(5);
+    const markFailuresInTx = vi.fn().mockResolvedValue(2);
+
+    const result = await cleanupStuckPlans(mockDb.client, undefined, {
+      markFailuresInTx,
+      batchSize: 2,
+    });
+
+    expect(result.cleaned).toBe(2);
+    expect(mockDb.spies.limitFn).toHaveBeenCalledWith(2);
+    expect(markFailuresInTx).toHaveBeenCalledWith(
+      mockDb.client,
+      ['id-0', 'id-1'],
+      expect.any(Date),
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      {
+        source: 'cleanup',
+        event: 'stuck_plans_cleanup_batch_full',
+        batchSize: 2,
+      },
+      'Plan cleanup filled its stuck-plan batch; backlog may remain',
     );
   });
 

--- a/tests/unit/features/plans/cleanup.spec.ts
+++ b/tests/unit/features/plans/cleanup.spec.ts
@@ -141,6 +141,28 @@ describe('cleanupStuckPlans', () => {
       expect.any(Date),
     );
   });
+
+  it('throws when markFailuresInTx updates fewer rows than locked plans', async () => {
+    mockDb = createMockDbClient(3);
+    const markFailuresInTx = vi.fn().mockResolvedValue(2);
+
+    await expect(
+      cleanupStuckPlans(mockDb.client, undefined, { markFailuresInTx }),
+    ).rejects.toThrow(
+      'Plan cleanup failed to mark all locked stuck plans as failed',
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'cleanup',
+        event: 'stuck_plans_cleanup_partial_failure',
+        expected: 3,
+        cleaned: 2,
+      }),
+      'Plan cleanup failed to mark all locked stuck plans as failed',
+    );
+    expect(logger.info).not.toHaveBeenCalled();
+  });
 });
 
 describe('cleanupOrphanedAttempts', () => {

--- a/tests/unit/features/plans/status-polling/plan-status-machine.spec.ts
+++ b/tests/unit/features/plans/status-polling/plan-status-machine.spec.ts
@@ -1,0 +1,266 @@
+import {
+  createInitialPlanPollState,
+  MAX_CONSECUTIVE_FAILURES,
+  transitionPlanPollState,
+  type PlanPollState,
+} from '@/features/plans/status-polling/plan-status-machine';
+import { INITIAL_POLL_MS } from '@/shared/constants/polling';
+import { describe, expect, it } from 'vitest';
+
+const deterministicRandom = () => 0.5;
+
+function pendingState(overrides: Partial<PlanPollState> = {}): PlanPollState {
+  return {
+    ...createInitialPlanPollState('plan-1', 'pending'),
+    ...overrides,
+  };
+}
+
+describe('plan-status-machine', () => {
+  describe('createInitialPlanPollState', () => {
+    it.each([
+      ['pending', 'polling'],
+      ['processing', 'polling'],
+      ['ready', 'terminal'],
+      ['failed', 'terminal'],
+    ] as const)('initializes %s as %s phase', (status, phase) => {
+      const state = createInitialPlanPollState('plan-1', status);
+      expect(state.phase).toBe(phase);
+      expect(state.status).toBe(status);
+      expect(state.attempts).toBe(0);
+      expect(state.error).toBeNull();
+      expect(state.pollingError).toBeNull();
+      expect(state.consecutiveFailures).toBe(0);
+      expect(state.delayMs).toBe(INITIAL_POLL_MS);
+    });
+  });
+
+  describe('response', () => {
+    it('updates status fields and clears consecutive failures while polling', () => {
+      const state = pendingState({ consecutiveFailures: 2, delayMs: 2000 });
+      const next = transitionPlanPollState(
+        state,
+        {
+          type: 'response',
+          status: 'processing',
+          attempts: 3,
+          error: null,
+          backoffMode: 'scheduled',
+        },
+        deterministicRandom,
+      );
+
+      expect(next.status).toBe('processing');
+      expect(next.attempts).toBe(3);
+      expect(next.error).toBeNull();
+      expect(next.consecutiveFailures).toBe(0);
+      expect(next.phase).toBe('polling');
+    });
+
+    it('transitions to terminal phase for ready status', () => {
+      const next = transitionPlanPollState(
+        pendingState(),
+        {
+          type: 'response',
+          status: 'ready',
+          attempts: 5,
+          error: null,
+          backoffMode: 'scheduled',
+        },
+        deterministicRandom,
+      );
+
+      expect(next.phase).toBe('terminal');
+      expect(next.status).toBe('ready');
+      expect(next.attempts).toBe(5);
+    });
+
+    it('transitions to terminal phase for failed status with error', () => {
+      const next = transitionPlanPollState(
+        pendingState(),
+        {
+          type: 'response',
+          status: 'failed',
+          attempts: 2,
+          error: 'AI provider error',
+          backoffMode: 'scheduled',
+        },
+        deterministicRandom,
+      );
+
+      expect(next.phase).toBe('terminal');
+      expect(next.status).toBe('failed');
+      expect(next.error).toBe('AI provider error');
+    });
+
+    it('resets delay on scheduled poll when status transitions', () => {
+      const state = pendingState({ delayMs: 3375 });
+      const next = transitionPlanPollState(
+        state,
+        {
+          type: 'response',
+          status: 'processing',
+          attempts: 1,
+          error: null,
+          backoffMode: 'scheduled',
+        },
+        deterministicRandom,
+      );
+
+      expect(next.delayMs).toBe(INITIAL_POLL_MS);
+    });
+
+    it('applies backoff on scheduled poll when status is unchanged', () => {
+      const state = pendingState({ delayMs: INITIAL_POLL_MS });
+      const next = transitionPlanPollState(
+        state,
+        {
+          type: 'response',
+          status: 'pending',
+          attempts: 1,
+          error: null,
+          backoffMode: 'scheduled',
+        },
+        deterministicRandom,
+      );
+
+      expect(next.delayMs).toBe(1500);
+    });
+
+    it('always applies backoff on immediate poll regardless of status transition', () => {
+      const state = pendingState({ delayMs: INITIAL_POLL_MS });
+      const next = transitionPlanPollState(
+        state,
+        {
+          type: 'response',
+          status: 'processing',
+          attempts: 1,
+          error: null,
+          backoffMode: 'immediate',
+        },
+        deterministicRandom,
+      );
+
+      expect(next.delayMs).toBe(1500);
+    });
+  });
+
+  describe('transient_failure', () => {
+    it('increments consecutive failures and applies backoff while polling', () => {
+      const state = pendingState({ consecutiveFailures: 0, delayMs: 1000 });
+      const next = transitionPlanPollState(
+        state,
+        { type: 'transient_failure', message: 'Unavailable' },
+        deterministicRandom,
+      );
+
+      expect(next.consecutiveFailures).toBe(1);
+      expect(next.phase).toBe('polling');
+      expect(next.pollingError).toBeNull();
+      expect(next.delayMs).toBe(1500);
+    });
+
+    it('stops polling after max consecutive failures', () => {
+      const state = pendingState({
+        consecutiveFailures: MAX_CONSECUTIVE_FAILURES - 1,
+      });
+      const next = transitionPlanPollState(
+        state,
+        { type: 'transient_failure', message: 'Service unavailable' },
+        deterministicRandom,
+      );
+
+      expect(next.consecutiveFailures).toBe(MAX_CONSECUTIVE_FAILURES);
+      expect(next.phase).toBe('stopped');
+      expect(next.pollingError).toBe('Service unavailable');
+    });
+
+    it('is a no-op in terminal phase', () => {
+      const state = createInitialPlanPollState('plan-1', 'ready');
+      const next = transitionPlanPollState(
+        state,
+        { type: 'transient_failure', message: 'Unavailable' },
+        deterministicRandom,
+      );
+
+      expect(next).toEqual(state);
+    });
+  });
+
+  describe('fatal_failure', () => {
+    it('stops polling immediately with pollingError', () => {
+      const next = transitionPlanPollState(pendingState(), {
+        type: 'fatal_failure',
+        message: 'Plan not found',
+      });
+
+      expect(next.phase).toBe('stopped');
+      expect(next.pollingError).toBe('Plan not found');
+    });
+  });
+
+  describe('revalidate', () => {
+    it('clears errors and resumes polling from stopped phase', () => {
+      const state = pendingState({
+        phase: 'stopped',
+        pollingError: 'Bad request',
+        consecutiveFailures: 3,
+        delayMs: 5000,
+      });
+      const next = transitionPlanPollState(state, { type: 'revalidate' });
+
+      expect(next.phase).toBe('polling');
+      expect(next.pollingError).toBeNull();
+      expect(next.consecutiveFailures).toBe(0);
+      expect(next.delayMs).toBe(INITIAL_POLL_MS);
+    });
+
+    it('is a no-op in terminal phase', () => {
+      const state = createInitialPlanPollState('plan-1', 'ready');
+      const next = transitionPlanPollState(state, { type: 'revalidate' });
+
+      expect(next).toEqual(state);
+    });
+
+    it('resets backoff while already polling', () => {
+      const state = pendingState({ delayMs: 5000, consecutiveFailures: 1 });
+      const next = transitionPlanPollState(state, { type: 'revalidate' });
+
+      expect(next.phase).toBe('polling');
+      expect(next.consecutiveFailures).toBe(0);
+      expect(next.delayMs).toBe(INITIAL_POLL_MS);
+    });
+  });
+
+  describe('plan_changed', () => {
+    it('fully resets state for the new plan', () => {
+      const state = pendingState({
+        status: 'processing',
+        attempts: 4,
+        error: 'transient',
+        pollingError: 'old error',
+        consecutiveFailures: 2,
+        delayMs: 8000,
+      });
+      const next = transitionPlanPollState(state, {
+        type: 'plan_changed',
+        planId: 'plan-2',
+        initialStatus: 'pending',
+      });
+
+      expect(next).toEqual(createInitialPlanPollState('plan-2', 'pending'));
+    });
+
+    it('initializes terminal phase when new plan is ready', () => {
+      const next = transitionPlanPollState(pendingState(), {
+        type: 'plan_changed',
+        planId: 'plan-2',
+        initialStatus: 'ready',
+      });
+
+      expect(next.phase).toBe('terminal');
+      expect(next.planId).toBe('plan-2');
+      expect(next.status).toBe('ready');
+    });
+  });
+});

--- a/tests/unit/features/plans/status-polling/plan-status-poller.spec.ts
+++ b/tests/unit/features/plans/status-polling/plan-status-poller.spec.ts
@@ -1,0 +1,50 @@
+import { PlanStatusPoller } from '@/features/plans/status-polling/plan-status-poller';
+import {
+  createMockFetchResponse,
+  createPlanStatusResponse,
+} from '@tests/fixtures/plan-status';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('PlanStatusPoller', () => {
+  it('does not apply a late fetch response after disposal', async () => {
+    type MockFetchResponse = ReturnType<typeof createMockFetchResponse>;
+
+    let resolveFetch!: (response: MockFetchResponse) => void;
+    let fetchSignal: AbortSignal | null = null;
+    const pendingFetch = new Promise<MockFetchResponse>((resolve) => {
+      resolveFetch = resolve;
+    });
+    const fetcher = vi.fn((_url: string, init?: { signal?: AbortSignal }) => {
+      fetchSignal = init?.signal ?? null;
+      return pendingFetch;
+    });
+
+    const poller = new PlanStatusPoller({
+      planId: 'plan-123',
+      initialStatus: 'pending',
+      fetcher: fetcher as unknown as typeof fetch,
+    });
+    const listener = vi.fn();
+    poller.subscribe(listener);
+
+    const initialSnapshot = poller.getSnapshot();
+    poller.start();
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    poller.dispose();
+    expect(fetchSignal).not.toBeNull();
+    expect(fetchSignal!.aborted).toBe(true);
+
+    resolveFetch(
+      createMockFetchResponse(
+        createPlanStatusResponse({ status: 'ready', attempts: 7 }),
+      ),
+    );
+    await pendingFetch;
+    await Promise.resolve();
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(poller.getSnapshot()).toEqual(initialSnapshot);
+  });
+});

--- a/tests/unit/hooks/usePlanStatus.spec.tsx
+++ b/tests/unit/hooks/usePlanStatus.spec.tsx
@@ -20,6 +20,16 @@ const FIRST_BACKOFF = 1500; // computeNextDelay(1000) = 1000 * 1.5
 const SECOND_BACKOFF = 2250; // computeNextDelay(1500) = 1500 * 1.5
 const THIRD_BACKOFF = 3375; // computeNextDelay(2250) = 2250 * 1.5
 
+function expectStatusFetch(
+  mockFetch: ReturnType<typeof vi.fn>,
+  planId: string,
+): void {
+  expect(mockFetch).toHaveBeenCalledWith(
+    `/api/v1/plans/${planId}/status`,
+    expect.objectContaining({ signal: expect.any(AbortSignal) }),
+  );
+}
+
 describe('usePlanStatus', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -66,7 +76,7 @@ describe('usePlanStatus', () => {
 
     // Wait for the immediate fetch call
     await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith('/api/v1/plans/plan-123/status');
+      expectStatusFetch(mockFetch, 'plan-123');
     });
   });
 
@@ -576,7 +586,7 @@ describe('usePlanStatus', () => {
       expect(result.current.pollingError).toBeNull();
     });
 
-    expect(mockFetch).toHaveBeenCalledWith('/api/v1/plans/plan-b/status');
+    expectStatusFetch(mockFetch, 'plan-b');
   });
 
   it('does not reset live polled state when initialStatus changes for the same planId', async () => {
@@ -680,7 +690,7 @@ describe('usePlanStatus', () => {
     expect(result.current.isPolling).toBe(false);
   });
 
-  it('resets state synchronously on planId change without a stale frame', async () => {
+  it('resets state on planId change without a stale frame', async () => {
     const mockFetch = vi
       .fn()
       .mockResolvedValueOnce(
@@ -710,10 +720,12 @@ describe('usePlanStatus', () => {
 
     rerender({ id: 'plan-b', initial: 'pending' });
 
-    expect(result.current.status).toBe('pending');
-    expect(result.current.attempts).toBe(0);
-    expect(result.current.error).toBeNull();
-    expect(result.current.pollingError).toBeNull();
+    await waitFor(() => {
+      expect(result.current.status).toBe('pending');
+      expect(result.current.attempts).toBe(0);
+      expect(result.current.error).toBeNull();
+      expect(result.current.pollingError).toBeNull();
+    });
   });
 
   it('does not revalidate when plan is in a terminal status', async () => {
@@ -776,6 +788,52 @@ describe('usePlanStatus', () => {
       await vi.advanceTimersByTimeAsync(FIRST_BACKOFF);
     });
     expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(vi.getTimerCount()).toBe(1);
+  });
+
+  it('reuses an in-flight scheduled fetch when revalidating', async () => {
+    vi.useFakeTimers();
+
+    type MockFetchResponse = ReturnType<typeof createMockFetchResponse>;
+    let resolveScheduledFetch!: (response: MockFetchResponse) => void;
+    const scheduledFetch = new Promise<MockFetchResponse>((resolve) => {
+      resolveScheduledFetch = resolve;
+    });
+    const response = createMockFetchResponse(
+      createPlanStatusResponse({ status: 'processing', attempts: 1 }),
+    );
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(response)
+      .mockReturnValueOnce(scheduledFetch)
+      .mockResolvedValue(response);
+
+    const { result } = renderHook(() =>
+      usePlanStatus('plan-123', 'pending', mockFetch),
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(FIRST_BACKOFF);
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(1);
+
+    let revalidatePromise!: Promise<void>;
+    await act(async () => {
+      revalidatePromise = result.current.revalidate();
+      await Promise.resolve();
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      resolveScheduledFetch(response);
+      await revalidatePromise;
+    });
+
     expect(vi.getTimerCount()).toBe(1);
   });
 

--- a/tests/unit/hooks/usePlanStatus.spec.tsx
+++ b/tests/unit/hooks/usePlanStatus.spec.tsx
@@ -680,6 +680,71 @@ describe('usePlanStatus', () => {
     expect(result.current.isPolling).toBe(false);
   });
 
+  it('resets state synchronously on planId change without a stale frame', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        createMockFetchResponse(
+          createPlanStatusResponse({
+            status: 'processing',
+            attempts: 2,
+            latestError: 'transient',
+          }),
+        ),
+      )
+      .mockResolvedValue(
+        createMockFetchResponse(
+          createPlanStatusResponse({ status: 'pending', attempts: 0 }),
+        ),
+      );
+
+    const { result, rerender } = renderHook(
+      ({ id, initial }: { id: string; initial: PlanStatus }) =>
+        usePlanStatus(id, initial, mockFetch),
+      { initialProps: { id: 'plan-a', initial: 'pending' as PlanStatus } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('processing');
+    });
+
+    rerender({ id: 'plan-b', initial: 'pending' });
+
+    expect(result.current.status).toBe('pending');
+    expect(result.current.attempts).toBe(0);
+    expect(result.current.error).toBeNull();
+    expect(result.current.pollingError).toBeNull();
+  });
+
+  it('does not revalidate when plan is in a terminal status', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(
+        createMockFetchResponse(
+          createPlanStatusResponse({ status: 'ready', attempts: 3 }),
+        ),
+      );
+
+    const { result } = renderHook(() =>
+      usePlanStatus('plan-123', 'pending', mockFetch),
+    );
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('ready');
+      expect(result.current.isPolling).toBe(false);
+    });
+
+    const callsBeforeRevalidate = mockFetch.mock.calls.length;
+
+    await act(async () => {
+      await result.current.revalidate();
+    });
+
+    expect(mockFetch.mock.calls.length).toBe(callsBeforeRevalidate);
+    expect(result.current.status).toBe('ready');
+    expect(result.current.isPolling).toBe(false);
+  });
+
   it('revalidate while polling is active clears errors and resumes polling', async () => {
     vi.useFakeTimers();
 

--- a/tests/unit/hooks/usePlanStatus.spec.tsx
+++ b/tests/unit/hooks/usePlanStatus.spec.tsx
@@ -1,3 +1,5 @@
+import type { PlanStatus } from '@/shared/types/client.types';
+
 import {
   createMockFetchResponse,
   createPlanStatusResponse,
@@ -533,6 +535,201 @@ describe('usePlanStatus', () => {
       await vi.advanceTimersByTimeAsync(INITIAL_POLL_MS);
     });
     expect(mockFetch).toHaveBeenCalledTimes(5);
+  });
+
+  it('resets state when planId changes', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        createMockFetchResponse(
+          createPlanStatusResponse({
+            status: 'processing',
+            attempts: 2,
+            latestError: 'transient',
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        createMockFetchResponse(
+          createPlanStatusResponse({ status: 'pending', attempts: 0 }),
+        ),
+      );
+
+    const { result, rerender } = renderHook(
+      ({ id, initial }: { id: string; initial: PlanStatus }) =>
+        usePlanStatus(id, initial, mockFetch),
+      { initialProps: { id: 'plan-a', initial: 'pending' as PlanStatus } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('processing');
+      expect(result.current.attempts).toBe(2);
+      expect(result.current.error).toBe('transient');
+    });
+
+    rerender({ id: 'plan-b', initial: 'pending' });
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('pending');
+      expect(result.current.attempts).toBe(0);
+      expect(result.current.error).toBeNull();
+      expect(result.current.pollingError).toBeNull();
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/v1/plans/plan-b/status');
+  });
+
+  it('does not reset live polled state when initialStatus changes for the same planId', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(
+        createMockFetchResponse(
+          createPlanStatusResponse({ status: 'processing', attempts: 4 }),
+        ),
+      );
+
+    const { result, rerender } = renderHook(
+      ({ initial }: { initial: PlanStatus }) =>
+        usePlanStatus('plan-123', initial, mockFetch),
+      { initialProps: { initial: 'pending' as PlanStatus } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('processing');
+      expect(result.current.attempts).toBe(4);
+    });
+
+    rerender({ initial: 'ready' });
+
+    expect(result.current.status).toBe('processing');
+    expect(result.current.attempts).toBe(4);
+  });
+
+  it('stops polling with a generic message when response validation fails', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        status: 'not-a-valid-status',
+        attempts: 1,
+        latestError: null,
+      }),
+    });
+
+    const { result } = renderHook(() =>
+      usePlanStatus('plan-123', 'pending', mockFetch),
+    );
+
+    await waitFor(() => {
+      expect(result.current.pollingError).toBe(
+        'Received invalid plan status response from server.',
+      );
+      expect(result.current.isPolling).toBe(false);
+    });
+
+    expect(clientLogger.error).toHaveBeenCalled();
+  });
+
+  it('stops polling on non-retriable 404 responses', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ error: 'Plan not found', code: 'NOT_FOUND' }),
+    });
+
+    const { result } = renderHook(() =>
+      usePlanStatus('plan-123', 'pending', mockFetch),
+    );
+
+    await waitFor(() => {
+      expect(result.current.pollingError).toBe('Plan not found');
+      expect(result.current.isPolling).toBe(false);
+    });
+
+    expect(clientLogger.error).toHaveBeenCalled();
+  });
+
+  it('keeps isPolling true during retriable failures until max failures', async () => {
+    vi.useFakeTimers();
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ error: 'Unavailable' }),
+    });
+
+    const { result } = renderHook(() =>
+      usePlanStatus('plan-123', 'pending', mockFetch),
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.isPolling).toBe(true);
+    expect(result.current.pollingError).toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(FIRST_BACKOFF);
+    });
+    expect(result.current.isPolling).toBe(true);
+    expect(result.current.pollingError).toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SECOND_BACKOFF);
+    });
+    expect(result.current.pollingError).toBe('Unavailable');
+    expect(result.current.isPolling).toBe(false);
+  });
+
+  it('revalidate while polling is active clears errors and resumes polling', async () => {
+    vi.useFakeTimers();
+
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: async () => ({ error: 'Unavailable' }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: async () => ({ error: 'Unavailable' }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: async () => ({ error: 'Unavailable' }),
+      })
+      .mockResolvedValue(
+        createMockFetchResponse(
+          createPlanStatusResponse({ status: 'processing', attempts: 1 }),
+        ),
+      );
+
+    const { result } = renderHook(() =>
+      usePlanStatus('plan-123', 'pending', mockFetch),
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(FIRST_BACKOFF);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SECOND_BACKOFF);
+    });
+
+    expect(result.current.pollingError).toBe('Unavailable');
+    expect(result.current.isPolling).toBe(false);
+
+    await act(async () => {
+      await result.current.revalidate();
+    });
+
+    expect(result.current.pollingError).toBeNull();
+    expect(result.current.status).toBe('processing');
+    expect(result.current.isPolling).toBe(true);
   });
 });
 

--- a/tests/unit/hooks/usePlanStatus.spec.tsx
+++ b/tests/unit/hooks/usePlanStatus.spec.tsx
@@ -745,6 +745,40 @@ describe('usePlanStatus', () => {
     expect(result.current.isPolling).toBe(false);
   });
 
+  it('does not keep the previous scheduled poll after revalidating while polling', async () => {
+    vi.useFakeTimers();
+
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(
+        createMockFetchResponse(
+          createPlanStatusResponse({ status: 'processing', attempts: 1 }),
+        ),
+      );
+
+    const { result } = renderHook(() =>
+      usePlanStatus('plan-123', 'pending', mockFetch),
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(1);
+
+    await act(async () => {
+      await result.current.revalidate();
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(FIRST_BACKOFF);
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(vi.getTimerCount()).toBe(1);
+  });
+
   it('revalidate while polling is active clears errors and resumes polling', async () => {
     vi.useFakeTimers();
 

--- a/tests/unit/lib/db/queries/module-lesson-generation.bulk-write.spec.ts
+++ b/tests/unit/lib/db/queries/module-lesson-generation.bulk-write.spec.ts
@@ -1,0 +1,69 @@
+import type { DbClient } from '@/lib/db/types';
+
+import { commitModuleLessonBatchSuccess } from '@/lib/db/queries/module-lesson-generation';
+import { SERVICE_ROLE_DB_MARKER } from '@supabase/service-role';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('commitModuleLessonBatchSuccess bulk task writes', () => {
+  it('issues one bulk UPDATE for all task lessons inside the transaction', async () => {
+    const taskIds = ['task-1', 'task-2', 'task-3', 'task-4', 'task-5'];
+    const tx = {
+      execute: vi.fn(async () => taskIds.map((id) => ({ id }))),
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockResolvedValue(taskIds.map((id) => ({ id }))),
+          }),
+        }),
+      }),
+      update: vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ id: 'module-1' }]),
+          }),
+        }),
+      }),
+      insert: vi.fn().mockReturnValue({
+        values: vi.fn().mockResolvedValue(undefined),
+      }),
+    };
+
+    const dbClient = {
+      [SERVICE_ROLE_DB_MARKER]: true,
+      execute: vi.fn().mockResolvedValue([]),
+      transaction: vi.fn(async (callback: (innerTx: typeof tx) => unknown) =>
+        callback(tx),
+      ),
+    } as unknown as DbClient;
+
+    await commitModuleLessonBatchSuccess(dbClient, {
+      userId: 'user-1',
+      planId: 'plan-1',
+      moduleId: 'module-1',
+      parsed: {
+        version: 1,
+        tasks: taskIds.map((taskId) => ({
+          taskId,
+          content: {
+            version: 1 as const,
+            blocks: [{ type: 'heading' as const, text: taskId }],
+          },
+        })),
+      },
+      metadata: { version: 1 },
+      usage: {
+        provider: 'mock',
+        model: 'mock-module-lesson-batch-v1',
+        inputTokens: 1,
+        outputTokens: 1,
+        totalTokens: 2,
+        estimatedCostCents: 0,
+        providerCostMicrousd: null,
+        isPartial: false,
+        missingFields: [],
+      },
+    });
+
+    expect(tx.execute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/lib/proxy-middleware-policy.spec.ts
+++ b/tests/unit/lib/proxy-middleware-policy.spec.ts
@@ -15,6 +15,7 @@ describe('middleware policy', () => {
     '/api/internal/',
     '/api/internal/jobs/regeneration/process',
     '/api/internal/maintenance/retention/cleanup',
+    '/api/internal/maintenance/plans/cleanup',
     '/api/internal/extra-segment',
   ])('isProtectedRoute skips internal worker prefix %s', (pathname) => {
     expect(isProtectedRoute(pathname)).toBe(false);


### PR DESCRIPTION
## Summary
- Wire plan cleanup maintenance route with hardened bulk-failure handling, shared internal-worker access, and operational runbook/docs
- Refactor `usePlanStatus` into a pure state machine + poller store (unchanged public API), including duplicate-timer fix on revalidate while polling
- Restore settings heading hierarchy and `CardTitle` semantics to fix billing smoke test assertions
- Add regression/integration coverage for cleanup routes, batched writes, route boundaries, and polling behavior

## Commits
- `fix(plans): resolve Needs Attention backlog (cleanup, polling, batch writes)`
- `refactor(plans): drop redundant memoization in plan UI`
- `fix(plans): wire plan cleanup maintenance route`
- `fix(settings): restore heading hierarchy for billing smoke`
- `fix(plans): harden plan cleanup maintenance`
- `refactor(plans): extract plan status polling state machine`
- `fix(plans): clear scheduled poll before revalidate`

## Test plan
- [x] `pnpm exec tsx scripts/tests/run.ts unit tests/unit/features/plans/status-polling/plan-status-machine.spec.ts tests/unit/hooks/usePlanStatus.spec.tsx tests/unit/app/plans/components/PlanPendingState.spec.tsx`
- [x] `pnpm exec tsx scripts/tests/run.ts integration tests/integration/hooks/light/usePlanStatus.test.tsx`
- [x] `npx -y react-doctor@latest . --verbose --diff`
- [x] Pre-push `pnpm check:full` passed
- [ ] CI green on PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production maintenance auth/scheduling and service-role cleanup that marks plans failed; polling refactor is broad but heavily tested. Misconfigured `MAINTENANCE_WORKER_TOKEN` or enabled flags could block or mishandle recovery until ops fix scheduler/Vercel env.
> 
> **Overview**
> Adds **scheduled plan maintenance** for stuck `generating` plans and orphaned generation attempts: internal `POST /api/internal/maintenance/plans/cleanup`, `PLAN_CLEANUP_ENABLED`, bulk failure marking with batch limits and partial-failure errors, plus a **GitHub Actions** job every 15 minutes (Sentry cron monitor). Retention cleanup now shares **`assertMaintenanceWorkerAccess`** and maintenance env treats plan + retention routes together for the worker token.
> 
> **Plan status polling** moves out of `usePlanStatus` into a pure **`plan-status-machine`** and **`PlanStatusPoller`** (same hook API), with fetch timeouts, clearer retry/fatal handling, and a fix so **revalidate** clears duplicate scheduled polls while polling.
> 
> **Data path:** module lesson commits use one bulk SQL `UPDATE` for all task rows; stuck-plan cleanup uses **`markPlanGenerationFailuresInTx`** in one shot per batch.
> 
> **UI/a11y:** settings get a layout **`h1`**, subpages **`h2`**, and **`CardTitle as='h3'`**; Playwright heading checks updated. Minor plan UI cleanup (shared **`logTaskStatusError`**, less redundant memoization).
> 
> Docs/env: plan cleanup runbook, deploy verification steps, deferred pnpm **`minimumReleaseAge`** policy doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6c4106420333d4b6f2a42f56b93dbd8d6699ddb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->