### PR TITLE
Pre-prod review cleanup, audit fixes, and main sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,9 @@ LESSON_GENERATION_ENABLED=
 # Shared bearer token for the manual retention cleanup route, only needed when enabled
 MAINTENANCE_WORKER_TOKEN=
 
+# Bearer token for GET /api/health/worker operator metrics. Required in production.
+WORKER_HEALTH_TOKEN=
+
 # Master switch for the manual retention cleanup HTTP route; Supabase Cron is separate
 RETENTION_CLEANUP_ENABLED=
 

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -94,6 +94,7 @@ PLAN_CLEANUP_ENABLED=false
 
 # Shared bearer token for production maintenance routes and the plan cleanup scheduler.
 MAINTENANCE_WORKER_TOKEN=replace-with-strong-production-secret
+WORKER_HEALTH_TOKEN=replace-with-strong-production-secret
 
 # Production log verbosity.
 LOG_LEVEL=info

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -59,8 +59,6 @@ jobs:
               - 'package.json'
               - 'pnpm-lock.yaml'
               - '.oxlintrc.json'
-              - '.prettierignore'
-              - 'prettier.config.mjs'
               - '.husky/**'
               - '.github/workflows/**'
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -382,7 +382,7 @@ jobs:
           key: ${{ steps.restore-vitest-cache.outputs.cache-primary-key || format('{0}-vitest-{1}-{2}', runner.os, hashFiles('pnpm-lock.yaml'), github.sha) }}
 
   integration-light:
-    name: Integration (related or light)
+    name: Integration (related/full/light)
     runs-on: ubuntu-latest
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
@@ -430,10 +430,9 @@ jobs:
         env:
           NODE_ENV: 'test'
           BASE_REF: ${{ github.base_ref }}
-          # No POSTGRES_URL: tests/setup/testcontainers.ts spins up Postgres and
-          # tests/setup/test-env.ts derives per-worker DBs from VITEST_POOL_ID.
         shell: bash
         run: |
+          set -e
           echo "Base ref: ${BASE_REF}"
           CHANGED_FILES=""
           if [ -n "${BASE_REF}" ]; then
@@ -445,7 +444,6 @@ jobs:
           COUNT=$(echo "${FILES}" | wc -l | tr -d ' ')
           echo "Changed candidate files: ${COUNT}"
 
-          # Global changes that should skip related integration and rely on light subset
           read -r -d '' GLOBAL_TRIGGER_PATTERN <<'EOF' || true
           ^(
             pnpm-lock\.yaml|
@@ -457,49 +455,61 @@ jobs:
             supabase/(schema|migrations|enums\.ts|config\.toml)(/.*)?
           )$
           EOF
-          # Remove newlines and spaces for grep -E compatibility
           GLOBAL_TRIGGER_PATTERN_CLEAN=$(echo "${GLOBAL_TRIGGER_PATTERN}" | tr -d '\n' | sed 's/ //g')
           GLOBAL_TRIGGER=$(echo "${CHANGED_FILES}" | tr ' ' '\n' | grep -E "${GLOBAL_TRIGGER_PATTERN_CLEAN}" || true)
+
+          MODE="light"
           if [ -n "${GLOBAL_TRIGGER}" ]; then
-            echo "Detected global change impacting many tests; skipping related integration."
-            COUNT=0
-          fi
-
-          if [ "${COUNT}" -gt 0 ] && [ "${COUNT}" -le 50 ]; then
-            echo "Running vitest related for integration project..."
-            pnpm vitest related --project integration --run --coverage \
-              --reporter=default \
-              --reporter=json \
-              --outputFile=test-results.json \
-              ${FILES}
-            EXIT=$?
-            if [ $EXIT -eq 0 ]; then
-              echo "Related integration run completed."
-              # Ensure coverage file exists before exiting
-              if [ -f coverage/lcov.info ]; then
-                echo "Coverage report generated successfully."
-              else
-                echo "⚠️ Warning: coverage/lcov.info not found after test run"
-              fi
-              exit 0
-            else
-              echo "Related run failed; falling back to light subset."
-            fi
+            MODE="full"
+            echo "Integration mode: full (global trigger detected)"
+          elif [ "${COUNT}" -gt 50 ]; then
+            MODE="full"
+            echo "Integration mode: full (${COUNT} candidate TypeScript files)"
+          elif [ "${COUNT}" -gt 0 ]; then
+            MODE="related"
+            echo "Integration mode: related (${COUNT} candidate TypeScript files)"
           else
-            echo "No suitable changed files; using light subset."
+            echo "Integration mode: light (no suitable source candidates)"
           fi
 
-          # Light subset fallback (or primary when no related)
-          mapfile -t LIGHT_FILES < <(find tests/integration -type f -path '*/light/*' \( -name "*.test.ts" -o -name "*.spec.ts" -o -name "*.test.tsx" -o -name "*.spec.tsx" \))
-          if [ "${#LIGHT_FILES[@]}" -eq 0 ]; then
-            echo "No light integration tests found; skipping."
-            exit 0
+          case "${MODE}" in
+            related)
+              pnpm vitest related --project integration --run --coverage \
+                --reporter=default \
+                --reporter=json \
+                --outputFile=test-results.json \
+                ${FILES}
+              ;;
+            full)
+              pnpm vitest run --project integration tests/integration \
+                --coverage \
+                --coverage.thresholds.lines=0 \
+                --coverage.thresholds.functions=0 \
+                --coverage.thresholds.branches=0 \
+                --coverage.thresholds.statements=0 \
+                --reporter=default \
+                --reporter=json \
+                --outputFile=test-results.json
+              ;;
+            light)
+              mapfile -t LIGHT_FILES < <(find tests/integration -type f -path '*/light/*' \( -name "*.test.ts" -o -name "*.spec.ts" -o -name "*.test.tsx" -o -name "*.spec.tsx" \))
+              if [ "${#LIGHT_FILES[@]}" -eq 0 ]; then
+                echo "No light integration tests found; skipping."
+                exit 0
+              fi
+              pnpm vitest run --project integration "${LIGHT_FILES[@]}" \
+                --coverage \
+                --reporter=default \
+                --reporter=json \
+                --outputFile=test-results.json
+              ;;
+          esac
+
+          if [ -f coverage/lcov.info ]; then
+            echo "Coverage report generated successfully."
+          else
+            echo "⚠️ Warning: coverage/lcov.info not found after test run"
           fi
-          pnpm vitest run --project integration "${LIGHT_FILES[@]}" \
-            --coverage \
-            --reporter=default \
-            --reporter=json \
-            --outputFile=test-results.json
       - name: Generate test summary
         if: always()
         run: |

--- a/docs/ci-cd/pipeline-and-deployment-strategy.md
+++ b/docs/ci-cd/pipeline-and-deployment-strategy.md
@@ -39,7 +39,7 @@ The pipeline intentionally favors safety on production DB changes: migrations ru
 ### 1) `.github/workflows/ci-pr.yml`
 
 - Trigger: PRs to `develop` or `main`
-- Runs: lint, type-check, dependency audit, build, unit tests, light integration tests
+- Runs: lint, type-check, dependency audit, build, unit tests, and PR integration tests (related for small source diffs, full for global or broad diffs, light only when no suitable source candidates)
 - Skips docs-only changes (`docs/**`, `**/*.md`, etc.)
 
 ### 2) `.github/workflows/ci-trunk.yml`

--- a/docs/ci/branching-strategy.md
+++ b/docs/ci/branching-strategy.md
@@ -93,7 +93,7 @@ We use 4 core GitHub Actions workflows:
 - Security audit (dependency vulnerabilities)
 - Build (Next.js)
 - Unit tests
-- Light integration tests
+- Integration tests (related for small source diffs, full for global or broad diffs, light only when no suitable source candidates)
 
 **Purpose:** Fast feedback on PRs before merge.
 

--- a/docs/development/deploy.md
+++ b/docs/development/deploy.md
@@ -21,6 +21,7 @@ After deploying a release that includes new Supabase migrations:
 2. If the CLI reports out-of-order local migrations, use `supabase db push --include-all` against the target project (see `docs/architecture/retention-cleanup-runbook.md`).
 3. Set worker tokens in the target environment for enabled internal routes:
    - `REGENERATION_WORKER_TOKEN` for regeneration drains
+   - `WORKER_HEALTH_TOKEN` for `GET /api/health/worker` operator metrics
    - `RETENTION_CLEANUP_ENABLED=true` and/or `PLAN_CLEANUP_ENABLED=true` plus `MAINTENANCE_WORKER_TOKEN` only when enabling maintenance routes
 4. Verify plan cleanup scheduler and alerting when `PLAN_CLEANUP_ENABLED=true`:
    - Set the same `MAINTENANCE_WORKER_TOKEN` value in Vercel Production and the GitHub Actions repository secret.
@@ -35,6 +36,10 @@ WHERE jobname = 'retention-cleanup';
 ```
 
 If the migration applied but no cron job exists, enable `pg_cron` in Supabase and register the job manually (see retention runbook).
+
+6. Enable module lesson generation when the hosted environment should serve it:
+   - Set `LESSON_GENERATION_ENABLED=true` in production/staging. When unset outside development, the flag defaults to **off** and `POST /api/v1/plans/:planId/modules/:moduleId/lesson-content/generate` returns HTTP `503` with `disabled`.
+   - After deploy, verify from an authenticated session that lesson generation does not return `503 disabled` for an unlocked module. See `docs/architecture/plan-generation-architecture.md` (module lesson generation) and `docs/development/environment.md` (`LESSON_GENERATION_ENABLED`).
 
 See also:
 

--- a/docs/development/environment.md
+++ b/docs/development/environment.md
@@ -51,7 +51,7 @@ Key auth-related server variables include:
 | `DEV_AUTH_USER_ID`                  | Optional dev/test auth override (`users.auth_user_id`); use bootstrap seed id for local DB                                            | No       |
 | `DEV_AUTH_USER_EMAIL`               | Optional dev/test display email                                                                                                       | No       |
 | `DEV_AUTH_USER_NAME`                | Optional dev/test display name                                                                                                        | No       |
-| `LESSON_GENERATION_ENABLED`         | `true`/`false`/`1`/`0`; when unset, defaults to **on** in development and **off** in other `NODE_ENV` values (see `lessonContentEnv`) | No       |
+| `LESSON_GENERATION_ENABLED`         | `true`/`false`/`1`/`0`; when unset, defaults to **on** in development and **off** in other `NODE_ENV` values (see `lessonContentEnv`). Set `true` in hosted production/staging when module lesson generation should be live — see `docs/development/deploy.md`. | No (yes for hosted lesson generation) |
 
 ### Workflow SDK
 
@@ -99,6 +99,7 @@ Shared bearer tokens for scheduler-triggered POST routes under `/api/internal/`.
 | `RETENTION_CLEANUP_ENABLED` | Master switch for the **manual** retention cleanup HTTP route only | Set `true` only when enabling the manual route |
 | `PLAN_CLEANUP_ENABLED`      | Master switch for the plan cleanup HTTP route                        | Set `true` when scheduled cleanup is enabled |
 | `MAINTENANCE_WORKER_TOKEN`  | Auth for maintenance cleanup routes and the plan cleanup scheduler   | Yes when any maintenance route is enabled |
+| `WORKER_HEALTH_TOKEN`       | Auth for `GET /api/health/worker` operator metrics                   | Yes                                            |
 
 Scheduled retention cleanup runs via Supabase Cron (`private.cleanup_retained_db_rows()`) and does not use these HTTP env vars. See `docs/architecture/retention-cleanup-runbook.md`.
 

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
-    "@types/node": "^20.19.39",
+    "@types/node": "^22.19.21",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@typescript/native-preview": "7.0.0-dev.20260421.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,7 +123,7 @@ importers:
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       stripe:
         specifier: ^20.4.1
-        version: 20.4.1(@types/node@20.19.39)
+        version: 20.4.1(@types/node@22.19.21)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -156,8 +156,8 @@ importers:
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
-        specifier: ^20.19.39
-        version: 20.19.39
+        specifier: ^22.19.21
+        version: 22.19.21
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -178,7 +178,7 @@ importers:
         version: 4.0.5(@opentelemetry/api@1.9.1)
       '@workflow/vitest':
         specifier: ^4.0.6
-        version: 4.0.6(@opentelemetry/api@1.9.1)(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)(zod@4.3.6)
+        version: 4.0.6(@opentelemetry/api@1.9.1)(vite@7.3.2(@types/node@22.19.21)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)(zod@4.3.6)
       '@workflow/world-local':
         specifier: ^4.0.6
         version: 4.1.2(@opentelemetry/api@1.9.1)
@@ -229,10 +229,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.3.2
-        version: 7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 7.3.2(@types/node@22.19.21)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.21)(@vitest/coverage-v8@4.1.4)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@7.3.2(@types/node@22.19.21)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
@@ -3342,8 +3342,8 @@ packages:
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
-  '@types/node@20.19.39':
-    resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
+  '@types/node@22.19.21':
+    resolution: {integrity: sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==}
 
   '@types/pg-pool@2.0.7':
     resolution: {integrity: sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==}
@@ -9483,19 +9483,19 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 20.19.39
+      '@types/node': 22.19.21
 
   '@types/deep-eql@4.0.2': {}
 
   '@types/docker-modem@3.0.6':
     dependencies:
-      '@types/node': 20.19.39
+      '@types/node': 22.19.21
       '@types/ssh2': 1.15.5
 
   '@types/dockerode@4.0.1':
     dependencies:
       '@types/docker-modem': 3.0.6
-      '@types/node': 20.19.39
+      '@types/node': 22.19.21
       '@types/ssh2': 1.15.5
 
   '@types/eslint-scope@3.7.7':
@@ -9518,13 +9518,13 @@ snapshots:
 
   '@types/mysql@2.15.27':
     dependencies:
-      '@types/node': 20.19.39
+      '@types/node': 22.19.21
 
   '@types/node@18.19.130':
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@20.19.39':
+  '@types/node@22.19.21':
     dependencies:
       undici-types: 6.21.0
 
@@ -9534,7 +9534,7 @@ snapshots:
 
   '@types/pg@8.15.6':
     dependencies:
-      '@types/node': 20.19.39
+      '@types/node': 22.19.21
       pg-protocol: 1.13.0
       pg-types: 2.2.0
 
@@ -9548,11 +9548,11 @@ snapshots:
 
   '@types/ssh2-streams@0.1.13':
     dependencies:
-      '@types/node': 20.19.39
+      '@types/node': 22.19.21
 
   '@types/ssh2@0.5.52':
     dependencies:
-      '@types/node': 20.19.39
+      '@types/node': 22.19.21
       '@types/ssh2-streams': 0.1.13
 
   '@types/ssh2@1.15.5':
@@ -9561,7 +9561,7 @@ snapshots:
 
   '@types/tedious@4.0.14':
     dependencies:
-      '@types/node': 20.19.39
+      '@types/node': 22.19.21
 
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260421.2':
     optional: true
@@ -9650,7 +9650,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.21)(@vitest/coverage-v8@4.1.4)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@7.3.2(@types/node@22.19.21)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -9661,13 +9661,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.4(vite@7.3.2(@types/node@22.19.21)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@22.19.21)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.4':
     dependencies:
@@ -9972,16 +9972,16 @@ snapshots:
       - '@swc/helpers'
       - supports-color
 
-  '@workflow/vitest@4.0.6(@opentelemetry/api@1.9.1)(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)(zod@4.3.6)':
+  '@workflow/vitest@4.0.6(@opentelemetry/api@1.9.1)(vite@7.3.2(@types/node@22.19.21)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)(zod@4.3.6)':
     dependencies:
       '@workflow/builders': 4.0.6(@opentelemetry/api@1.9.1)
       '@workflow/core': 4.2.5(@opentelemetry/api@1.9.1)
       '@workflow/rollup': 4.0.5(@opentelemetry/api@1.9.1)
       '@workflow/world': 4.1.2(zod@4.3.6)
       '@workflow/world-local': 4.1.2(@opentelemetry/api@1.9.1)
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.21)(@vitest/coverage-v8@4.1.4)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@7.3.2(@types/node@22.19.21)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      vite: 7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@22.19.21)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -11373,7 +11373,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 20.19.39
+      '@types/node': 22.19.21
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -12029,7 +12029,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 20.19.39
+      '@types/node': 22.19.21
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -12558,9 +12558,9 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
-  stripe@20.4.1(@types/node@20.19.39):
+  stripe@20.4.1(@types/node@22.19.21):
     optionalDependencies:
-      '@types/node': 20.19.39
+      '@types/node': 22.19.21
 
   strnum@2.3.0: {}
 
@@ -12894,7 +12894,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
+  vite@7.3.2(@types/node@22.19.21)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -12903,7 +12903,7 @@ snapshots:
       rollup: 4.60.2
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 20.19.39
+      '@types/node': 22.19.21
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
@@ -12911,10 +12911,10 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.21)(@vitest/coverage-v8@4.1.4)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@7.3.2(@types/node@22.19.21)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.4(vite@7.3.2(@types/node@22.19.21)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -12931,11 +12931,11 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@22.19.21)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
-      '@types/node': 20.19.39
+      '@types/node': 22.19.21
       '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
       jsdom: 27.4.0(@noble/hashes@2.2.0)
     transitivePeerDependencies:

--- a/src/app/(app)/plans/[id]/modules/[moduleId]/components/useModuleLessonGeneration.ts
+++ b/src/app/(app)/plans/[id]/modules/[moduleId]/components/useModuleLessonGeneration.ts
@@ -169,7 +169,14 @@ export function useModuleLessonGeneration({
           }
 
           const outcome = await pollStatus();
-          if (cancelled || outcome !== 'continue') {
+          if (cancelled) {
+            return;
+          }
+          if (outcome === 'error') {
+            refresh();
+            return;
+          }
+          if (outcome !== 'continue') {
             return;
           }
 

--- a/src/app/(app)/plans/[id]/modules/[moduleId]/components/useModuleLessonGeneration.ts
+++ b/src/app/(app)/plans/[id]/modules/[moduleId]/components/useModuleLessonGeneration.ts
@@ -169,7 +169,7 @@ export function useModuleLessonGeneration({
           }
 
           const outcome = await pollStatus();
-          if (cancelled || outcome === 'terminal') {
+          if (cancelled || outcome !== 'continue') {
             return;
           }
 

--- a/src/app/(app)/plans/[id]/modules/[moduleId]/components/useModuleLessonGeneration.ts
+++ b/src/app/(app)/plans/[id]/modules/[moduleId]/components/useModuleLessonGeneration.ts
@@ -1,7 +1,10 @@
 import type { ModuleLessonGenerationApiResponse } from '@/shared/types/lesson-content.types';
 
 import { clientLogger } from '@/lib/logging/client';
-import { ModuleLessonGenerationApiResponseSchema } from '@/shared/schemas/lesson-content.schemas';
+import {
+  ModuleLessonGenerationApiResponseSchema,
+  ModuleLessonGenerationStatusResponseSchema,
+} from '@/shared/schemas/lesson-content.schemas';
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState, useTransition } from 'react';
 import { toast } from 'sonner';
@@ -51,6 +54,10 @@ function applyModuleLessonGenerationResponse(
   }
 }
 
+function buildModuleLessonStatusUrl(planId: string, moduleId: string): string {
+  return `/api/v1/plans/${planId}/modules/${moduleId}/lesson-content/status`;
+}
+
 export function useModuleLessonGeneration({
   planId,
   moduleId,
@@ -83,23 +90,91 @@ export function useModuleLessonGeneration({
 
     let cancelled = false;
     let timeoutId: number | undefined;
+    const statusUrl = buildModuleLessonStatusUrl(planId, moduleId);
 
-    const schedule = (): void => {
-      timeoutId = window.setTimeout(() => {
-        if (cancelled) return;
+    const pollStatus = async (): Promise<'continue' | 'terminal' | 'error'> => {
+      try {
+        const response = await fetch(statusUrl, { cache: 'no-store' });
 
-        generationPollCountRef.current += 1;
-        if (
-          generationPollCountRef.current > MODULE_LESSON_GENERATION_MAX_POLLS
-        ) {
-          setGenerationTakingLong(true);
-          return;
+        if (!response.ok) {
+          clientLogger.error('Module lesson generation status request failed', {
+            moduleId,
+            planId,
+            ok: response.ok,
+            status: response.status,
+          });
+          return 'error';
+        }
+
+        let raw: unknown;
+        try {
+          raw = await response.json();
+        } catch (parseError) {
+          clientLogger.error(
+            'Module lesson generation status response JSON parse failed',
+            {
+              parseError,
+              moduleId,
+              planId,
+              ok: response.ok,
+              status: response.status,
+            },
+          );
+          return 'error';
+        }
+
+        const parsed =
+          ModuleLessonGenerationStatusResponseSchema.safeParse(raw);
+        if (!parsed.success) {
+          clientLogger.error(
+            'Module lesson generation status response validation failed',
+            {
+              issues: parsed.error.flatten(),
+              moduleId,
+              planId,
+              ok: response.ok,
+              status: response.status,
+            },
+          );
+          return 'error';
+        }
+
+        if (parsed.data.status === 'generating') {
+          return 'continue';
         }
 
         refresh();
-        if (!cancelled) {
+        return 'terminal';
+      } catch (error) {
+        clientLogger.error('Module lesson generation status request failed', {
+          error,
+          moduleId,
+          planId,
+        });
+        return 'error';
+      }
+    };
+
+    const schedule = (): void => {
+      timeoutId = window.setTimeout(() => {
+        void (async () => {
+          if (cancelled) return;
+
+          generationPollCountRef.current += 1;
+          if (
+            generationPollCountRef.current > MODULE_LESSON_GENERATION_MAX_POLLS
+          ) {
+            setGenerationTakingLong(true);
+            return;
+          }
+
+          const outcome = await pollStatus();
+          if (cancelled || outcome === 'terminal') {
+            return;
+          }
+
           schedule();
-        }
+        })();
       }, MODULE_LESSON_GENERATION_POLL_MS);
     };
 
@@ -111,7 +186,7 @@ export function useModuleLessonGeneration({
         window.clearTimeout(timeoutId);
       }
     };
-  }, [previousModulesComplete, refresh, status]);
+  }, [moduleId, planId, previousModulesComplete, refresh, status]);
 
   const generateLessons = (): void => {
     if (!previousModulesComplete) {

--- a/src/app/api/health/worker/route.ts
+++ b/src/app/api/health/worker/route.ts
@@ -8,7 +8,6 @@ import { assertInternalWorkerAccess } from '@/lib/api/internal/internal-worker-a
 import { checkIpRateLimit } from '@/lib/api/ip-rate-limit';
 import { maintenanceEnv } from '@/lib/config/env';
 import { getSystemWideJobMetrics } from '@/lib/db/queries/admin/jobs-metrics';
-import { logger } from '@/lib/logging/logger';
 import { getLoggingRequestContext } from '@/lib/logging/request-context';
 import { NextResponse } from 'next/server';
 
@@ -50,7 +49,7 @@ export async function GET(request: Request): Promise<Response> {
       status: httpStatus,
     });
   } catch (error) {
-    logger.error({ error }, 'Health worker check failed');
+    requestLogger.error({ error }, 'Health worker check failed');
 
     return NextResponse.json(buildWorkerHealthMonitoringErrorBody(timestamp), {
       status: 503,

--- a/src/app/api/health/worker/route.ts
+++ b/src/app/api/health/worker/route.ts
@@ -4,14 +4,33 @@ import {
   buildHealthyWorkerHealthBody,
   buildWorkerHealthMonitoringErrorBody,
 } from '@/lib/api/health/worker-health-checks';
+import { assertInternalWorkerAccess } from '@/lib/api/internal/internal-worker-access';
 import { checkIpRateLimit } from '@/lib/api/ip-rate-limit';
+import { maintenanceEnv } from '@/lib/config/env';
 import { getSystemWideJobMetrics } from '@/lib/db/queries/admin/jobs-metrics';
 import { logger } from '@/lib/logging/logger';
+import { getLoggingRequestContext } from '@/lib/logging/request-context';
 import { NextResponse } from 'next/server';
 
+const WORKER_HEALTH_HEADER = 'x-worker-health-token';
+
 export async function GET(request: Request): Promise<Response> {
+  const { logger: requestLogger } = getLoggingRequestContext(request);
+  const pathname = new URL(request.url).pathname;
+
   try {
     checkIpRateLimit(request, 'health');
+    assertInternalWorkerAccess({
+      request,
+      pathname,
+      logger: requestLogger,
+      enabled: true,
+      workerToken: maintenanceEnv.workerHealthToken,
+      headerName: WORKER_HEALTH_HEADER,
+      unavailableMessage: 'Worker health check is currently unavailable.',
+      unauthorizedLogMessage: 'Unauthorized worker health check attempt',
+      missingWorkerTokenLogMessage: 'Worker health token missing in production',
+    });
   } catch (error) {
     return toErrorResponse(error);
   }

--- a/src/app/api/v1/plans/[planId]/modules/[moduleId]/lesson-content/status/route.ts
+++ b/src/app/api/v1/plans/[planId]/modules/[moduleId]/lesson-content/status/route.ts
@@ -1,0 +1,41 @@
+import { requireUuidRouteParam } from '@/features/plans/api/route-context';
+import { getModuleLessonGenerationStatusForRead } from '@/features/plans/read-projection/service';
+import { NotFoundError } from '@/lib/api/errors';
+import { requestBoundary } from '@/lib/api/request-boundary';
+import { json } from '@/lib/api/response';
+import { logger } from '@/lib/logging/logger';
+import { ModuleLessonGenerationStatusResponseSchema } from '@/shared/schemas/lesson-content.schemas';
+
+/**
+ * GET /api/v1/plans/:planId/modules/:moduleId/lesson-content/status
+ * Returns the owned module's lesson generation status for client polling.
+ */
+export const GET = requestBoundary.route(
+  { rateLimit: 'read' },
+  async ({ params, actor, db, correlationId }): Promise<Response> => {
+    const planId = requireUuidRouteParam(params, 'planId');
+    const moduleId = requireUuidRouteParam(params, 'moduleId');
+
+    logger.debug(
+      { planId, moduleId, userId: actor.id, correlationId },
+      'Module lesson generation status request received',
+    );
+
+    const snapshot = await getModuleLessonGenerationStatusForRead({
+      planId,
+      moduleId,
+      userId: actor.id,
+      dbClient: db,
+    });
+
+    if (!snapshot) {
+      throw new NotFoundError('Module not found.');
+    }
+
+    const body = ModuleLessonGenerationStatusResponseSchema.parse(snapshot);
+
+    return json(body, {
+      headers: { 'Cache-Control': 'no-store' },
+    });
+  },
+);

--- a/src/app/api/v1/plans/[planId]/route.ts
+++ b/src/app/api/v1/plans/[planId]/route.ts
@@ -46,12 +46,12 @@ export const GET = requestBoundary.route(
 
 export const DELETE = requestBoundary.route(
   { rateLimit: 'mutation' },
-  async ({ params, actor, db }) => {
+  async ({ params, actor }) => {
     const planId = requireUuidRouteParam(params, 'planId');
 
     logger.info({ planId, userId: actor.id }, 'Deleting learning plan');
 
-    await removePlanForWrite({ planId, userId: actor.id, dbClient: db });
+    await removePlanForWrite({ planId, userId: actor.id });
 
     logger.info({ planId, userId: actor.id }, 'Learning plan deleted');
 

--- a/src/features/plans/cleanup.ts
+++ b/src/features/plans/cleanup.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, lt, sql } from 'drizzle-orm';
+import { and, eq, inArray, isNull, lt, sql } from 'drizzle-orm';
 // Use the store function directly (not PlanPersistenceAdapter) so failure
 // updates run on the same transaction handle as SELECT … FOR UPDATE.
 import type { DbClient } from '@/lib/db/types';
@@ -19,6 +19,12 @@ export const STUCK_PLAN_CLEANUP_BATCH_SIZE = 1000;
 
 /** In-progress attempts older than this are considered orphaned. */
 export const ORPHANED_ATTEMPT_THRESHOLD_MS = 15 * 60 * 1000; // 15 minutes
+
+/**
+ * Max orphaned attempts processed per cleanup run. Matches stuck-plan batching so
+ * each maintenance transaction stays bounded.
+ */
+export const ORPHANED_ATTEMPT_CLEANUP_BATCH_SIZE = 1000;
 
 /**
  * Marks plans stuck in 'generating' status for longer than the threshold as 'failed'.
@@ -99,47 +105,81 @@ export async function cleanupStuckPlans(
   });
 }
 
+type CleanupOrphanedAttemptsDependencies = {
+  batchSize?: number;
+};
+
 /**
  * Finalizes orphaned 'in_progress' generation attempts older than the threshold.
  * Sets classification to 'timeout' for attempts that were never completed.
+ * Rows are locked inside a transaction before updates so cleanup does not race
+ * concurrent generation state updates.
  */
 export async function cleanupOrphanedAttempts(
   dbClient: DbClient,
   thresholdMs: number = ORPHANED_ATTEMPT_THRESHOLD_MS,
+  deps: CleanupOrphanedAttemptsDependencies = {},
 ): Promise<{ cleaned: number }> {
   const cutoff = new Date(Date.now() - thresholdMs);
+  const batchSize = deps.batchSize ?? ORPHANED_ATTEMPT_CLEANUP_BATCH_SIZE;
 
-  const result = await dbClient
-    .update(generationAttempts)
-    .set({
-      classification: 'timeout',
-      // Raw SQL literal — the generation_attempts.status column uses a DB enum
-      // whose TypeScript type doesn't include 'failure' directly.
-      status: sql<string>`'failure'`,
-    })
-    .where(
-      and(
-        isNull(generationAttempts.classification),
-        eq(generationAttempts.status, 'in_progress'),
-        lt(generationAttempts.createdAt, cutoff),
-      ),
-    )
-    .returning({ id: generationAttempts.id });
+  return dbClient.transaction(async (tx) => {
+    const orphanedAttempts = await tx
+      .select({ id: generationAttempts.id })
+      .from(generationAttempts)
+      .where(
+        and(
+          isNull(generationAttempts.classification),
+          eq(generationAttempts.status, 'in_progress'),
+          lt(generationAttempts.createdAt, cutoff),
+        ),
+      )
+      .limit(batchSize)
+      .for('update');
 
-  const cleaned = result.length;
+    if (orphanedAttempts.length === 0) {
+      return { cleaned: 0 };
+    }
 
-  if (cleaned > 0) {
-    logger.info(
-      {
-        source: 'cleanup',
-        event: 'orphaned_attempts_cleaned',
-        count: cleaned,
-      },
-      `Finalized ${cleaned} orphaned attempt(s)`,
-    );
-  }
+    const attemptIds = orphanedAttempts.map((attempt) => attempt.id);
 
-  return { cleaned };
+    const result = await tx
+      .update(generationAttempts)
+      .set({
+        classification: 'timeout',
+        // Raw SQL literal — the generation_attempts.status column uses a DB enum
+        // whose TypeScript type doesn't include 'failure' directly.
+        status: sql<string>`'failure'`,
+      })
+      .where(inArray(generationAttempts.id, attemptIds))
+      .returning({ id: generationAttempts.id });
+
+    const cleaned = result.length;
+
+    if (cleaned > 0) {
+      logger.info(
+        {
+          source: 'cleanup',
+          event: 'orphaned_attempts_cleaned',
+          count: cleaned,
+        },
+        `Finalized ${cleaned} orphaned attempt(s)`,
+      );
+    }
+
+    if (cleaned === batchSize) {
+      logger.warn(
+        {
+          source: 'cleanup',
+          event: 'orphaned_attempts_cleanup_batch_full',
+          batchSize,
+        },
+        'Plan cleanup filled its orphaned-attempt batch; backlog may remain',
+      );
+    }
+
+    return { cleaned };
+  });
 }
 
 /**

--- a/src/features/plans/cleanup.ts
+++ b/src/features/plans/cleanup.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, isNull, lt, sql } from 'drizzle-orm';
+import { and, eq, inArray, isNull, lt } from 'drizzle-orm';
 // Use the store function directly (not PlanPersistenceAdapter) so failure
 // updates run on the same transaction handle as SELECT … FOR UPDATE.
 import type { DbClient } from '@/lib/db/types';
@@ -147,14 +147,28 @@ export async function cleanupOrphanedAttempts(
       .update(generationAttempts)
       .set({
         classification: 'timeout',
-        // Raw SQL literal — the generation_attempts.status column uses a DB enum
-        // whose TypeScript type doesn't include 'failure' directly.
-        status: sql<string>`'failure'`,
+        status: 'failure',
       })
       .where(inArray(generationAttempts.id, attemptIds))
       .returning({ id: generationAttempts.id });
 
-    const cleaned = result.length;
+    const cleanedAttemptIds = result.map((attempt) => attempt.id);
+    const cleaned = cleanedAttemptIds.length;
+
+    if (cleaned !== attemptIds.length) {
+      logger.error(
+        {
+          source: 'cleanup',
+          event: 'orphaned_attempts_cleanup_partial_failure',
+          expected: attemptIds.length,
+          cleaned,
+        },
+        'Plan cleanup failed to finalize all locked orphaned attempts',
+      );
+      throw new Error(
+        'Plan cleanup failed to finalize all locked orphaned attempts',
+      );
+    }
 
     if (cleaned > 0) {
       logger.info(

--- a/src/features/plans/read-projection/detail-aggregate.ts
+++ b/src/features/plans/read-projection/detail-aggregate.ts
@@ -1,10 +1,10 @@
 import type { TaskResourceWithResource } from '@/lib/db/queries/types/modules.types';
+import type { PlanDetailTaskRow } from '@/lib/db/queries/types/plans.types';
 import type {
   GenerationAttempt,
   LearningPlan,
   LearningPlanDetail,
   Module,
-  Task,
   TaskProgress,
 } from '@/shared/types/db.types';
 
@@ -15,7 +15,7 @@ type ModuleTasks = LearningPlanDetail['plan']['modules'][number]['tasks'];
 export function buildLearningPlanDetail(params: {
   plan: LearningPlan;
   moduleRows: Module[];
-  taskRows: Task[];
+  taskRows: PlanDetailTaskRow[];
   progressRows: TaskProgress[];
   resourceRows: TaskResourceWithResource[];
   latestAttempt: GenerationAttempt | null;

--- a/src/features/plans/read-projection/service.ts
+++ b/src/features/plans/read-projection/service.ts
@@ -26,7 +26,10 @@ import {
   buildLightweightPlanSummaries,
   buildPlanSummaries,
 } from '@/features/plans/read-projection/summary-projection';
-import { getModuleDetailRows } from '@/lib/db/queries/modules';
+import {
+  getModuleDetailRows,
+  getModuleLessonGenerationStatus,
+} from '@/lib/db/queries/modules';
 import {
   getLearningPlanDetailRows,
   getLightweightPlanSummaryRowsForUser,
@@ -139,6 +142,34 @@ export async function getPlanGenerationStatusSnapshot(params: {
   }
 
   return buildPlanDetailStatusSnapshot(rows);
+}
+
+export async function getModuleLessonGenerationStatusForRead(params: {
+  planId: string;
+  moduleId: string;
+  userId: string;
+  dbClient?: PlanDbClient;
+}): Promise<{
+  planId: string;
+  moduleId: string;
+  status: 'not_generated' | 'generating' | 'ready' | 'failed';
+} | null> {
+  const status = await getModuleLessonGenerationStatus(
+    params.planId,
+    params.moduleId,
+    params.userId,
+    params.dbClient,
+  );
+
+  if (!status) {
+    return null;
+  }
+
+  return {
+    planId: params.planId,
+    moduleId: params.moduleId,
+    status,
+  };
 }
 
 export async function getPlanGenerationAttemptsForRead(params: {

--- a/src/features/plans/write-service/index.ts
+++ b/src/features/plans/write-service/index.ts
@@ -2,7 +2,6 @@ import type { PlanDbClient } from '@/features/plans/read-projection/types';
 
 import { ConflictError, NotFoundError } from '@/lib/api/errors';
 import { deletePlan } from '@/lib/db/queries/plans';
-import { db as serviceRoleDb } from '@supabase/service-role';
 
 /**
  * Deletes a user-owned plan through the feature service boundary so route
@@ -13,7 +12,11 @@ export async function removePlanForWrite(params: {
   userId: string;
   dbClient: PlanDbClient;
 }): Promise<void> {
-  const result = await deletePlan(params.planId, params.userId, serviceRoleDb);
+  const result = await deletePlan(
+    params.planId,
+    params.userId,
+    params.dbClient,
+  );
 
   if (result.success) {
     return;

--- a/src/features/plans/write-service/index.ts
+++ b/src/features/plans/write-service/index.ts
@@ -1,5 +1,3 @@
-import type { PlanDbClient } from '@/features/plans/read-projection/types';
-
 import { ConflictError, NotFoundError } from '@/lib/api/errors';
 import { deletePlan } from '@/lib/db/queries/plans';
 
@@ -10,13 +8,8 @@ import { deletePlan } from '@/lib/db/queries/plans';
 export async function removePlanForWrite(params: {
   planId: string;
   userId: string;
-  dbClient: PlanDbClient;
 }): Promise<void> {
-  const result = await deletePlan(
-    params.planId,
-    params.userId,
-    params.dbClient,
-  );
+  const result = await deletePlan(params.planId, params.userId);
 
   if (result.success) {
     return;

--- a/src/lib/config/env/maintenance.ts
+++ b/src/lib/config/env/maintenance.ts
@@ -13,6 +13,7 @@ interface MaintenanceEnv {
   readonly retentionCleanupEnabled: boolean;
   readonly planCleanupEnabled: boolean;
   readonly workerToken: string | undefined;
+  readonly workerHealthToken: string | undefined;
 }
 
 const defaultMaintenanceAccess = createServerEnvAccess(getProcessEnvSource);
@@ -43,6 +44,12 @@ export function createMaintenanceEnv(access: ServerEnvAccess): MaintenanceEnv {
         return undefined;
       }
       return access.getServerRequiredProdOnly('MAINTENANCE_WORKER_TOKEN');
+    },
+    /**
+     * Bearer token for GET /api/health/worker operator metrics.
+     */
+    get workerHealthToken(): string | undefined {
+      return access.getServerRequiredProdOnly('WORKER_HEALTH_TOKEN');
     },
   };
 }

--- a/src/lib/db/queries/modules.ts
+++ b/src/lib/db/queries/modules.ts
@@ -93,3 +93,37 @@ export async function getModuleDetailRows(
     resourceRows,
   };
 }
+
+/**
+ * Returns the owned module's lesson generation status, or null when missing or
+ * unauthorized. Uses the injected request DB client for RLS-scoped reads.
+ */
+export async function getModuleLessonGenerationStatus(
+  planId: string,
+  moduleId: string,
+  userId: string,
+  dbClient?: ModulesDbClient,
+): Promise<'not_generated' | 'generating' | 'ready' | 'failed' | null> {
+  const client = dbClient ?? getDb();
+
+  const [row] = await client
+    .select({
+      status: modules.lessonGenerationStatus,
+    })
+    .from(modules)
+    .innerJoin(learningPlans, eq(modules.planId, learningPlans.id))
+    .where(
+      and(
+        eq(modules.id, moduleId),
+        eq(modules.planId, planId),
+        eq(learningPlans.userId, userId),
+      ),
+    )
+    .limit(1);
+
+  if (!row) {
+    return null;
+  }
+
+  return row.status;
+}

--- a/src/lib/db/queries/plans.ts
+++ b/src/lib/db/queries/plans.ts
@@ -8,6 +8,7 @@ import type {
   LightweightModuleMetricsRow,
   LightweightPlanListRow,
   PlanAttemptsPlanMeta,
+  PlanDetailTaskRow,
   PlanProgressStatusRow,
   PlanSummaryTaskRow,
 } from '@/lib/db/queries/types/plans.types';
@@ -16,7 +17,6 @@ import type {
   GenerationAttempt,
   LearningPlan,
   Module,
-  Task,
   TaskProgress,
 } from '@/shared/types/db.types';
 
@@ -58,7 +58,7 @@ type LightweightPlanSummaryRows = {
 type LearningPlanDetailRows = {
   plan: LearningPlan;
   moduleRows: Module[];
-  taskRows: Task[];
+  taskRows: PlanDetailTaskRow[];
   progressRows: TaskProgress[];
   resourceRows: TaskResourceWithResource[];
   latestAttempt: GenerationAttempt | null;
@@ -345,9 +345,19 @@ export async function getLearningPlanDetailRows(
 
   const moduleIds = moduleRows.map((module) => module.id);
 
-  const taskRows = moduleIds.length
+  const taskRows: PlanDetailTaskRow[] = moduleIds.length
     ? await client
-        .select()
+        .select({
+          id: tasks.id,
+          moduleId: tasks.moduleId,
+          order: tasks.order,
+          title: tasks.title,
+          description: tasks.description,
+          estimatedMinutes: tasks.estimatedMinutes,
+          hasMicroExplanation: tasks.hasMicroExplanation,
+          createdAt: tasks.createdAt,
+          updatedAt: tasks.updatedAt,
+        })
         .from(tasks)
         .where(inArray(tasks.moduleId, moduleIds))
         .orderBy(asc(tasks.order))

--- a/src/lib/db/queries/types/modules.types.ts
+++ b/src/lib/db/queries/types/modules.types.ts
@@ -30,6 +30,19 @@ export interface ModuleWithTasks extends Module {
   tasks: TaskWithRelations[];
 }
 
+/** Task with relations for plan detail reads (lesson content not loaded). */
+export interface PlanDetailTaskWithRelations extends Omit<
+  Task,
+  'lessonContent' | 'lessonContentUpdatedAt'
+> {
+  resources: TaskResourceWithResource[];
+  progress?: TaskProgress | null;
+}
+
+export interface PlanDetailModuleWithTasks extends Module {
+  tasks: PlanDetailTaskWithRelations[];
+}
+
 /** Per-module task completion aggregates for module navigation (storage / projection input). */
 export interface ModuleTaskMetricRow {
   id: string;

--- a/src/lib/db/queries/types/plans.types.ts
+++ b/src/lib/db/queries/types/plans.types.ts
@@ -18,6 +18,12 @@ export type PlanSummaryTaskRow = Pick<
   'id' | 'moduleId' | 'estimatedMinutes'
 > & { planId: string };
 
+/** Task row shape for plan detail reads (excludes large lesson JSON blobs). */
+export type PlanDetailTaskRow = Omit<
+  TaskRow,
+  'lessonContent' | 'lessonContentUpdatedAt'
+>;
+
 export type PlanProgressStatusRow = Pick<TaskProgressRow, 'taskId' | 'status'>;
 
 /**

--- a/src/shared/schemas/lesson-content.schemas.ts
+++ b/src/shared/schemas/lesson-content.schemas.ts
@@ -147,3 +147,8 @@ export const ModuleLessonGenerationApiResponseSchema = z.discriminatedUnion(
     }),
   ],
 );
+
+export const ModuleLessonGenerationStatusResponseSchema =
+  ModuleLessonGenerationApiBaseSchema.extend({
+    status: z.enum(['not_generated', 'generating', 'ready', 'failed']),
+  }).strict();

--- a/src/shared/types/db.types.ts
+++ b/src/shared/types/db.types.ts
@@ -2,6 +2,7 @@ import type { GenerationAttemptRecord } from '@/lib/db/queries/types/attempts.ty
 import type {
   Module,
   ModuleWithTasks,
+  PlanDetailModuleWithTasks,
 } from '@/lib/db/queries/types/modules.types';
 import type { LightweightPlanListRow } from '@/lib/db/queries/types/plans.types';
 import type { InferSelectModel } from 'drizzle-orm';
@@ -40,6 +41,10 @@ export type LearningPlanWithModules = LearningPlan & {
   modules: ModuleWithTasks[];
 };
 
+export type LearningPlanWithModulesForDetail = LearningPlan & {
+  modules: PlanDetailModuleWithTasks[];
+};
+
 type ProgressMetrics = {
   completion: number;
   completedTasks: number;
@@ -70,7 +75,7 @@ export type LightweightPlanSummary = LightweightPlanListRow &
   };
 
 export type LearningPlanDetail = Omit<ProgressMetrics, 'completion'> & {
-  plan: LearningPlanWithModules;
+  plan: LearningPlanWithModulesForDetail;
   latestAttempt: GenerationAttempt | null;
   attemptsCount: number;
 };

--- a/src/shared/types/lesson-content.types.ts
+++ b/src/shared/types/lesson-content.types.ts
@@ -6,6 +6,7 @@ import {
   ModuleLessonBatchProviderOutputSchema,
   ModuleLessonGenerationApiResponseSchema,
   ModuleLessonGenerationMetadataSchema,
+  ModuleLessonGenerationStatusResponseSchema,
 } from '@/shared/schemas/lesson-content.schemas';
 
 export type LessonContentBlock = z.infer<typeof LessonContentBlockSchema>;
@@ -18,4 +19,7 @@ export type ModuleLessonGenerationMetadata = z.infer<
 >;
 export type ModuleLessonGenerationApiResponse = z.infer<
   typeof ModuleLessonGenerationApiResponseSchema
+>;
+export type ModuleLessonGenerationStatusResponse = z.infer<
+  typeof ModuleLessonGenerationStatusResponseSchema
 >;

--- a/tests/integration/api/plans.module-lesson-content.status.spec.ts
+++ b/tests/integration/api/plans.module-lesson-content.status.spec.ts
@@ -1,0 +1,222 @@
+import { GET } from '@/app/api/v1/plans/[planId]/modules/[moduleId]/lesson-content/status/route';
+import { learningPlans, modules } from '@supabase/schema';
+import { db } from '@supabase/service-role';
+import { setTestUser, clearTestUser } from '@tests/helpers/auth';
+import { ensureUser } from '@tests/helpers/db/users';
+import { buildRouteHandlerContext } from '@tests/helpers/route-handler-context';
+import { buildTestAuthUserId, buildTestEmail } from '@tests/helpers/testIds';
+import { NextRequest } from 'next/server';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const BASE_URL = 'http://localhost/api/v1/plans';
+const VALID_PLAN_ID = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+const OTHER_PLAN_ID = 'a57ac10b-58cc-4372-a567-0e02b2c3d480';
+const VALID_MODULE_ID = '7f9c2f8d-1a9b-4f6e-9f6c-2b2c3d479abc';
+
+type LessonGenerationStatus =
+  | 'not_generated'
+  | 'generating'
+  | 'ready'
+  | 'failed';
+
+async function seedOwnedPlanForStatusApi(userId: string): Promise<void> {
+  await db.insert(learningPlans).values({
+    id: VALID_PLAN_ID,
+    userId,
+    topic: 'Lesson status API test plan',
+    skillLevel: 'beginner',
+    weeklyHours: 5,
+    learningStyle: 'mixed',
+    visibility: 'private',
+    origin: 'ai',
+    generationStatus: 'ready',
+  });
+}
+
+async function seedOwnedModule(
+  status: LessonGenerationStatus,
+  moduleId = VALID_MODULE_ID,
+): Promise<void> {
+  await db.insert(modules).values({
+    id: moduleId,
+    planId: VALID_PLAN_ID,
+    order: 1,
+    title: 'Status test module',
+    description: 'Module for lesson status API tests',
+    estimatedMinutes: 30,
+    lessonGenerationStatus: status,
+  });
+}
+
+async function authenticateTestUser(suffix: string) {
+  const authUserId = buildTestAuthUserId(`lesson-status-api-${suffix}`);
+  setTestUser(authUserId);
+  return ensureUser({
+    authUserId,
+    email: buildTestEmail(authUserId),
+    subscriptionTier: 'starter',
+  });
+}
+
+function createRequest(planId = VALID_PLAN_ID, moduleId = VALID_MODULE_ID) {
+  return new NextRequest(
+    `${BASE_URL}/${planId}/modules/${moduleId}/lesson-content/status`,
+    { method: 'GET' },
+  );
+}
+
+describe('GET /api/v1/plans/:planId/modules/:moduleId/lesson-content/status', () => {
+  afterEach(() => {
+    clearTestUser();
+  });
+
+  it.each([
+    ['not_generated', 'not_generated'],
+    ['generating', 'generating'],
+    ['ready', 'ready'],
+    ['failed', 'failed'],
+  ] as const)(
+    'returns %s status for the owner module',
+    async (persistedStatus, expectedStatus) => {
+      const userId = await authenticateTestUser(persistedStatus);
+      await seedOwnedPlanForStatusApi(userId);
+      await seedOwnedModule(persistedStatus);
+
+      const response = await GET(
+        createRequest(),
+        buildRouteHandlerContext({
+          planId: VALID_PLAN_ID,
+          moduleId: VALID_MODULE_ID,
+        }),
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Cache-Control')).toBe('no-store');
+      expect(body).toEqual({
+        planId: VALID_PLAN_ID,
+        moduleId: VALID_MODULE_ID,
+        status: expectedStatus,
+      });
+    },
+  );
+
+  it('returns 404 for a missing module', async () => {
+    const userId = await authenticateTestUser('missing-module');
+    await seedOwnedPlanForStatusApi(userId);
+
+    const response = await GET(
+      createRequest(),
+      buildRouteHandlerContext({
+        planId: VALID_PLAN_ID,
+        moduleId: VALID_MODULE_ID,
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body).toMatchObject({ error: 'Module not found.' });
+  });
+
+  it("returns 404 for another user's module", async () => {
+    const ownerUserId = await authenticateTestUser('owner');
+    await seedOwnedPlanForStatusApi(ownerUserId);
+    await seedOwnedModule('ready');
+
+    const otherAuthUserId = buildTestAuthUserId('lesson-status-api-other');
+    setTestUser(otherAuthUserId);
+    await ensureUser({
+      authUserId: otherAuthUserId,
+      email: buildTestEmail(otherAuthUserId),
+      subscriptionTier: 'starter',
+    });
+
+    const response = await GET(
+      createRequest(),
+      buildRouteHandlerContext({
+        planId: VALID_PLAN_ID,
+        moduleId: VALID_MODULE_ID,
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body).toMatchObject({ error: 'Module not found.' });
+  });
+
+  it('returns 404 when the module belongs to a different owned plan', async () => {
+    const userId = await authenticateTestUser('wrong-plan');
+    await seedOwnedPlanForStatusApi(userId);
+    await db.insert(learningPlans).values({
+      id: OTHER_PLAN_ID,
+      userId,
+      topic: 'Other owned plan',
+      skillLevel: 'beginner',
+      weeklyHours: 5,
+      learningStyle: 'mixed',
+      visibility: 'private',
+      origin: 'ai',
+      generationStatus: 'ready',
+    });
+    await seedOwnedModule('ready');
+
+    const response = await GET(
+      createRequest(OTHER_PLAN_ID, VALID_MODULE_ID),
+      buildRouteHandlerContext({
+        planId: OTHER_PLAN_ID,
+        moduleId: VALID_MODULE_ID,
+      }),
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it('rejects invalid UUID params', async () => {
+    await authenticateTestUser('invalid-param');
+
+    const response = await GET(
+      createRequest('not-a-uuid', VALID_MODULE_ID),
+      buildRouteHandlerContext({
+        planId: 'not-a-uuid',
+        moduleId: VALID_MODULE_ID,
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe('Invalid planId format.');
+  });
+
+  it('returns canonical unauthorized response without calling the read boundary', async () => {
+    clearTestUser();
+
+    const response = await GET(
+      createRequest(),
+      buildRouteHandlerContext({
+        planId: VALID_PLAN_ID,
+        moduleId: VALID_MODULE_ID,
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body).toMatchObject({
+      error: 'Unauthorized',
+      code: 'UNAUTHORIZED',
+    });
+  });
+
+  it('keeps service-role imports out of the user-facing route', () => {
+    const routeSource = readFileSync(
+      join(
+        process.cwd(),
+        'src/app/api/v1/plans/[planId]/modules/[moduleId]/lesson-content/status/route.ts',
+      ),
+      'utf8',
+    );
+
+    expect(routeSource).not.toContain('@supabase/service-role');
+  });
+});

--- a/tests/integration/db/plan-cleanup.spec.ts
+++ b/tests/integration/db/plan-cleanup.spec.ts
@@ -241,4 +241,58 @@ describe('cleanupOrphanedAttempts (integration)', () => {
 
     expect(result.cleaned).toBe(0);
   });
+
+  it('processes only one bounded batch per run', async () => {
+    const user = await createTestUser();
+    const staleCutoff = new Date(
+      Date.now() - ORPHANED_ATTEMPT_THRESHOLD_MS - 60_000,
+    );
+    const attemptIds: string[] = [];
+
+    for (let index = 0; index < 3; index += 1) {
+      const plan = await createTestPlan({
+        userId: user.id,
+        topic: `Stale attempt plan ${index}`,
+      });
+      const [attempt] = await db
+        .insert(generationAttempts)
+        .values({
+          planId: plan.id,
+          status: 'in_progress',
+          classification: null,
+          durationMs: 0,
+          modulesCount: 0,
+          tasksCount: 0,
+        })
+        .returning();
+      await db
+        .update(generationAttempts)
+        .set({ createdAt: staleCutoff })
+        .where(eq(generationAttempts.id, attempt.id));
+      attemptIds.push(attempt.id);
+    }
+
+    const result = await cleanupOrphanedAttempts(db, undefined, {
+      batchSize: 2,
+    });
+
+    expect(result.cleaned).toBe(2);
+
+    const rows = await db
+      .select({
+        id: generationAttempts.id,
+        status: generationAttempts.status,
+        classification: generationAttempts.classification,
+      })
+      .from(generationAttempts)
+      .where(inArray(generationAttempts.id, attemptIds));
+
+    const finalized = rows.filter((row) => row.classification === 'timeout');
+    const stillInProgress = rows.filter(
+      (row) => row.status === 'in_progress' && row.classification === null,
+    );
+
+    expect(finalized).toHaveLength(2);
+    expect(stillInProgress).toHaveLength(1);
+  });
 });

--- a/tests/integration/system/light/health-endpoint.test.ts
+++ b/tests/integration/system/light/health-endpoint.test.ts
@@ -4,17 +4,26 @@ import { JOB_TYPES } from '@/features/jobs/types';
 import { clearAllRateLimiters } from '@/lib/api/ip-rate-limit';
 import { jobQueue } from '@supabase/schema';
 import { db } from '@supabase/service-role';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * Creates a mock Request object for testing the health endpoint.
  * The health endpoint now requires a Request argument for IP-based rate limiting.
  */
-function createMockRequest(ip: string = '127.0.0.1'): Request {
+function createMockRequest(
+  ip: string = '127.0.0.1',
+  authToken?: string,
+): Request {
+  const headers: Record<string, string> = {
+    'x-forwarded-for': ip,
+  };
+
+  if (authToken) {
+    headers.authorization = `Bearer ${authToken}`;
+  }
+
   return new Request('http://localhost/api/health/worker', {
-    headers: {
-      'x-forwarded-for': ip,
-    },
+    headers,
   });
 }
 
@@ -26,6 +35,7 @@ describe('Health Endpoint', () => {
 
   afterEach(() => {
     clearAllRateLimiters();
+    vi.unstubAllEnvs();
   });
 
   describe('Healthy State', () => {
@@ -282,6 +292,30 @@ describe('Health Endpoint', () => {
       const now = new Date();
       const diffMs = now.getTime() - timestamp.getTime();
       expect(diffMs).toBeLessThan(60 * 1000); // within 1 minute
+    });
+  });
+
+  describe('Operator auth', () => {
+    it('returns 401 when a worker health token is configured but missing from the request', async () => {
+      vi.stubEnv('WORKER_HEALTH_TOKEN', 'configured-health-secret');
+
+      const response = await GET(createMockRequest());
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.code).toBe('UNAUTHORIZED');
+    });
+
+    it('accepts a matching bearer token when configured', async () => {
+      vi.stubEnv('WORKER_HEALTH_TOKEN', 'configured-health-secret');
+
+      const response = await GET(
+        createMockRequest('127.0.0.1', 'configured-health-secret'),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.status).toBe('healthy');
     });
   });
 });

--- a/tests/unit/components/ModuleLessonsClient.spec.tsx
+++ b/tests/unit/components/ModuleLessonsClient.spec.tsx
@@ -243,7 +243,7 @@ describe('ModuleLessonsClient', () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(refreshMock).not.toHaveBeenCalled();
+    expect(refreshMock).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       vi.advanceTimersByTime(2500);

--- a/tests/unit/components/ModuleLessonsClient.spec.tsx
+++ b/tests/unit/components/ModuleLessonsClient.spec.tsx
@@ -216,6 +216,42 @@ describe('ModuleLessonsClient', () => {
     expect(refreshMock.mock.calls.length).toBe(callsAfterTerminal);
   });
 
+  it('stops polling when status polling fails', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        mockJsonFetchResponse(
+          { error: { code: 'INTERNAL_ERROR', message: 'Unavailable' } },
+          { ok: false, status: 500 },
+        ),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderClient({
+      lessonGeneration: {
+        status: 'generating',
+        startedAt: new Date('2025-06-01T00:00:00.000Z'),
+        completedAt: null,
+        failedAt: null,
+        error: null,
+      },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(2500);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(refreshMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(2500);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('shows long-running notice and stops polling after max attempts', async () => {
     vi.useFakeTimers();
     const fetchMock = vi.fn().mockResolvedValue(

--- a/tests/unit/components/ModuleLessonsClient.spec.tsx
+++ b/tests/unit/components/ModuleLessonsClient.spec.tsx
@@ -11,6 +11,7 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 const PLAN_ID = randomUUID();
 const MODULE_ID = randomUUID();
 const GENERATE_URL = `/api/v1/plans/${PLAN_ID}/modules/${MODULE_ID}/lesson-content/generate`;
+const STATUS_URL = `/api/v1/plans/${PLAN_ID}/modules/${MODULE_ID}/lesson-content/status`;
 
 const refreshMock = vi.fn();
 const toastErrorMock = vi.mocked(toast.error);
@@ -149,8 +150,17 @@ describe('ModuleLessonsClient', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('shows generating state and schedules refresh', async () => {
+  it('shows generating state and polls status without refreshing', async () => {
     vi.useFakeTimers();
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockJsonFetchResponse({
+        planId: PLAN_ID,
+        moduleId: MODULE_ID,
+        status: 'generating',
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
     renderClient({
       lessonGeneration: {
         status: 'generating',
@@ -166,11 +176,57 @@ describe('ModuleLessonsClient', () => {
     await act(async () => {
       vi.advanceTimersByTime(2500);
     });
-    expect(refreshMock).toHaveBeenCalled();
+
+    expect(fetchMock).toHaveBeenCalledWith(STATUS_URL, { cache: 'no-store' });
+    expect(refreshMock).not.toHaveBeenCalled();
+  });
+
+  it('refreshes once when status polling returns ready', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockJsonFetchResponse({
+        planId: PLAN_ID,
+        moduleId: MODULE_ID,
+        status: 'ready',
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderClient({
+      lessonGeneration: {
+        status: 'generating',
+        startedAt: new Date('2025-06-01T00:00:00.000Z'),
+        completedAt: null,
+        failedAt: null,
+        error: null,
+      },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(2500);
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(STATUS_URL, { cache: 'no-store' });
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+
+    const callsAfterTerminal = refreshMock.mock.calls.length;
+    await act(async () => {
+      vi.advanceTimersByTime(2500);
+    });
+    expect(refreshMock.mock.calls.length).toBe(callsAfterTerminal);
   });
 
   it('shows long-running notice and stops polling after max attempts', async () => {
     vi.useFakeTimers();
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockJsonFetchResponse({
+        planId: PLAN_ID,
+        moduleId: MODULE_ID,
+        status: 'generating',
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
     renderClient({
       lessonGeneration: {
         status: 'generating',
@@ -195,11 +251,12 @@ describe('ModuleLessonsClient', () => {
       screen.getByText('Generation taking longer than expected'),
     ).toBeInTheDocument();
 
-    const callsAfterStop = refreshMock.mock.calls.length;
+    const callsAfterStop = fetchMock.mock.calls.length;
     await act(async () => {
       vi.advanceTimersByTime(2500);
     });
-    expect(refreshMock.mock.calls.length).toBe(callsAfterStop);
+    expect(fetchMock.mock.calls.length).toBe(callsAfterStop);
+    expect(refreshMock).not.toHaveBeenCalled();
   });
 
   it('shows failed generation copy from server and retry affordance', () => {

--- a/tests/unit/config/env.spec.ts
+++ b/tests/unit/config/env.spec.ts
@@ -625,6 +625,24 @@ describe('Environment Configuration', () => {
       expect(maintenance.planCleanupEnabled).toBe(true);
       expect(() => maintenance.workerToken).toThrow(EnvValidationError);
     });
+
+    it('requires a worker health token in production', () => {
+      vi.stubGlobal('window', undefined);
+      const maintenance = createMaintenanceEnvForTests({
+        NODE_ENV: 'production',
+      });
+
+      expect(() => maintenance.workerHealthToken).toThrow(EnvValidationError);
+    });
+
+    it('allows an optional worker health token outside production', () => {
+      vi.stubGlobal('window', undefined);
+      const maintenance = createMaintenanceEnvForTests({
+        NODE_ENV: 'test',
+      });
+
+      expect(maintenance.workerHealthToken).toBeUndefined();
+    });
   });
 
   describe('parseEnvNumber', () => {

--- a/tests/unit/features/plans/cleanup.spec.ts
+++ b/tests/unit/features/plans/cleanup.spec.ts
@@ -3,6 +3,7 @@ import type { DbClient } from '@/lib/db/types';
 import {
   cleanupOrphanedAttempts,
   cleanupStuckPlans,
+  ORPHANED_ATTEMPT_CLEANUP_BATCH_SIZE,
   ORPHANED_ATTEMPT_THRESHOLD_MS,
   STUCK_PLAN_CLEANUP_BATCH_SIZE,
   STUCK_PLAN_THRESHOLD_MS,
@@ -211,6 +212,11 @@ describe('cleanupOrphanedAttempts', () => {
     const result = await cleanupOrphanedAttempts(mockDb.client);
 
     expect(result.cleaned).toBe(5);
+    expect(mockDb.spies.transactionFn).toHaveBeenCalledTimes(1);
+    expect(mockDb.spies.selectFn).toHaveBeenCalledTimes(1);
+    expect(mockDb.spies.limitFn).toHaveBeenCalledWith(
+      ORPHANED_ATTEMPT_CLEANUP_BATCH_SIZE,
+    );
     expect(mockDb.spies.updateFn).toHaveBeenCalledTimes(1);
     expect(mockDb.spies.setFn).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -244,5 +250,27 @@ describe('cleanupOrphanedAttempts', () => {
     );
 
     expect(result.cleaned).toBe(2);
+  });
+
+  it('processes only one bounded batch per run', async () => {
+    mockDb = createMockDbClient(5);
+    mockDb.spies.returningFn.mockResolvedValue(
+      Array.from({ length: 2 }, (_, index) => ({ id: `id-${index}` })),
+    );
+
+    const result = await cleanupOrphanedAttempts(mockDb.client, undefined, {
+      batchSize: 2,
+    });
+
+    expect(result.cleaned).toBe(2);
+    expect(mockDb.spies.limitFn).toHaveBeenCalledWith(2);
+    expect(logger.warn).toHaveBeenCalledWith(
+      {
+        source: 'cleanup',
+        event: 'orphaned_attempts_cleanup_batch_full',
+        batchSize: 2,
+      },
+      'Plan cleanup filled its orphaned-attempt batch; backlog may remain',
+    );
   });
 });

--- a/tests/unit/features/plans/cleanup.spec.ts
+++ b/tests/unit/features/plans/cleanup.spec.ts
@@ -221,6 +221,7 @@ describe('cleanupOrphanedAttempts', () => {
     expect(mockDb.spies.setFn).toHaveBeenCalledWith(
       expect.objectContaining({
         classification: 'timeout',
+        status: 'failure',
       }),
     );
   });
@@ -272,5 +273,28 @@ describe('cleanupOrphanedAttempts', () => {
       },
       'Plan cleanup filled its orphaned-attempt batch; backlog may remain',
     );
+  });
+
+  it('throws when fewer orphaned attempts are finalized than locked', async () => {
+    mockDb = createMockDbClient(3);
+    mockDb.spies.returningFn.mockResolvedValue([
+      { id: 'id-0' },
+      { id: 'id-1' },
+    ]);
+
+    await expect(cleanupOrphanedAttempts(mockDb.client)).rejects.toThrow(
+      'Plan cleanup failed to finalize all locked orphaned attempts',
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'cleanup',
+        event: 'orphaned_attempts_cleanup_partial_failure',
+        expected: 3,
+        cleaned: 2,
+      }),
+      'Plan cleanup failed to finalize all locked orphaned attempts',
+    );
+    expect(logger.info).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/features/plans/write-service.spec.ts
+++ b/tests/unit/features/plans/write-service.spec.ts
@@ -1,0 +1,47 @@
+import { removePlanForWrite } from '@/features/plans/write-service';
+import { deletePlan } from '@/lib/db/queries/plans';
+import { createId } from '@tests/fixtures/ids';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/db/queries/plans', () => ({
+  deletePlan: vi.fn(),
+}));
+
+const mockDeletePlan = vi.mocked(deletePlan);
+
+describe('removePlanForWrite', () => {
+  const planId = createId('plan');
+  const userId = createId('user');
+  const dbClient = { tag: 'request-scoped-db' } as never;
+
+  beforeEach(() => {
+    mockDeletePlan.mockReset();
+  });
+
+  it('forwards the injected db client to deletePlan', async () => {
+    mockDeletePlan.mockResolvedValue({ success: true });
+
+    await removePlanForWrite({ planId, userId, dbClient });
+
+    expect(mockDeletePlan).toHaveBeenCalledWith(planId, userId, dbClient);
+  });
+
+  it('throws NotFoundError when deletePlan returns not_found', async () => {
+    mockDeletePlan.mockResolvedValue({ success: false, reason: 'not_found' });
+
+    await expect(
+      removePlanForWrite({ planId, userId, dbClient }),
+    ).rejects.toThrow('Learning plan not found.');
+  });
+
+  it('throws ConflictError when deletePlan returns currently_generating', async () => {
+    mockDeletePlan.mockResolvedValue({
+      success: false,
+      reason: 'currently_generating',
+    });
+
+    await expect(
+      removePlanForWrite({ planId, userId, dbClient }),
+    ).rejects.toThrow('Cannot delete a plan that is currently generating.');
+  });
+});

--- a/tests/unit/features/plans/write-service.spec.ts
+++ b/tests/unit/features/plans/write-service.spec.ts
@@ -12,26 +12,25 @@ const mockDeletePlan = vi.mocked(deletePlan);
 describe('removePlanForWrite', () => {
   const planId = createId('plan');
   const userId = createId('user');
-  const dbClient = { tag: 'request-scoped-db' } as never;
 
   beforeEach(() => {
     mockDeletePlan.mockReset();
   });
 
-  it('forwards the injected db client to deletePlan', async () => {
+  it('delegates to deletePlan with ownership context only', async () => {
     mockDeletePlan.mockResolvedValue({ success: true });
 
-    await removePlanForWrite({ planId, userId, dbClient });
+    await removePlanForWrite({ planId, userId });
 
-    expect(mockDeletePlan).toHaveBeenCalledWith(planId, userId, dbClient);
+    expect(mockDeletePlan).toHaveBeenCalledWith(planId, userId);
   });
 
   it('throws NotFoundError when deletePlan returns not_found', async () => {
     mockDeletePlan.mockResolvedValue({ success: false, reason: 'not_found' });
 
-    await expect(
-      removePlanForWrite({ planId, userId, dbClient }),
-    ).rejects.toThrow('Learning plan not found.');
+    await expect(removePlanForWrite({ planId, userId })).rejects.toThrow(
+      'Learning plan not found.',
+    );
   });
 
   it('throws ConflictError when deletePlan returns currently_generating', async () => {
@@ -40,8 +39,8 @@ describe('removePlanForWrite', () => {
       reason: 'currently_generating',
     });
 
-    await expect(
-      removePlanForWrite({ planId, userId, dbClient }),
-    ).rejects.toThrow('Cannot delete a plan that is currently generating.');
+    await expect(removePlanForWrite({ planId, userId })).rejects.toThrow(
+      'Cannot delete a plan that is currently generating.',
+    );
   });
 });

--- a/tests/unit/shared/lesson-content.schemas.spec.ts
+++ b/tests/unit/shared/lesson-content.schemas.spec.ts
@@ -3,6 +3,7 @@ import {
   ModuleLessonBatchProviderOutputSchema,
   ModuleLessonGenerationApiResponseSchema,
   ModuleLessonGenerationMetadataSchema,
+  ModuleLessonGenerationStatusResponseSchema,
 } from '@/shared/schemas/lesson-content.schemas';
 import {
   MAX_LESSON_BLOCK_TEXT_LENGTH,
@@ -259,6 +260,48 @@ describe('lesson content Zod contracts', () => {
         planId,
         moduleId,
         reason: 'disabled',
+      }),
+    ).toThrow();
+  });
+});
+
+describe('module lesson generation status response schema', () => {
+  it('accepts each persisted status', () => {
+    const planId = randomUUID();
+    const moduleId = randomUUID();
+
+    for (const status of [
+      'not_generated',
+      'generating',
+      'ready',
+      'failed',
+    ] as const) {
+      expect(
+        ModuleLessonGenerationStatusResponseSchema.parse({
+          planId,
+          moduleId,
+          status,
+        }),
+      ).toEqual({ planId, moduleId, status });
+    }
+  });
+
+  it('rejects unknown status values', () => {
+    expect(() =>
+      ModuleLessonGenerationStatusResponseSchema.parse({
+        planId: randomUUID(),
+        moduleId: randomUUID(),
+        status: 'processing',
+      }),
+    ).toThrow();
+  });
+
+  it('rejects invalid UUID params', () => {
+    expect(() =>
+      ModuleLessonGenerationStatusResponseSchema.parse({
+        planId: 'not-a-uuid',
+        moduleId: randomUUID(),
+        status: 'ready',
       }),
     ).toThrow();
   });


### PR DESCRIPTION
## Summary

- Hardens pre-prod maintenance paths: transactional plan cleanup batching, request-scoped DB usage in plan writes, and bearer-protected worker health endpoint with deploy/env docs.
- Implements audit follow-ups: PR integration selection modes (`full` / `related` / `light`) and module lesson generation status polling instead of repeated `router.refresh()` loops.
- Improves plan read performance by omitting lesson content from plan detail reads.
- Syncs `develop` with recent `main` changes: remove no-op trunk E2E lane, React Doctor CI, bootstrap worktree linking, and patched Workflow `esbuild` overrides.

## Test plan

- [x] CI passes on PR (`All Checks Passed (PR)`)
- [x] Verify module lesson generation polls `/lesson-content/status` and refreshes once on terminal status
- [x] Verify PR integration job selects `full` / `related` / `light` as documented
- [ ] Smoke-check worker health endpoint auth in staging (`WORKER_HEALTH_TOKEN`)
- [ ] Confirm trunk CI no longer schedules the removed E2E job after merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches operator health auth, maintenance cleanup transactions, and a new authenticated read API used by the lesson UI; changes are covered by integration/unit tests but staging verification of worker health auth is still called out in the PR test plan.
> 
> **Overview**
> Adds **`WORKER_HEALTH_TOKEN`** and gates **`GET /api/health/worker`** with the same internal bearer pattern as other worker routes, plus deploy/env documentation.
> 
> Module lesson **generation UI** now polls a new **`GET .../lesson-content/status`** endpoint (validated response schema) instead of repeatedly calling **`router.refresh()`** while status stays `generating`; it refreshes once on terminal status or on poll errors.
> 
> **Plan detail reads** stop selecting **`lessonContent`** / **`lessonContentUpdatedAt`** on tasks, with matching DTO/types so large JSON blobs are not loaded on the plan page.
> 
> **Orphaned generation-attempt cleanup** runs in a bounded, transactional batch (`SELECT … FOR UPDATE`, max 1000 per run) with stricter failure handling; **plan delete** write path no longer threads an explicit DB client through the route.
> 
> **PR CI** integration job picks **`related`**, **`full`**, or **`light`** based on changed files (global triggers or >50 TS files → full). **`@types/node`** moves to v22. Docs note **`LESSON_GENERATION_ENABLED`** for hosted deploys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa6add4d1ffe9b46697cea1991232a38a415caa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

