### PR TITLE
Add React Doctor CI

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -1,0 +1,26 @@
+name: React Doctor
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  statuses: write
+
+concurrency:
+  group: react-doctor-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  react-doctor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: millionco/react-doctor@v2


### PR DESCRIPTION
Adds the official React Doctor GitHub Action workflow for pull requests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change with no application runtime or deployment impact; third-party action runs with scoped GitHub permissions.
> 
> **Overview**
> Adds a new **React Doctor** GitHub Actions workflow that runs on pull requests (open/sync/reopen/ready for review) and on pushes to `main`.
> 
> The job checks out the repo with full history (`fetch-depth: 0`) and runs `millionco/react-doctor@v2`, with concurrency per PR/ref and permissions for PR/issue comments and commit statuses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f97d896f8cd1887ea8e40d2a3b1cf00b5d0d5cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->