### PR TITLE
feat(ui): add liquid glass header shell across marketing and app routes

### DIFF
--- a/docs/styles/style-guide.md
+++ b/docs/styles/style-guide.md
@@ -55,7 +55,7 @@ All product colors should come from **semantic tokens** in `globals.css`. They a
 
 **App chrome:** use shared [`PageShell`](../../src/components/ui/page-shell.tsx), [`PageHeader`](../../src/components/ui/page-header.tsx), [`Surface`](../../src/components/ui/surface.tsx), and [`MetricCard`](../../src/components/ui/metric-card.tsx) on product routes. Reserve glass recipes (`backdrop-blur`, `bg-white/30`, high blur) for marketing/hero, not default dashboard content.
 
-**Site header variants:** [`header-shell.ts`](../../src/components/shared/nav/header-shell.ts) applies opaque `bg-card` / `border-border` on authenticated product routes and glass/blur only on marketing paths (`/`, `/landing`, `/about`, `/pricing`). [`BrandLogo`](../../src/components/shared/BrandLogo.tsx) defaults to solid `text-primary` in chrome to avoid theme hydration mismatch; use `variant="gradient"` only where client-only rendering is acceptable.
+**Site header variants:** [`header-shell.ts`](../../src/components/shared/nav/header-shell.ts) applies liquid glass to marketing paths (`/`, `/landing`, `/about`, `/pricing`) and protected app paths (`/dashboard`, `/plans`, `/settings`, `/analytics`, `/account`), while auth and other non-product shell routes stay opaque. [`BrandLogo`](../../src/components/shared/BrandLogo.tsx) defaults to solid `text-primary` in chrome to avoid theme hydration mismatch; use `variant="gradient"` only where client-only rendering is acceptable.
 
 **Marketing composition:** use [`MarketingPageShell`](../../src/app/(marketing)/_shared/MarketingPageShell.tsx), [`MarketingHero`](../../src/app/(marketing)/_shared/MarketingHero.tsx), [`MarketingSection`](../../src/app/(marketing)/_shared/MarketingSection.tsx), [`MarketingCard`](../../src/app/(marketing)/_shared/MarketingCard.tsx), and shared glass surfaces from [`marketing-glass-surface.ts`](../../src/app/(marketing)/_shared/marketing-glass-surface.ts). Default section width is `max-w-screen-xl`; narrower grids (e.g. pricing) may use `max-w-5xl` when layout requires it.
 
@@ -272,6 +272,64 @@ className =
 className =
   'rounded-full bg-white/20 px-3 py-1 text-xs font-medium text-white backdrop-blur-sm';
 ```
+
+### Liquid glass / refraction
+
+Liquid glass is a **separate visual layer** from glassmorphism. It refracts live DOM pixels through an SVG displacement lens instead of simulating depth with alpha and blur alone.
+
+| | Glassmorphism | Liquid glass |
+| -- | ------------- | ------------ |
+| Mechanism | Alpha + `backdrop-blur` + borders | SVG `feDisplacementMap` lens (`filter: url(#id)`) |
+| Default scope | Marketing cards, legacy fallback | Shared site header + opt-in CTAs |
+| Product UI | Never on `Surface` / dense shells | Header chrome only |
+
+**Do not use liquid glass on:**
+
+- `Surface` and other shared product shells
+- Dashboard, settings, and plan-generation page content
+- Dense forms, data tables, modals, or any UI where legibility and interaction density matter
+
+Header-only by default: site header chrome uses liquid glass on marketing routes and protected app routes (`/dashboard`, `/plans`, `/settings`, `/analytics`, and `/account`). Keep product page surfaces, cards, forms, and dense workflows opaque unless there is a separate design review.
+
+#### Import path
+
+```tsx
+import {
+  LiquidGlass,
+  MARKETING_CTA_PHYSICS,
+  MARKETING_HEADER_PHYSICS,
+  PRICING_HEADER_PHYSICS,
+} from '@/components/shared/liquid-glass';
+```
+
+Use `LiquidGlass` as a client wrapper around children. Pass `fallbackClassName` with the existing glassmorphism shell classes so reduced-motion and unsupported browsers degrade gracefully.
+
+#### Marketing presets
+
+| Preset | Constant | When to use |
+| ------ | -------- | ----------- |
+| Header (default) | `MARKETING_HEADER_PHYSICS` | Shared nav shell on marketing and protected app routes |
+| Header (subtle) | `PRICING_HEADER_PHYSICS` | `/pricing` — set `intensity="subtle"` on `LiquidGlass` |
+| CTA (opt-in) | `MARKETING_CTA_PHYSICS` | Button-sized lenses on marketing CTAs only |
+
+`intensity="subtle"` resolves to `PRICING_HEADER_PHYSICS` (lower `scale`, `chroma`, and edge highlight). Use it anywhere the header should read lighter than the default preset — today that is `/pricing`.
+
+Do **not** apply `intensity="subtle"` to product content UI or as a global default; it is a pricing-header tuning knob.
+
+#### Performance
+
+- Keep the SVG filter region **small and tight** — header bar bounds (~`max-w-7xl` × ~48–56px) or button-sized CTAs, not full-viewport areas.
+- **Never** attach full-viewport displacement filters to fixed chrome (nav, sticky bars). Scroll jank on iOS is the primary risk.
+- Regenerate the displacement map only on resize or physics changes, not on scroll or animation frames.
+- Prefer marketing presets over ad-hoc physics values; tune `scale` / `chroma` down if Safari or iOS shows jank.
+
+#### Accessibility and browser verification
+
+- **Reduced motion:** `LiquidGlass` skips the SVG filter when `prefers-reduced-motion: reduce` is set and renders children with `fallbackClassName` (static glassmorphism). Do not bypass this path.
+- **Contrast:** Verify header links, CTA labels, and borders in light and dark mode after enabling liquid glass. Refraction must not reduce text legibility below WCAG expectations for marketing or protected app routes.
+- **Safari / iOS:** Test shared site header and opt-in CTAs on Safari desktop and iOS Safari. Filter IDs refresh on map updates to avoid stale-cache bugs; still confirm no hydration mismatch and acceptable scroll performance on fixed header.
+
+When liquid glass is unavailable (feature detection) or disabled (reduced motion), fall back to the glassmorphism patterns in this section — do not leave transparent, unblurred chrome.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -129,7 +129,8 @@
       "serialize-javascript": "^7.0.3",
       "fast-uri": "^3.1.2",
       "kysely": "^0.28.17",
-      "undici": ">=7.24.0",
+      "piscina": "4.9.3",
+      "undici": "7.28.0",
       "devalue": ">=5.8.1"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,8 @@ overrides:
   serialize-javascript: ^7.0.3
   fast-uri: ^3.1.2
   kysely: ^0.28.17
-  undici: '>=7.24.0'
+  piscina: 4.9.3
+  undici: 7.28.0
   devalue: '>=5.8.1'
 
 importers:
@@ -5796,8 +5797,8 @@ packages:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
     hasBin: true
 
-  piscina@4.9.2:
-    resolution: {integrity: sha512-Fq0FERJWFEUpB4eSY59wSNwXD4RYqR+nR/WiEVcZW8IWfVBxJJafcgTEZDQo8k3w0sUarJ8RyVbbUF4GQ2LGbQ==}
+  piscina@4.9.3:
+    resolution: {integrity: sha512-3e3ka9QCE8RJ5I9uszdAADZnkcYi21cqmF3gxox3u884N72qpFHCsIVhHt8cEQ9t3Auq/NqoiCEuhxlxxQuDWA==}
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -6549,8 +6550,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.1.0:
@@ -9524,7 +9525,7 @@ snapshots:
       '@xhmikosr/bin-wrapper': 14.2.4
       commander: 8.3.0
       minimatch: 10.2.5
-      piscina: 4.9.2
+      piscina: 4.9.3
       semver: 7.7.4
       slash: 3.0.0
       source-map: 0.7.6
@@ -10243,7 +10244,7 @@ snapshots:
       '@workflow/world': 4.1.2(zod@4.3.6)
       async-sema: 3.1.1
       ulid: 3.0.2
-      undici: 7.25.0
+      undici: 7.28.0
       zod: 4.3.6
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -10255,7 +10256,7 @@ snapshots:
       '@workflow/errors': 4.1.2
       '@workflow/world': 4.1.2(zod@4.3.6)
       cbor-x: 1.6.0
-      undici: 7.25.0
+      undici: 7.28.0
       zod: 4.3.6
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -12206,7 +12207,7 @@ snapshots:
       sonic-boom: 4.2.1
       thread-stream: 4.0.0
 
-  piscina@4.9.2:
+  piscina@4.9.3:
     optionalDependencies:
       '@napi-rs/nice': 1.1.1
 
@@ -12985,7 +12986,7 @@ snapshots:
       ssh-remote-port-forward: 1.0.4
       tar-fs: 3.1.2
       tmp: 0.2.5
-      undici: 7.25.0
+      undici: 7.28.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -13106,7 +13107,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   unicorn-magic@0.1.0: {}
 

--- a/src/app/(app)/settings/components/SettingsSidebar.tsx
+++ b/src/app/(app)/settings/components/SettingsSidebar.tsx
@@ -42,10 +42,10 @@ export function SettingsSidebar(): React.ReactElement {
             href={item.href}
             aria-current={isActive ? 'page' : undefined}
             className={cn(
-              'flex items-center gap-3 rounded-md border border-transparent bg-sidebar px-3 py-2 text-sm font-medium transition-colors',
+              'flex items-center gap-3 rounded-md border border-transparent px-3 py-2 text-sm font-medium transition-colors',
               isActive
                 ? 'border-sidebar-border bg-sidebar-primary text-sidebar-primary-foreground'
-                : 'text-sidebar-foreground hover:border-sidebar-border hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+                : 'text-muted-foreground hover:bg-muted hover:text-foreground',
             )}
           >
             <Icon className='size-4 shrink-0' />

--- a/src/app/(marketing)/_shared/LiquidGlassButton.tsx
+++ b/src/app/(marketing)/_shared/LiquidGlassButton.tsx
@@ -17,6 +17,10 @@ const CTA_LENS_BORDER_RADIUS = 8;
 const CTA_FALLBACK_CLASS_NAME =
   'inline-flex rounded-lg border border-white/30 bg-primary/90 shadow-lg backdrop-blur-md dark:border-white/10';
 
+/** Semi-transparent surface so the liquid-glass layer remains visible through the CTA. */
+const LIQUID_GLASS_CTA_SURFACE_CLASS_NAME =
+  'border border-white/25 bg-primary/70 shadow-primary/20 hover:bg-primary/80 dark:border-white/10';
+
 type LiquidGlassButtonProps = ComponentProps<typeof Button>;
 
 /**
@@ -41,7 +45,11 @@ export function LiquidGlassButton({
         asChild={asChild}
         variant={variant}
         size={size}
-        className={cn(marketingPrimaryCtaClassName, className)}
+        className={cn(
+          marketingPrimaryCtaClassName,
+          LIQUID_GLASS_CTA_SURFACE_CLASS_NAME,
+          className,
+        )}
         {...props}
       />
     </LiquidGlass>

--- a/src/app/(marketing)/_shared/LiquidGlassButton.tsx
+++ b/src/app/(marketing)/_shared/LiquidGlassButton.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import type { ComponentProps } from 'react';
+
+import { marketingPrimaryCtaClassName } from '@/app/(marketing)/_shared/marketing-cta';
+import {
+  LiquidGlass,
+  MARKETING_CTA_PHYSICS,
+} from '@/components/shared/liquid-glass';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+/** Matches `rounded-lg` on marketing primary CTAs. */
+const CTA_LENS_BORDER_RADIUS = 8;
+
+/** Static glass fallback when displacement filters are unavailable. */
+const CTA_FALLBACK_CLASS_NAME =
+  'inline-flex rounded-lg border border-white/30 bg-primary/90 shadow-lg backdrop-blur-md dark:border-white/10';
+
+type LiquidGlassButtonProps = ComponentProps<typeof Button>;
+
+/**
+ * Marketing-only primary CTA with liquid-glass refraction.
+ * Wraps `Button` outside the interactive child so `asChild` + `Link` stay valid.
+ */
+export function LiquidGlassButton({
+  className,
+  variant = 'default',
+  size = 'default',
+  asChild = false,
+  ...props
+}: LiquidGlassButtonProps) {
+  return (
+    <LiquidGlass
+      lens={{ width: 0, height: 0, borderRadius: CTA_LENS_BORDER_RADIUS }}
+      physics={MARKETING_CTA_PHYSICS}
+      fallbackClassName={CTA_FALLBACK_CLASS_NAME}
+      className='inline-flex'
+    >
+      <Button
+        asChild={asChild}
+        variant={variant}
+        size={size}
+        className={cn(marketingPrimaryCtaClassName, className)}
+        {...props}
+      />
+    </LiquidGlass>
+  );
+}

--- a/src/app/(marketing)/_shared/MarketingCta.tsx
+++ b/src/app/(marketing)/_shared/MarketingCta.tsx
@@ -1,8 +1,7 @@
 import type { ReactNode } from 'react';
 
-import { marketingPrimaryCtaClassName } from '@/app/(marketing)/_shared/marketing-cta';
+import { LiquidGlassButton } from '@/app/(marketing)/_shared/LiquidGlassButton';
 import { MarketingCard } from '@/app/(marketing)/_shared/MarketingCard';
-import { Button } from '@/components/ui/button';
 import Link from 'next/link';
 
 interface MarketingCtaProps {
@@ -36,13 +35,9 @@ export function MarketingCta({
           <p className='marketing-subtitle mx-auto mb-6 max-w-xl lg:mb-10'>
             {description}
           </p>
-          <Button
-            asChild
-            variant='default'
-            className={marketingPrimaryCtaClassName}
-          >
+          <LiquidGlassButton asChild>
             <Link href={href}>{buttonLabel}</Link>
-          </Button>
+          </LiquidGlassButton>
         </MarketingCard>
       </div>
     </section>

--- a/src/app/(marketing)/landing/components/HeroSection.tsx
+++ b/src/app/(marketing)/landing/components/HeroSection.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { marketingPrimaryCtaClassName } from '@/app/(marketing)/_shared/marketing-cta';
+import { LiquidGlassButton } from '@/app/(marketing)/_shared/LiquidGlassButton';
 import { MarketingHero } from '@/app/(marketing)/_shared/MarketingHero';
 import { LandingHeroVisual } from '@/app/(marketing)/landing/components/LandingHeroVisual';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { ArrowRight } from 'lucide-react';
 import Link from 'next/link';
 import { useId } from 'react';
@@ -30,16 +29,12 @@ export function HeroSection() {
       }
       subtitle='Atlaris builds module-by-module roadmaps, attaches resources to each session, and syncs your study blocks to Google Calendar.'
       cta={
-        <Button
-          asChild
-          variant='default'
-          className={marketingPrimaryCtaClassName}
-        >
+        <LiquidGlassButton asChild>
           <Link href='/plans/new'>
             Get started free
             <ArrowRight className='ml-2 size-4 transition-transform group-hover:translate-x-1' />
           </Link>
-        </Button>
+        </LiquidGlassButton>
       }
       visual={<LandingHeroVisual />}
     />

--- a/src/components/shared/SiteHeader.tsx
+++ b/src/components/shared/SiteHeader.tsx
@@ -78,7 +78,7 @@ export default async function SiteHeader() {
 
   return (
     <header className='fixed top-0 left-0 z-50 w-full px-4 pt-3 lg:px-6 lg:pt-4'>
-      <div className='mx-auto max-w-7xl'>
+      <div className='mx-auto max-w-7xl overflow-hidden rounded-2xl'>
         <SiteHeaderChrome
           navItems={navItems}
           tier={tier}

--- a/src/components/shared/SiteHeader.tsx
+++ b/src/components/shared/SiteHeader.tsx
@@ -78,7 +78,7 @@ export default async function SiteHeader() {
 
   return (
     <header className='fixed top-0 left-0 z-50 w-full px-4 pt-3 lg:px-6 lg:pt-4'>
-      <div className='mx-auto max-w-7xl overflow-hidden rounded-2xl'>
+      <div className='mx-auto max-w-7xl'>
         <SiteHeaderChrome
           navItems={navItems}
           tier={tier}

--- a/src/components/shared/liquid-glass/LiquidGlass.tsx
+++ b/src/components/shared/liquid-glass/LiquidGlass.tsx
@@ -3,62 +3,16 @@
 import type { LiquidGlassProps } from './types';
 
 import { generateLensMap } from './generate-lens-map';
-import { resolveLiquidGlassPhysics } from './types';
-import { cn } from '@/lib/utils';
 import {
-  useEffect,
-  useId,
-  useMemo,
-  useRef,
-  useState,
-  type CSSProperties,
-} from 'react';
-
-const MIN_MEASURED_SIZE = 1;
-
-function supportsSvgDisplacementFilters(): boolean {
-  if (typeof window === 'undefined' || typeof document === 'undefined') {
-    return false;
-  }
-
-  return (
-    typeof SVGFEDisplacementMapElement !== 'undefined' &&
-    typeof SVGFEImageElement !== 'undefined'
-  );
-}
-
-function lensMapToDataUrl(
-  data: Uint8ClampedArray,
-  width: number,
-  height: number,
-): string {
-  const canvas = document.createElement('canvas');
-  canvas.width = width;
-  canvas.height = height;
-
-  const context = canvas.getContext('2d');
-  if (!context) {
-    return '';
-  }
-
-  const imageData = context.createImageData(width, height);
-  imageData.data.set(data);
-  context.putImageData(imageData, 0, 0);
-  return canvas.toDataURL();
-}
-
-function specularLightPosition(
-  angleDegrees: number,
-  width: number,
-  height: number,
-): { x: number; y: number; z: number } {
-  const radians = (angleDegrees * Math.PI) / 180;
-  return {
-    x: width / 2 + Math.cos(radians) * width,
-    y: height / 2 + Math.sin(radians) * height,
-    z: Math.max(width, height),
-  };
-}
+  buildMapSignature,
+  computeEffectiveLens,
+  lensMapToDataUrl,
+  specularLightPosition,
+} from './liquid-glass-utils';
+import { resolveLiquidGlassPhysics } from './types';
+import { useLiquidGlassRuntime } from './use-liquid-glass-runtime';
+import { cn } from '@/lib/utils';
+import { useEffect, useId, useRef, useState, type CSSProperties } from 'react';
 
 export function LiquidGlass({
   lens,
@@ -70,71 +24,21 @@ export function LiquidGlass({
 }: LiquidGlassProps) {
   const baseFilterId = useId();
   const containerRef = useRef<HTMLDivElement>(null);
-  const [filterRevision, setFilterRevision] = useState(0);
   const [measuredSize, setMeasuredSize] = useState({
     width: lens.width,
     height: lens.height,
   });
-  const [isMounted, setIsMounted] = useState(false);
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
-  const [isSupported, setIsSupported] = useState(true);
+  const { isMounted, isSupported, prefersReducedMotion } =
+    useLiquidGlassRuntime();
 
   const resolvedPhysics = resolveLiquidGlassPhysics(intensity, physics);
-
-  const effectiveLens = useMemo(
-    () => ({
-      width:
-        lens.width > 0
-          ? Math.round(lens.width)
-          : Math.max(MIN_MEASURED_SIZE, measuredSize.width),
-      height:
-        lens.height > 0
-          ? Math.round(lens.height)
-          : Math.max(MIN_MEASURED_SIZE, measuredSize.height),
-      borderRadius: Math.max(0, Math.round(lens.borderRadius)),
-    }),
-    [
-      lens.borderRadius,
-      lens.height,
-      lens.width,
-      measuredSize.height,
-      measuredSize.width,
-    ],
+  const effectiveLens = computeEffectiveLens(lens, measuredSize);
+  const mapResult = generateLensMap(effectiveLens, resolvedPhysics);
+  const mapSignature = buildMapSignature(
+    effectiveLens,
+    mapResult.scale,
+    mapResult.chromaAmount,
   );
-
-  const mapResult = useMemo(
-    () => generateLensMap(effectiveLens, resolvedPhysics),
-    [effectiveLens, resolvedPhysics],
-  );
-
-  const mapSignature = useMemo(
-    () =>
-      `${effectiveLens.width}:${effectiveLens.height}:${effectiveLens.borderRadius}:${mapResult.scale}:${mapResult.chromaAmount}`,
-    [
-      effectiveLens.borderRadius,
-      effectiveLens.height,
-      effectiveLens.width,
-      mapResult.chromaAmount,
-      mapResult.scale,
-    ],
-  );
-
-  useEffect(() => {
-    setIsMounted(true);
-    setIsSupported(supportsSvgDisplacementFilters());
-
-    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-    const syncReducedMotion = () => {
-      setPrefersReducedMotion(mediaQuery.matches);
-    };
-
-    syncReducedMotion();
-    mediaQuery.addEventListener('change', syncReducedMotion);
-
-    return () => {
-      mediaQuery.removeEventListener('change', syncReducedMotion);
-    };
-  }, []);
 
   useEffect(() => {
     const node = containerRef.current;
@@ -150,8 +54,8 @@ export function LiquidGlass({
 
       const { width, height } = entry.contentRect;
       setMeasuredSize({
-        width: Math.max(MIN_MEASURED_SIZE, Math.round(width)),
-        height: Math.max(MIN_MEASURED_SIZE, Math.round(height)),
+        width: Math.max(1, Math.round(width)),
+        height: Math.max(1, Math.round(height)),
       });
     });
 
@@ -162,29 +66,15 @@ export function LiquidGlass({
     };
   }, [lens.height, lens.width]);
 
-  useEffect(() => {
-    setFilterRevision((revision) => revision + 1);
-  }, [mapSignature]);
-
-  const displacementMapUrl = useMemo(() => {
-    if (!isMounted || prefersReducedMotion || !isSupported) {
-      return '';
-    }
-
-    return lensMapToDataUrl(mapResult.data, mapResult.width, mapResult.height);
-  }, [
-    isMounted,
-    isSupported,
-    mapResult.data,
-    mapResult.height,
-    mapResult.width,
-    prefersReducedMotion,
-  ]);
+  const displacementMapUrl =
+    isMounted && !prefersReducedMotion && isSupported
+      ? lensMapToDataUrl(mapResult.data, mapResult.width, mapResult.height)
+      : '';
 
   const useStaticFallback =
     !isMounted || prefersReducedMotion || !isSupported || !displacementMapUrl;
 
-  const filterId = `${baseFilterId}-liquid-glass-${filterRevision}`;
+  const filterId = `${baseFilterId}-liquid-glass-${mapSignature.replace(/:/g, '-')}`;
   const filterStyle: CSSProperties | undefined = useStaticFallback
     ? undefined
     : { filter: `url(#${filterId})` };

--- a/src/components/shared/liquid-glass/LiquidGlass.tsx
+++ b/src/components/shared/liquid-glass/LiquidGlass.tsx
@@ -2,18 +2,28 @@
 
 import type { LiquidGlassProps } from './types';
 
-import { generateLensMap } from './generate-lens-map';
+import { generateLensMap, getLensMapDataUrl } from './generate-lens-map';
 import {
   buildMapSignature,
   computeEffectiveLens,
-  lensMapToDataUrl,
   specularLightPosition,
 } from './liquid-glass-utils';
 import { resolveLiquidGlassPhysics } from './types';
 import { useLiquidGlassRuntime } from './use-liquid-glass-runtime';
 import { cn } from '@/lib/utils';
-import { useEffect, useId, useRef, useState, type CSSProperties } from 'react';
+import {
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+} from 'react';
 
+/**
+ * Wraps children with an SVG displacement filter for a liquid-glass lens effect.
+ * Falls back to static glassmorphism when filters, motion preferences, or sizing are unavailable.
+ */
 export function LiquidGlass({
   lens,
   physics,
@@ -41,6 +51,19 @@ export function LiquidGlass({
   const mapSignature = mapResult
     ? buildMapSignature(effectiveLens, mapResult.scale, mapResult.chromaAmount)
     : '';
+
+  useLayoutEffect(() => {
+    const node = containerRef.current;
+    if (!node || (lens.width > 0 && lens.height > 0)) return;
+
+    const { width, height } = node.getBoundingClientRect();
+    if (width <= 0 || height <= 0) return;
+
+    setMeasuredSize({
+      width: Math.max(1, Math.round(width)),
+      height: Math.max(1, Math.round(height)),
+    });
+  }, [lens.width, lens.height]);
 
   useEffect(() => {
     const node = containerRef.current;
@@ -72,12 +95,18 @@ export function LiquidGlass({
     };
   }, [lens.height, lens.width]);
 
-  const displacementMapUrl = mapResult
-    ? lensMapToDataUrl(mapResult.data, mapResult.width, mapResult.height)
-    : '';
+  const displacementMapUrl = mapResult ? getLensMapDataUrl(mapResult) : '';
+
+  const awaitingMeasurement =
+    (lens.width === 0 || lens.height === 0) &&
+    (measuredSize.width === 0 || measuredSize.height === 0);
 
   const useStaticFallback =
-    !isMounted || prefersReducedMotion || !isSupported || !displacementMapUrl;
+    !isMounted ||
+    prefersReducedMotion ||
+    !isSupported ||
+    !displacementMapUrl ||
+    awaitingMeasurement;
 
   const filterId = `${baseFilterId}-liquid-glass-${mapSignature.replace(/:/g, '-')}`;
   const filterStyle: CSSProperties | undefined = useStaticFallback

--- a/src/components/shared/liquid-glass/LiquidGlass.tsx
+++ b/src/components/shared/liquid-glass/LiquidGlass.tsx
@@ -39,16 +39,16 @@ export function LiquidGlass({
     ? generateLensMap(effectiveLens, resolvedPhysics)
     : null;
   const mapSignature = mapResult
-    ? buildMapSignature(
-        effectiveLens,
-        mapResult.scale,
-        mapResult.chromaAmount,
-      )
+    ? buildMapSignature(effectiveLens, mapResult.scale, mapResult.chromaAmount)
     : '';
 
   useEffect(() => {
     const node = containerRef.current;
-    if (!node || (lens.width > 0 && lens.height > 0)) {
+    if (
+      !node ||
+      typeof ResizeObserver === 'undefined' ||
+      (lens.width > 0 && lens.height > 0)
+    ) {
       return;
     }
 

--- a/src/components/shared/liquid-glass/LiquidGlass.tsx
+++ b/src/components/shared/liquid-glass/LiquidGlass.tsx
@@ -42,9 +42,12 @@ export function LiquidGlass({
     useLiquidGlassRuntime();
 
   const resolvedPhysics = resolveLiquidGlassPhysics(intensity, physics);
+  const awaitingMeasurement =
+    (lens.width === 0 || lens.height === 0) &&
+    (measuredSize.width === 0 || measuredSize.height === 0);
   const effectiveLens = computeEffectiveLens(lens, measuredSize);
   const shouldUseDynamicFilter =
-    isMounted && !prefersReducedMotion && isSupported;
+    isMounted && !prefersReducedMotion && isSupported && !awaitingMeasurement;
   const mapResult = shouldUseDynamicFilter
     ? generateLensMap(effectiveLens, resolvedPhysics)
     : null;
@@ -96,10 +99,6 @@ export function LiquidGlass({
   }, [lens.height, lens.width]);
 
   const displacementMapUrl = mapResult ? getLensMapDataUrl(mapResult) : '';
-
-  const awaitingMeasurement =
-    (lens.width === 0 || lens.height === 0) &&
-    (measuredSize.width === 0 || measuredSize.height === 0);
 
   const useStaticFallback =
     !isMounted ||

--- a/src/components/shared/liquid-glass/LiquidGlass.tsx
+++ b/src/components/shared/liquid-glass/LiquidGlass.tsx
@@ -33,12 +33,18 @@ export function LiquidGlass({
 
   const resolvedPhysics = resolveLiquidGlassPhysics(intensity, physics);
   const effectiveLens = computeEffectiveLens(lens, measuredSize);
-  const mapResult = generateLensMap(effectiveLens, resolvedPhysics);
-  const mapSignature = buildMapSignature(
-    effectiveLens,
-    mapResult.scale,
-    mapResult.chromaAmount,
-  );
+  const shouldUseDynamicFilter =
+    isMounted && !prefersReducedMotion && isSupported;
+  const mapResult = shouldUseDynamicFilter
+    ? generateLensMap(effectiveLens, resolvedPhysics)
+    : null;
+  const mapSignature = mapResult
+    ? buildMapSignature(
+        effectiveLens,
+        mapResult.scale,
+        mapResult.chromaAmount,
+      )
+    : '';
 
   useEffect(() => {
     const node = containerRef.current;
@@ -66,10 +72,9 @@ export function LiquidGlass({
     };
   }, [lens.height, lens.width]);
 
-  const displacementMapUrl =
-    isMounted && !prefersReducedMotion && isSupported
-      ? lensMapToDataUrl(mapResult.data, mapResult.width, mapResult.height)
-      : '';
+  const displacementMapUrl = mapResult
+    ? lensMapToDataUrl(mapResult.data, mapResult.width, mapResult.height)
+    : '';
 
   const useStaticFallback =
     !isMounted || prefersReducedMotion || !isSupported || !displacementMapUrl;
@@ -79,7 +84,10 @@ export function LiquidGlass({
     ? undefined
     : { filter: `url(#${filterId})` };
 
-  const chromaOffset = mapResult.chromaAmount;
+  const chromaOffset =
+    mapResult?.chromaAmount ??
+    Math.max(0, resolvedPhysics.chroma * resolvedPhysics.scale * 0.35);
+  const displacementScale = mapResult?.scale ?? resolvedPhysics.scale;
   const edgeHighlight = resolvedPhysics.edgeHighlight ?? 0;
   const specularAngle = resolvedPhysics.specularAngle ?? 135;
   const light = specularLightPosition(
@@ -118,7 +126,7 @@ export function LiquidGlass({
               <feDisplacementMap
                 in='SourceGraphic'
                 in2='displacementMap'
-                scale={mapResult.scale}
+                scale={displacementScale}
                 xChannelSelector='R'
                 yChannelSelector='G'
                 result='displaced'

--- a/src/components/shared/liquid-glass/LiquidGlass.tsx
+++ b/src/components/shared/liquid-glass/LiquidGlass.tsx
@@ -1,0 +1,360 @@
+'use client';
+
+import type { LiquidGlassProps } from './types';
+
+import { generateLensMap } from './generate-lens-map';
+import { resolveLiquidGlassPhysics } from './types';
+import { cn } from '@/lib/utils';
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+} from 'react';
+
+const MIN_MEASURED_SIZE = 1;
+
+function supportsSvgDisplacementFilters(): boolean {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return false;
+  }
+
+  return (
+    typeof SVGFEDisplacementMapElement !== 'undefined' &&
+    typeof SVGFEImageElement !== 'undefined'
+  );
+}
+
+function lensMapToDataUrl(
+  data: Uint8ClampedArray,
+  width: number,
+  height: number,
+): string {
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+
+  const context = canvas.getContext('2d');
+  if (!context) {
+    return '';
+  }
+
+  const imageData = context.createImageData(width, height);
+  imageData.data.set(data);
+  context.putImageData(imageData, 0, 0);
+  return canvas.toDataURL();
+}
+
+function specularLightPosition(
+  angleDegrees: number,
+  width: number,
+  height: number,
+): { x: number; y: number; z: number } {
+  const radians = (angleDegrees * Math.PI) / 180;
+  return {
+    x: width / 2 + Math.cos(radians) * width,
+    y: height / 2 + Math.sin(radians) * height,
+    z: Math.max(width, height),
+  };
+}
+
+export function LiquidGlass({
+  lens,
+  physics,
+  className,
+  fallbackClassName,
+  children,
+  intensity = 'default',
+}: LiquidGlassProps) {
+  const baseFilterId = useId();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [filterRevision, setFilterRevision] = useState(0);
+  const [measuredSize, setMeasuredSize] = useState({
+    width: lens.width,
+    height: lens.height,
+  });
+  const [isMounted, setIsMounted] = useState(false);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const [isSupported, setIsSupported] = useState(true);
+
+  const resolvedPhysics = resolveLiquidGlassPhysics(intensity, physics);
+
+  const effectiveLens = useMemo(
+    () => ({
+      width:
+        lens.width > 0
+          ? Math.round(lens.width)
+          : Math.max(MIN_MEASURED_SIZE, measuredSize.width),
+      height:
+        lens.height > 0
+          ? Math.round(lens.height)
+          : Math.max(MIN_MEASURED_SIZE, measuredSize.height),
+      borderRadius: Math.max(0, Math.round(lens.borderRadius)),
+    }),
+    [
+      lens.borderRadius,
+      lens.height,
+      lens.width,
+      measuredSize.height,
+      measuredSize.width,
+    ],
+  );
+
+  const mapResult = useMemo(
+    () => generateLensMap(effectiveLens, resolvedPhysics),
+    [effectiveLens, resolvedPhysics],
+  );
+
+  const mapSignature = useMemo(
+    () =>
+      `${effectiveLens.width}:${effectiveLens.height}:${effectiveLens.borderRadius}:${mapResult.scale}:${mapResult.chromaAmount}`,
+    [
+      effectiveLens.borderRadius,
+      effectiveLens.height,
+      effectiveLens.width,
+      mapResult.chromaAmount,
+      mapResult.scale,
+    ],
+  );
+
+  useEffect(() => {
+    setIsMounted(true);
+    setIsSupported(supportsSvgDisplacementFilters());
+
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const syncReducedMotion = () => {
+      setPrefersReducedMotion(mediaQuery.matches);
+    };
+
+    syncReducedMotion();
+    mediaQuery.addEventListener('change', syncReducedMotion);
+
+    return () => {
+      mediaQuery.removeEventListener('change', syncReducedMotion);
+    };
+  }, []);
+
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node || (lens.width > 0 && lens.height > 0)) {
+      return;
+    }
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) {
+        return;
+      }
+
+      const { width, height } = entry.contentRect;
+      setMeasuredSize({
+        width: Math.max(MIN_MEASURED_SIZE, Math.round(width)),
+        height: Math.max(MIN_MEASURED_SIZE, Math.round(height)),
+      });
+    });
+
+    observer.observe(node);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [lens.height, lens.width]);
+
+  useEffect(() => {
+    setFilterRevision((revision) => revision + 1);
+  }, [mapSignature]);
+
+  const displacementMapUrl = useMemo(() => {
+    if (!isMounted || prefersReducedMotion || !isSupported) {
+      return '';
+    }
+
+    return lensMapToDataUrl(mapResult.data, mapResult.width, mapResult.height);
+  }, [
+    isMounted,
+    isSupported,
+    mapResult.data,
+    mapResult.height,
+    mapResult.width,
+    prefersReducedMotion,
+  ]);
+
+  const useStaticFallback =
+    !isMounted || prefersReducedMotion || !isSupported || !displacementMapUrl;
+
+  const filterId = `${baseFilterId}-liquid-glass-${filterRevision}`;
+  const filterStyle: CSSProperties | undefined = useStaticFallback
+    ? undefined
+    : { filter: `url(#${filterId})` };
+
+  const chromaOffset = mapResult.chromaAmount;
+  const edgeHighlight = resolvedPhysics.edgeHighlight ?? 0;
+  const specularAngle = resolvedPhysics.specularAngle ?? 135;
+  const light = specularLightPosition(
+    specularAngle,
+    effectiveLens.width,
+    effectiveLens.height,
+  );
+
+  return (
+    <>
+      {isMounted && !useStaticFallback ? (
+        <svg
+          aria-hidden='true'
+          className='pointer-events-none absolute h-0 w-0 overflow-hidden'
+          focusable='false'
+        >
+          <defs>
+            <filter
+              id={filterId}
+              filterUnits='userSpaceOnUse'
+              x='0'
+              y='0'
+              width={effectiveLens.width}
+              height={effectiveLens.height}
+              colorInterpolationFilters='sRGB'
+            >
+              <feImage
+                href={displacementMapUrl}
+                x='0'
+                y='0'
+                width={effectiveLens.width}
+                height={effectiveLens.height}
+                preserveAspectRatio='none'
+                result='displacementMap'
+              />
+              <feDisplacementMap
+                in='SourceGraphic'
+                in2='displacementMap'
+                scale={mapResult.scale}
+                xChannelSelector='R'
+                yChannelSelector='G'
+                result='displaced'
+              />
+
+              {chromaOffset > 0 ? (
+                <>
+                  <feOffset
+                    in='displaced'
+                    dx={chromaOffset}
+                    dy={0}
+                    result='shiftedRed'
+                  />
+                  <feOffset
+                    in='displaced'
+                    dx={-chromaOffset}
+                    dy={0}
+                    result='shiftedBlue'
+                  />
+                  <feColorMatrix
+                    in='shiftedRed'
+                    type='matrix'
+                    values='1 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 1 0'
+                    result='redChannel'
+                  />
+                  <feColorMatrix
+                    in='displaced'
+                    type='matrix'
+                    values='0 0 0 0 0  0 1 0 0 0  0 0 0 0 0  0 0 0 1 0'
+                    result='greenChannel'
+                  />
+                  <feColorMatrix
+                    in='shiftedBlue'
+                    type='matrix'
+                    values='0 0 0 0 0  0 0 0 0 0  0 0 1 0 0  0 0 0 1 0'
+                    result='blueChannel'
+                  />
+                  <feBlend
+                    in='redChannel'
+                    in2='greenChannel'
+                    mode='screen'
+                    result='rg'
+                  />
+                  <feBlend
+                    in='rg'
+                    in2='blueChannel'
+                    mode='screen'
+                    result='chroma'
+                  />
+                </>
+              ) : (
+                <feMerge result='chroma'>
+                  <feMergeNode in='displaced' />
+                </feMerge>
+              )}
+
+              {edgeHighlight > 0 ? (
+                <>
+                  <feMorphology
+                    in='SourceAlpha'
+                    operator='dilate'
+                    radius={1}
+                    result='edgeMask'
+                  />
+                  <feGaussianBlur
+                    in='edgeMask'
+                    stdDeviation={edgeHighlight * 2}
+                    result='edgeBlur'
+                  />
+                  <feComponentTransfer in='edgeBlur' result='edgeGlow'>
+                    <feFuncA
+                      type='linear'
+                      slope={edgeHighlight}
+                      intercept={0}
+                    />
+                  </feComponentTransfer>
+                  <feBlend
+                    in='chroma'
+                    in2='edgeGlow'
+                    mode='screen'
+                    result='highlighted'
+                  />
+                </>
+              ) : (
+                <feMerge result='highlighted'>
+                  <feMergeNode in='chroma' />
+                </feMerge>
+              )}
+
+              {edgeHighlight > 0 ? (
+                <feSpecularLighting
+                  in='SourceAlpha'
+                  surfaceScale={edgeHighlight * 4}
+                  specularConstant={0.75}
+                  specularExponent={20}
+                  lightingColor='white'
+                  result='specular'
+                >
+                  <fePointLight x={light.x} y={light.y} z={light.z} />
+                </feSpecularLighting>
+              ) : null}
+
+              <feMerge>
+                <feMergeNode in='highlighted' />
+                {edgeHighlight > 0 ? <feMergeNode in='specular' /> : null}
+              </feMerge>
+            </filter>
+          </defs>
+        </svg>
+      ) : null}
+
+      <div
+        ref={containerRef}
+        data-slot='liquid-glass'
+        className={cn('relative isolate overflow-hidden', className)}
+      >
+        <div
+          aria-hidden='true'
+          className={cn(
+            'pointer-events-none absolute inset-0 -z-10',
+            fallbackClassName,
+          )}
+          style={filterStyle}
+        />
+        {children}
+      </div>
+    </>
+  );
+}

--- a/src/components/shared/liquid-glass/LiquidGlassLayer.tsx
+++ b/src/components/shared/liquid-glass/LiquidGlassLayer.tsx
@@ -32,12 +32,18 @@ export function LiquidGlassLayer({
 
   const resolvedPhysics = resolveLiquidGlassPhysics(intensity, physics);
   const effectiveLens = computeEffectiveLens(lens, measuredSize);
-  const mapResult = generateLensMap(effectiveLens, resolvedPhysics);
-  const mapSignature = buildMapSignature(
-    effectiveLens,
-    mapResult.scale,
-    mapResult.chromaAmount,
-  );
+  const shouldUseDynamicFilter =
+    isMounted && !prefersReducedMotion && isSupported;
+  const mapResult = shouldUseDynamicFilter
+    ? generateLensMap(effectiveLens, resolvedPhysics)
+    : null;
+  const mapSignature = mapResult
+    ? buildMapSignature(
+        effectiveLens,
+        mapResult.scale,
+        mapResult.chromaAmount,
+      )
+    : '';
 
   useEffect(() => {
     const node = layerRef.current;
@@ -65,10 +71,9 @@ export function LiquidGlassLayer({
     };
   }, [lens.height, lens.width]);
 
-  const displacementMapUrl =
-    isMounted && !prefersReducedMotion && isSupported
-      ? lensMapToDataUrl(mapResult.data, mapResult.width, mapResult.height)
-      : '';
+  const displacementMapUrl = mapResult
+    ? lensMapToDataUrl(mapResult.data, mapResult.width, mapResult.height)
+    : '';
 
   const useStaticFallback =
     !isMounted || prefersReducedMotion || !isSupported || !displacementMapUrl;
@@ -90,7 +95,10 @@ export function LiquidGlassLayer({
         filter: `url(#${filterId})`,
       };
 
-  const chromaOffset = mapResult.chromaAmount;
+  const chromaOffset =
+    mapResult?.chromaAmount ??
+    Math.max(0, resolvedPhysics.chroma * resolvedPhysics.scale * 0.35);
+  const displacementScale = mapResult?.scale ?? resolvedPhysics.scale;
   const edgeHighlight = resolvedPhysics.edgeHighlight ?? 0;
   const specularAngle = resolvedPhysics.specularAngle ?? 135;
   const light = specularLightPosition(
@@ -129,7 +137,7 @@ export function LiquidGlassLayer({
               <feDisplacementMap
                 in='SourceGraphic'
                 in2='displacementMap'
-                scale={mapResult.scale}
+                scale={displacementScale}
                 xChannelSelector='R'
                 yChannelSelector='G'
                 result='displaced'

--- a/src/components/shared/liquid-glass/LiquidGlassLayer.tsx
+++ b/src/components/shared/liquid-glass/LiquidGlassLayer.tsx
@@ -2,18 +2,27 @@
 
 import type { LiquidGlassLayerProps } from './types';
 
-import { generateLensMap } from './generate-lens-map';
+import { generateLensMap, getLensMapDataUrl } from './generate-lens-map';
 import {
   buildMapSignature,
   computeEffectiveLens,
-  lensMapToDataUrl,
   specularLightPosition,
 } from './liquid-glass-utils';
 import { resolveLiquidGlassPhysics } from './types';
 import { useLiquidGlassRuntime } from './use-liquid-glass-runtime';
 import { cn } from '@/lib/utils';
-import { useEffect, useId, useRef, useState, type CSSProperties } from 'react';
+import {
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+} from 'react';
 
+/**
+ * Decorative glass layer without children — use when interactive content sits in a sibling above the filter.
+ */
 export function LiquidGlassLayer({
   lens,
   physics,
@@ -40,6 +49,19 @@ export function LiquidGlassLayer({
   const mapSignature = mapResult
     ? buildMapSignature(effectiveLens, mapResult.scale, mapResult.chromaAmount)
     : '';
+
+  useLayoutEffect(() => {
+    const node = layerRef.current;
+    if (!node || (lens.width > 0 && lens.height > 0)) return;
+
+    const { width, height } = node.getBoundingClientRect();
+    if (width <= 0 || height <= 0) return;
+
+    setMeasuredSize({
+      width: Math.max(1, Math.round(width)),
+      height: Math.max(1, Math.round(height)),
+    });
+  }, [lens.width, lens.height]);
 
   useEffect(() => {
     const node = layerRef.current;
@@ -71,12 +93,18 @@ export function LiquidGlassLayer({
     };
   }, [lens.height, lens.width]);
 
-  const displacementMapUrl = mapResult
-    ? lensMapToDataUrl(mapResult.data, mapResult.width, mapResult.height)
-    : '';
+  const displacementMapUrl = mapResult ? getLensMapDataUrl(mapResult) : '';
+
+  const awaitingMeasurement =
+    (lens.width === 0 || lens.height === 0) &&
+    (measuredSize.width === 0 || measuredSize.height === 0);
 
   const useStaticFallback =
-    !isMounted || prefersReducedMotion || !isSupported || !displacementMapUrl;
+    !isMounted ||
+    prefersReducedMotion ||
+    !isSupported ||
+    !displacementMapUrl ||
+    awaitingMeasurement;
 
   const filterId = `${baseFilterId}-liquid-glass-layer-${mapSignature.replace(/:/g, '-')}`;
   const borderRadiusPx = effectiveLens.borderRadius;

--- a/src/components/shared/liquid-glass/LiquidGlassLayer.tsx
+++ b/src/components/shared/liquid-glass/LiquidGlassLayer.tsx
@@ -1,0 +1,367 @@
+'use client';
+
+import type { LiquidGlassLayerProps } from './types';
+
+import { generateLensMap } from './generate-lens-map';
+import { resolveLiquidGlassPhysics } from './types';
+import { cn } from '@/lib/utils';
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+} from 'react';
+
+const MIN_MEASURED_SIZE = 1;
+
+function supportsSvgDisplacementFilters(): boolean {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return false;
+  }
+
+  return (
+    typeof SVGFEDisplacementMapElement !== 'undefined' &&
+    typeof SVGFEImageElement !== 'undefined'
+  );
+}
+
+function lensMapToDataUrl(
+  data: Uint8ClampedArray,
+  width: number,
+  height: number,
+): string {
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+
+  const context = canvas.getContext('2d');
+  if (!context) {
+    return '';
+  }
+
+  const imageData = context.createImageData(width, height);
+  imageData.data.set(data);
+  context.putImageData(imageData, 0, 0);
+  return canvas.toDataURL();
+}
+
+function specularLightPosition(
+  angleDegrees: number,
+  width: number,
+  height: number,
+): { x: number; y: number; z: number } {
+  const radians = (angleDegrees * Math.PI) / 180;
+  return {
+    x: width / 2 + Math.cos(radians) * width,
+    y: height / 2 + Math.sin(radians) * height,
+    z: Math.max(width, height),
+  };
+}
+
+export function LiquidGlassLayer({
+  lens,
+  physics,
+  className,
+  fallbackClassName,
+  intensity = 'default',
+}: LiquidGlassLayerProps) {
+  const baseFilterId = useId();
+  const layerRef = useRef<HTMLDivElement>(null);
+  const [filterRevision, setFilterRevision] = useState(0);
+  const [measuredSize, setMeasuredSize] = useState({
+    width: lens.width,
+    height: lens.height,
+  });
+  const [isMounted, setIsMounted] = useState(false);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const [isSupported, setIsSupported] = useState(true);
+
+  const resolvedPhysics = resolveLiquidGlassPhysics(intensity, physics);
+
+  const effectiveLens = useMemo(
+    () => ({
+      width:
+        lens.width > 0
+          ? Math.round(lens.width)
+          : Math.max(MIN_MEASURED_SIZE, measuredSize.width),
+      height:
+        lens.height > 0
+          ? Math.round(lens.height)
+          : Math.max(MIN_MEASURED_SIZE, measuredSize.height),
+      borderRadius: Math.max(0, Math.round(lens.borderRadius)),
+    }),
+    [
+      lens.borderRadius,
+      lens.height,
+      lens.width,
+      measuredSize.height,
+      measuredSize.width,
+    ],
+  );
+
+  const mapResult = useMemo(
+    () => generateLensMap(effectiveLens, resolvedPhysics),
+    [effectiveLens, resolvedPhysics],
+  );
+
+  const mapSignature = useMemo(
+    () =>
+      `${effectiveLens.width}:${effectiveLens.height}:${effectiveLens.borderRadius}:${mapResult.scale}:${mapResult.chromaAmount}`,
+    [
+      effectiveLens.borderRadius,
+      effectiveLens.height,
+      effectiveLens.width,
+      mapResult.chromaAmount,
+      mapResult.scale,
+    ],
+  );
+
+  useEffect(() => {
+    setIsMounted(true);
+    setIsSupported(supportsSvgDisplacementFilters());
+
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const syncReducedMotion = () => {
+      setPrefersReducedMotion(mediaQuery.matches);
+    };
+
+    syncReducedMotion();
+    mediaQuery.addEventListener('change', syncReducedMotion);
+
+    return () => {
+      mediaQuery.removeEventListener('change', syncReducedMotion);
+    };
+  }, []);
+
+  useEffect(() => {
+    const node = layerRef.current;
+    if (!node || (lens.width > 0 && lens.height > 0)) {
+      return;
+    }
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) {
+        return;
+      }
+
+      const { width, height } = entry.contentRect;
+      setMeasuredSize({
+        width: Math.max(MIN_MEASURED_SIZE, Math.round(width)),
+        height: Math.max(MIN_MEASURED_SIZE, Math.round(height)),
+      });
+    });
+
+    observer.observe(node);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [lens.height, lens.width]);
+
+  useEffect(() => {
+    setFilterRevision((revision) => revision + 1);
+  }, [mapSignature]);
+
+  const displacementMapUrl = useMemo(() => {
+    if (!isMounted || prefersReducedMotion || !isSupported) {
+      return '';
+    }
+
+    return lensMapToDataUrl(mapResult.data, mapResult.width, mapResult.height);
+  }, [
+    isMounted,
+    isSupported,
+    mapResult.data,
+    mapResult.height,
+    mapResult.width,
+    prefersReducedMotion,
+  ]);
+
+  const useStaticFallback =
+    !isMounted || prefersReducedMotion || !isSupported || !displacementMapUrl;
+
+  const filterId = `${baseFilterId}-liquid-glass-layer-${filterRevision}`;
+  const borderRadiusPx = effectiveLens.borderRadius;
+  const roundedClipStyle: Pick<
+    CSSProperties,
+    'borderRadius' | 'clipPath' | 'contain'
+  > = {
+    borderRadius: borderRadiusPx,
+    clipPath: `inset(0 round ${borderRadiusPx}px)`,
+    contain: 'paint',
+  };
+  const filterStyle: CSSProperties | undefined = useStaticFallback
+    ? roundedClipStyle
+    : {
+        ...roundedClipStyle,
+        filter: `url(#${filterId})`,
+      };
+
+  const chromaOffset = mapResult.chromaAmount;
+  const edgeHighlight = resolvedPhysics.edgeHighlight ?? 0;
+  const specularAngle = resolvedPhysics.specularAngle ?? 135;
+  const light = specularLightPosition(
+    specularAngle,
+    effectiveLens.width,
+    effectiveLens.height,
+  );
+
+  return (
+    <>
+      {isMounted && !useStaticFallback ? (
+        <svg
+          aria-hidden='true'
+          className='pointer-events-none absolute h-0 w-0 overflow-hidden'
+          focusable='false'
+        >
+          <defs>
+            <filter
+              id={filterId}
+              filterUnits='userSpaceOnUse'
+              x='0'
+              y='0'
+              width={effectiveLens.width}
+              height={effectiveLens.height}
+              colorInterpolationFilters='sRGB'
+            >
+              <feImage
+                href={displacementMapUrl}
+                x='0'
+                y='0'
+                width={effectiveLens.width}
+                height={effectiveLens.height}
+                preserveAspectRatio='none'
+                result='displacementMap'
+              />
+              <feDisplacementMap
+                in='SourceGraphic'
+                in2='displacementMap'
+                scale={mapResult.scale}
+                xChannelSelector='R'
+                yChannelSelector='G'
+                result='displaced'
+              />
+
+              {chromaOffset > 0 ? (
+                <>
+                  <feOffset
+                    in='displaced'
+                    dx={chromaOffset}
+                    dy={0}
+                    result='shiftedRed'
+                  />
+                  <feOffset
+                    in='displaced'
+                    dx={-chromaOffset}
+                    dy={0}
+                    result='shiftedBlue'
+                  />
+                  <feColorMatrix
+                    in='shiftedRed'
+                    type='matrix'
+                    values='1 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 1 0'
+                    result='redChannel'
+                  />
+                  <feColorMatrix
+                    in='displaced'
+                    type='matrix'
+                    values='0 0 0 0 0  0 1 0 0 0  0 0 0 0 0  0 0 0 1 0'
+                    result='greenChannel'
+                  />
+                  <feColorMatrix
+                    in='shiftedBlue'
+                    type='matrix'
+                    values='0 0 0 0 0  0 0 0 0 0  0 0 1 0 0  0 0 0 1 0'
+                    result='blueChannel'
+                  />
+                  <feBlend
+                    in='redChannel'
+                    in2='greenChannel'
+                    mode='screen'
+                    result='rg'
+                  />
+                  <feBlend
+                    in='rg'
+                    in2='blueChannel'
+                    mode='screen'
+                    result='chroma'
+                  />
+                </>
+              ) : (
+                <feMerge result='chroma'>
+                  <feMergeNode in='displaced' />
+                </feMerge>
+              )}
+
+              {edgeHighlight > 0 ? (
+                <>
+                  <feMorphology
+                    in='SourceAlpha'
+                    operator='dilate'
+                    radius={1}
+                    result='edgeMask'
+                  />
+                  <feGaussianBlur
+                    in='edgeMask'
+                    stdDeviation={edgeHighlight * 2}
+                    result='edgeBlur'
+                  />
+                  <feComponentTransfer in='edgeBlur' result='edgeGlow'>
+                    <feFuncA
+                      type='linear'
+                      slope={edgeHighlight}
+                      intercept={0}
+                    />
+                  </feComponentTransfer>
+                  <feBlend
+                    in='chroma'
+                    in2='edgeGlow'
+                    mode='screen'
+                    result='highlighted'
+                  />
+                </>
+              ) : (
+                <feMerge result='highlighted'>
+                  <feMergeNode in='chroma' />
+                </feMerge>
+              )}
+
+              {edgeHighlight > 0 ? (
+                <feSpecularLighting
+                  in='SourceAlpha'
+                  surfaceScale={edgeHighlight * 4}
+                  specularConstant={0.75}
+                  specularExponent={20}
+                  lightingColor='white'
+                  result='specular'
+                >
+                  <fePointLight x={light.x} y={light.y} z={light.z} />
+                </feSpecularLighting>
+              ) : null}
+
+              <feMerge>
+                <feMergeNode in='highlighted' />
+                {edgeHighlight > 0 ? <feMergeNode in='specular' /> : null}
+              </feMerge>
+            </filter>
+          </defs>
+        </svg>
+      ) : null}
+
+      <div
+        ref={layerRef}
+        aria-hidden='true'
+        data-slot='liquid-glass-layer'
+        className={cn(
+          'pointer-events-none overflow-hidden',
+          fallbackClassName,
+          className,
+        )}
+        style={filterStyle}
+      />
+    </>
+  );
+}

--- a/src/components/shared/liquid-glass/LiquidGlassLayer.tsx
+++ b/src/components/shared/liquid-glass/LiquidGlassLayer.tsx
@@ -3,62 +3,16 @@
 import type { LiquidGlassLayerProps } from './types';
 
 import { generateLensMap } from './generate-lens-map';
-import { resolveLiquidGlassPhysics } from './types';
-import { cn } from '@/lib/utils';
 import {
-  useEffect,
-  useId,
-  useMemo,
-  useRef,
-  useState,
-  type CSSProperties,
-} from 'react';
-
-const MIN_MEASURED_SIZE = 1;
-
-function supportsSvgDisplacementFilters(): boolean {
-  if (typeof window === 'undefined' || typeof document === 'undefined') {
-    return false;
-  }
-
-  return (
-    typeof SVGFEDisplacementMapElement !== 'undefined' &&
-    typeof SVGFEImageElement !== 'undefined'
-  );
-}
-
-function lensMapToDataUrl(
-  data: Uint8ClampedArray,
-  width: number,
-  height: number,
-): string {
-  const canvas = document.createElement('canvas');
-  canvas.width = width;
-  canvas.height = height;
-
-  const context = canvas.getContext('2d');
-  if (!context) {
-    return '';
-  }
-
-  const imageData = context.createImageData(width, height);
-  imageData.data.set(data);
-  context.putImageData(imageData, 0, 0);
-  return canvas.toDataURL();
-}
-
-function specularLightPosition(
-  angleDegrees: number,
-  width: number,
-  height: number,
-): { x: number; y: number; z: number } {
-  const radians = (angleDegrees * Math.PI) / 180;
-  return {
-    x: width / 2 + Math.cos(radians) * width,
-    y: height / 2 + Math.sin(radians) * height,
-    z: Math.max(width, height),
-  };
-}
+  buildMapSignature,
+  computeEffectiveLens,
+  lensMapToDataUrl,
+  specularLightPosition,
+} from './liquid-glass-utils';
+import { resolveLiquidGlassPhysics } from './types';
+import { useLiquidGlassRuntime } from './use-liquid-glass-runtime';
+import { cn } from '@/lib/utils';
+import { useEffect, useId, useRef, useState, type CSSProperties } from 'react';
 
 export function LiquidGlassLayer({
   lens,
@@ -69,71 +23,21 @@ export function LiquidGlassLayer({
 }: LiquidGlassLayerProps) {
   const baseFilterId = useId();
   const layerRef = useRef<HTMLDivElement>(null);
-  const [filterRevision, setFilterRevision] = useState(0);
   const [measuredSize, setMeasuredSize] = useState({
     width: lens.width,
     height: lens.height,
   });
-  const [isMounted, setIsMounted] = useState(false);
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
-  const [isSupported, setIsSupported] = useState(true);
+  const { isMounted, isSupported, prefersReducedMotion } =
+    useLiquidGlassRuntime();
 
   const resolvedPhysics = resolveLiquidGlassPhysics(intensity, physics);
-
-  const effectiveLens = useMemo(
-    () => ({
-      width:
-        lens.width > 0
-          ? Math.round(lens.width)
-          : Math.max(MIN_MEASURED_SIZE, measuredSize.width),
-      height:
-        lens.height > 0
-          ? Math.round(lens.height)
-          : Math.max(MIN_MEASURED_SIZE, measuredSize.height),
-      borderRadius: Math.max(0, Math.round(lens.borderRadius)),
-    }),
-    [
-      lens.borderRadius,
-      lens.height,
-      lens.width,
-      measuredSize.height,
-      measuredSize.width,
-    ],
+  const effectiveLens = computeEffectiveLens(lens, measuredSize);
+  const mapResult = generateLensMap(effectiveLens, resolvedPhysics);
+  const mapSignature = buildMapSignature(
+    effectiveLens,
+    mapResult.scale,
+    mapResult.chromaAmount,
   );
-
-  const mapResult = useMemo(
-    () => generateLensMap(effectiveLens, resolvedPhysics),
-    [effectiveLens, resolvedPhysics],
-  );
-
-  const mapSignature = useMemo(
-    () =>
-      `${effectiveLens.width}:${effectiveLens.height}:${effectiveLens.borderRadius}:${mapResult.scale}:${mapResult.chromaAmount}`,
-    [
-      effectiveLens.borderRadius,
-      effectiveLens.height,
-      effectiveLens.width,
-      mapResult.chromaAmount,
-      mapResult.scale,
-    ],
-  );
-
-  useEffect(() => {
-    setIsMounted(true);
-    setIsSupported(supportsSvgDisplacementFilters());
-
-    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-    const syncReducedMotion = () => {
-      setPrefersReducedMotion(mediaQuery.matches);
-    };
-
-    syncReducedMotion();
-    mediaQuery.addEventListener('change', syncReducedMotion);
-
-    return () => {
-      mediaQuery.removeEventListener('change', syncReducedMotion);
-    };
-  }, []);
 
   useEffect(() => {
     const node = layerRef.current;
@@ -149,8 +53,8 @@ export function LiquidGlassLayer({
 
       const { width, height } = entry.contentRect;
       setMeasuredSize({
-        width: Math.max(MIN_MEASURED_SIZE, Math.round(width)),
-        height: Math.max(MIN_MEASURED_SIZE, Math.round(height)),
+        width: Math.max(1, Math.round(width)),
+        height: Math.max(1, Math.round(height)),
       });
     });
 
@@ -161,29 +65,15 @@ export function LiquidGlassLayer({
     };
   }, [lens.height, lens.width]);
 
-  useEffect(() => {
-    setFilterRevision((revision) => revision + 1);
-  }, [mapSignature]);
-
-  const displacementMapUrl = useMemo(() => {
-    if (!isMounted || prefersReducedMotion || !isSupported) {
-      return '';
-    }
-
-    return lensMapToDataUrl(mapResult.data, mapResult.width, mapResult.height);
-  }, [
-    isMounted,
-    isSupported,
-    mapResult.data,
-    mapResult.height,
-    mapResult.width,
-    prefersReducedMotion,
-  ]);
+  const displacementMapUrl =
+    isMounted && !prefersReducedMotion && isSupported
+      ? lensMapToDataUrl(mapResult.data, mapResult.width, mapResult.height)
+      : '';
 
   const useStaticFallback =
     !isMounted || prefersReducedMotion || !isSupported || !displacementMapUrl;
 
-  const filterId = `${baseFilterId}-liquid-glass-layer-${filterRevision}`;
+  const filterId = `${baseFilterId}-liquid-glass-layer-${mapSignature.replace(/:/g, '-')}`;
   const borderRadiusPx = effectiveLens.borderRadius;
   const roundedClipStyle: Pick<
     CSSProperties,

--- a/src/components/shared/liquid-glass/LiquidGlassLayer.tsx
+++ b/src/components/shared/liquid-glass/LiquidGlassLayer.tsx
@@ -38,16 +38,16 @@ export function LiquidGlassLayer({
     ? generateLensMap(effectiveLens, resolvedPhysics)
     : null;
   const mapSignature = mapResult
-    ? buildMapSignature(
-        effectiveLens,
-        mapResult.scale,
-        mapResult.chromaAmount,
-      )
+    ? buildMapSignature(effectiveLens, mapResult.scale, mapResult.chromaAmount)
     : '';
 
   useEffect(() => {
     const node = layerRef.current;
-    if (!node || (lens.width > 0 && lens.height > 0)) {
+    if (
+      !node ||
+      typeof ResizeObserver === 'undefined' ||
+      (lens.width > 0 && lens.height > 0)
+    ) {
       return;
     }
 

--- a/src/components/shared/liquid-glass/LiquidGlassLayer.tsx
+++ b/src/components/shared/liquid-glass/LiquidGlassLayer.tsx
@@ -40,9 +40,12 @@ export function LiquidGlassLayer({
     useLiquidGlassRuntime();
 
   const resolvedPhysics = resolveLiquidGlassPhysics(intensity, physics);
+  const awaitingMeasurement =
+    (lens.width === 0 || lens.height === 0) &&
+    (measuredSize.width === 0 || measuredSize.height === 0);
   const effectiveLens = computeEffectiveLens(lens, measuredSize);
   const shouldUseDynamicFilter =
-    isMounted && !prefersReducedMotion && isSupported;
+    isMounted && !prefersReducedMotion && isSupported && !awaitingMeasurement;
   const mapResult = shouldUseDynamicFilter
     ? generateLensMap(effectiveLens, resolvedPhysics)
     : null;
@@ -94,10 +97,6 @@ export function LiquidGlassLayer({
   }, [lens.height, lens.width]);
 
   const displacementMapUrl = mapResult ? getLensMapDataUrl(mapResult) : '';
-
-  const awaitingMeasurement =
-    (lens.width === 0 || lens.height === 0) &&
-    (measuredSize.width === 0 || measuredSize.height === 0);
 
   const useStaticFallback =
     !isMounted ||

--- a/src/components/shared/liquid-glass/generate-lens-map.ts
+++ b/src/components/shared/liquid-glass/generate-lens-map.ts
@@ -14,6 +14,7 @@ export type LensMapResult = {
 };
 
 const lensMapCache = new Map<string, LensMapResult>();
+const MAX_LENS_MAP_CACHE_ENTRIES = 32;
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
@@ -108,19 +109,26 @@ function buildCacheKey(
   lens: LiquidGlassLens,
   physics: LiquidGlassPhysics,
 ): string {
+  const width = Math.max(1, Math.round(lens.width));
+  const height = Math.max(1, Math.round(lens.height));
+  const borderRadius = Math.max(
+    0,
+    Math.min(
+      Math.round(lens.borderRadius),
+      Math.floor(width / 2),
+      Math.floor(height / 2),
+    ),
+  );
+
   return JSON.stringify({
-    width: Math.round(lens.width),
-    height: Math.round(lens.height),
-    borderRadius: Math.round(lens.borderRadius),
+    width,
+    height,
+    borderRadius,
     scale: Math.round(physics.scale),
     depth: Math.round(physics.depth * 100),
     curvature: Math.round(physics.curvature * 100),
     splay: Math.round(physics.splay * 100),
     chroma: Math.round(physics.chroma * 100),
-    blur: Math.round((physics.blur ?? 0) * 100),
-    glow: Math.round((physics.glow ?? 0) * 100),
-    edgeHighlight: Math.round((physics.edgeHighlight ?? 0) * 100),
-    specularAngle: Math.round(physics.specularAngle ?? 0),
   });
 }
 
@@ -210,6 +218,14 @@ export function generateLensMap(
   }
 
   const result = createLensMap(lens, resolvedPhysics);
+
+  if (lensMapCache.size >= MAX_LENS_MAP_CACHE_ENTRIES) {
+    const oldestKey = lensMapCache.keys().next().value;
+    if (oldestKey) {
+      lensMapCache.delete(oldestKey);
+    }
+  }
+
   lensMapCache.set(cacheKey, result);
   return result;
 }

--- a/src/components/shared/liquid-glass/generate-lens-map.ts
+++ b/src/components/shared/liquid-glass/generate-lens-map.ts
@@ -1,0 +1,215 @@
+import type { LiquidGlassLens, LiquidGlassPhysics } from './types';
+
+import { DEFAULT_LIQUID_GLASS_PHYSICS } from './types';
+
+const NEUTRAL_CHANNEL = 128;
+const NEUTRAL_ALPHA = 255;
+
+export type LensMapResult = {
+  width: number;
+  height: number;
+  data: Uint8ClampedArray;
+  scale: number;
+  chromaAmount: number;
+};
+
+const lensMapCache = new Map<string, LensMapResult>();
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function clampChannel(value: number): number {
+  return clamp(Math.round(value), 0, 255);
+}
+
+function mirrorChannel(value: number): number {
+  return clampChannel(256 - value);
+}
+
+function signedDistanceToRoundedRect(
+  px: number,
+  py: number,
+  width: number,
+  height: number,
+  radius: number,
+): number {
+  const r = Math.min(radius, width / 2, height / 2);
+  const cx = px + 0.5 - width / 2;
+  const cy = py + 0.5 - height / 2;
+  const halfW = width / 2;
+  const halfH = height / 2;
+
+  const qx = Math.abs(cx) - halfW + r;
+  const qy = Math.abs(cy) - halfH + r;
+  const outside = Math.hypot(Math.max(qx, 0), Math.max(qy, 0));
+  const inside = Math.min(Math.max(qx, qy), 0);
+
+  return outside + inside - r;
+}
+
+function computeQuadrantDisplacement(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  borderRadius: number,
+  physics: LiquidGlassPhysics,
+): { r: number; g: number } {
+  if (signedDistanceToRoundedRect(x, y, width, height, borderRadius) > 0) {
+    return { r: NEUTRAL_CHANNEL, g: NEUTRAL_CHANNEL };
+  }
+
+  const centerX = width / 2;
+  const centerY = height / 2;
+  const nx = (x + 0.5 - centerX) / centerX;
+  const ny = (y + 0.5 - centerY) / centerY;
+  const radiusSquared = nx * nx + ny * ny;
+
+  if (radiusSquared >= 1) {
+    return { r: NEUTRAL_CHANNEL, g: NEUTRAL_CHANNEL };
+  }
+
+  const { depth, curvature, scale, splay } = physics;
+  const cap = Math.pow(1 - radiusSquared, curvature);
+  const capDerivative =
+    curvature <= 0 || radiusSquared >= 1
+      ? 0
+      : -2 * curvature * Math.pow(1 - radiusSquared, curvature - 1);
+
+  const gradientX = depth * capDerivative * nx;
+  const gradientY = depth * capDerivative * ny;
+
+  const dx = scale * gradientX * centerX + splay * nx * cap;
+  const dy = scale * gradientY * centerY + splay * ny * cap;
+
+  return {
+    r: clampChannel(NEUTRAL_CHANNEL + dx),
+    g: clampChannel(NEUTRAL_CHANNEL + dy),
+  };
+}
+
+function writePixel(
+  data: Uint8ClampedArray,
+  width: number,
+  x: number,
+  y: number,
+  r: number,
+  g: number,
+): void {
+  const index = (y * width + x) * 4;
+  data[index] = r;
+  data[index + 1] = g;
+  data[index + 2] = NEUTRAL_CHANNEL;
+  data[index + 3] = NEUTRAL_ALPHA;
+}
+
+function buildCacheKey(
+  lens: LiquidGlassLens,
+  physics: LiquidGlassPhysics,
+): string {
+  return JSON.stringify({
+    width: Math.round(lens.width),
+    height: Math.round(lens.height),
+    borderRadius: Math.round(lens.borderRadius),
+    scale: Math.round(physics.scale),
+    depth: Math.round(physics.depth * 100),
+    curvature: Math.round(physics.curvature * 100),
+    splay: Math.round(physics.splay * 100),
+    chroma: Math.round(physics.chroma * 100),
+    blur: Math.round((physics.blur ?? 0) * 100),
+    glow: Math.round((physics.glow ?? 0) * 100),
+    edgeHighlight: Math.round((physics.edgeHighlight ?? 0) * 100),
+    specularAngle: Math.round(physics.specularAngle ?? 0),
+  });
+}
+
+function createLensMap(
+  lens: LiquidGlassLens,
+  physics: LiquidGlassPhysics,
+): LensMapResult {
+  const width = Math.max(1, Math.round(lens.width));
+  const height = Math.max(1, Math.round(lens.height));
+  const borderRadius = Math.max(0, Math.round(lens.borderRadius));
+  const data = new Uint8ClampedArray(width * height * 4);
+
+  for (let index = 0; index < data.length; index += 4) {
+    data[index] = NEUTRAL_CHANNEL;
+    data[index + 1] = NEUTRAL_CHANNEL;
+    data[index + 2] = NEUTRAL_CHANNEL;
+    data[index + 3] = NEUTRAL_ALPHA;
+  }
+
+  const halfWidth = Math.ceil(width / 2);
+  const halfHeight = Math.ceil(height / 2);
+  const mirrorX = (x: number) => width - 1 - x;
+  const mirrorY = (y: number) => height - 1 - y;
+
+  for (let y = 0; y < halfHeight; y += 1) {
+    for (let x = 0; x < halfWidth; x += 1) {
+      const { r, g } = computeQuadrantDisplacement(
+        x,
+        y,
+        width,
+        height,
+        borderRadius,
+        physics,
+      );
+
+      writePixel(data, width, x, y, r, g);
+
+      const flippedX = mirrorX(x);
+      if (flippedX !== x) {
+        writePixel(data, width, flippedX, y, mirrorChannel(r), g);
+      }
+
+      const flippedY = mirrorY(y);
+      if (flippedY !== y) {
+        writePixel(data, width, x, flippedY, r, mirrorChannel(g));
+      }
+
+      if (flippedX !== x && flippedY !== y) {
+        writePixel(
+          data,
+          width,
+          flippedX,
+          flippedY,
+          mirrorChannel(r),
+          mirrorChannel(g),
+        );
+      }
+    }
+  }
+
+  return {
+    width,
+    height,
+    data,
+    scale: physics.scale,
+    chromaAmount: Math.max(0, physics.chroma * physics.scale * 0.35),
+  };
+}
+
+export function clearLensMapCache(): void {
+  lensMapCache.clear();
+}
+
+export function generateLensMap(
+  lens: LiquidGlassLens,
+  physics: Partial<LiquidGlassPhysics> = {},
+): LensMapResult {
+  const resolvedPhysics: LiquidGlassPhysics = {
+    ...DEFAULT_LIQUID_GLASS_PHYSICS,
+    ...physics,
+  };
+  const cacheKey = buildCacheKey(lens, resolvedPhysics);
+  const cached = lensMapCache.get(cacheKey);
+
+  if (cached) {
+    return cached;
+  }
+
+  const result = createLensMap(lens, resolvedPhysics);
+  lensMapCache.set(cacheKey, result);
+  return result;
+}

--- a/src/components/shared/liquid-glass/generate-lens-map.ts
+++ b/src/components/shared/liquid-glass/generate-lens-map.ts
@@ -1,5 +1,6 @@
 import type { LiquidGlassLens, LiquidGlassPhysics } from './types';
 
+import { lensMapToDataUrl } from './liquid-glass-utils';
 import { DEFAULT_LIQUID_GLASS_PHYSICS } from './types';
 
 const NEUTRAL_CHANNEL = 128;
@@ -14,6 +15,7 @@ export type LensMapResult = {
 };
 
 const lensMapCache = new Map<string, LensMapResult>();
+const lensMapDataUrlCache = new WeakMap<LensMapResult, string>();
 const MAX_LENS_MAP_CACHE_ENTRIES = 32;
 
 function clamp(value: number, min: number, max: number): number {
@@ -198,10 +200,26 @@ function createLensMap(
   };
 }
 
+/** Clears the in-memory lens displacement map cache (for tests and hot reload). */
 export function clearLensMapCache(): void {
   lensMapCache.clear();
 }
 
+/** Returns a cached data URL for the RGB displacement map encoded in `result`. */
+export function getLensMapDataUrl(result: LensMapResult): string {
+  const cached = lensMapDataUrlCache.get(result);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const dataUrl = lensMapToDataUrl(result.data, result.width, result.height);
+  lensMapDataUrlCache.set(result, dataUrl);
+  return dataUrl;
+}
+
+/**
+ * Builds (or returns a cached) feDisplacementMap RGBA buffer for the given lens and physics.
+ */
 export function generateLensMap(
   lens: LiquidGlassLens,
   physics: Partial<LiquidGlassPhysics> = {},

--- a/src/components/shared/liquid-glass/index.ts
+++ b/src/components/shared/liquid-glass/index.ts
@@ -1,0 +1,18 @@
+export { LiquidGlass } from './LiquidGlass';
+export { LiquidGlassLayer } from './LiquidGlassLayer';
+export {
+  clearLensMapCache,
+  generateLensMap,
+  type LensMapResult,
+} from './generate-lens-map';
+export {
+  DEFAULT_LIQUID_GLASS_PHYSICS,
+  MARKETING_CTA_PHYSICS,
+  MARKETING_HEADER_PHYSICS,
+  PRICING_HEADER_PHYSICS,
+  resolveLiquidGlassPhysics,
+  type LiquidGlassLens,
+  type LiquidGlassLayerProps,
+  type LiquidGlassPhysics,
+  type LiquidGlassProps,
+} from './types';

--- a/src/components/shared/liquid-glass/index.ts
+++ b/src/components/shared/liquid-glass/index.ts
@@ -3,6 +3,7 @@ export { LiquidGlassLayer } from './LiquidGlassLayer';
 export {
   clearLensMapCache,
   generateLensMap,
+  getLensMapDataUrl,
   type LensMapResult,
 } from './generate-lens-map';
 export {

--- a/src/components/shared/liquid-glass/liquid-glass-utils.ts
+++ b/src/components/shared/liquid-glass/liquid-glass-utils.ts
@@ -2,6 +2,7 @@ import type { LiquidGlassLens } from './types';
 
 export const MIN_MEASURED_SIZE = 1;
 
+/** Resolves explicit lens dimensions or measured container size, with sane minimums. */
 export function computeEffectiveLens(
   lens: LiquidGlassLens,
   measuredSize: { width: number; height: number },
@@ -19,6 +20,7 @@ export function computeEffectiveLens(
   };
 }
 
+/** Stable cache key fragment for SVG filter ids derived from lens size and map parameters. */
 export function buildMapSignature(
   effectiveLens: LiquidGlassLens,
   scale: number,
@@ -27,6 +29,7 @@ export function buildMapSignature(
   return `${effectiveLens.width}:${effectiveLens.height}:${effectiveLens.borderRadius}:${scale}:${chromaAmount}`;
 }
 
+/** Encodes displacement map pixels as a PNG data URL for `feImage`. */
 export function lensMapToDataUrl(
   data: Uint8ClampedArray,
   width: number,
@@ -51,6 +54,7 @@ export function lensMapToDataUrl(
   return canvas.toDataURL();
 }
 
+/** Maps a specular highlight angle to `fePointLight` coordinates for the lens bounds. */
 export function specularLightPosition(
   angleDegrees: number,
   width: number,

--- a/src/components/shared/liquid-glass/liquid-glass-utils.ts
+++ b/src/components/shared/liquid-glass/liquid-glass-utils.ts
@@ -1,0 +1,61 @@
+import type { LiquidGlassLens } from './types';
+
+export const MIN_MEASURED_SIZE = 1;
+
+export function computeEffectiveLens(
+  lens: LiquidGlassLens,
+  measuredSize: { width: number; height: number },
+): LiquidGlassLens {
+  return {
+    width:
+      lens.width > 0
+        ? Math.round(lens.width)
+        : Math.max(MIN_MEASURED_SIZE, measuredSize.width),
+    height:
+      lens.height > 0
+        ? Math.round(lens.height)
+        : Math.max(MIN_MEASURED_SIZE, measuredSize.height),
+    borderRadius: Math.max(0, Math.round(lens.borderRadius)),
+  };
+}
+
+export function buildMapSignature(
+  effectiveLens: LiquidGlassLens,
+  scale: number,
+  chromaAmount: number,
+): string {
+  return `${effectiveLens.width}:${effectiveLens.height}:${effectiveLens.borderRadius}:${scale}:${chromaAmount}`;
+}
+
+export function lensMapToDataUrl(
+  data: Uint8ClampedArray,
+  width: number,
+  height: number,
+): string {
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+
+  const context = canvas.getContext('2d');
+  if (!context) {
+    return '';
+  }
+
+  const imageData = context.createImageData(width, height);
+  imageData.data.set(data);
+  context.putImageData(imageData, 0, 0);
+  return canvas.toDataURL();
+}
+
+export function specularLightPosition(
+  angleDegrees: number,
+  width: number,
+  height: number,
+): { x: number; y: number; z: number } {
+  const radians = (angleDegrees * Math.PI) / 180;
+  return {
+    x: width / 2 + Math.cos(radians) * width,
+    y: height / 2 + Math.sin(radians) * height,
+    z: Math.max(width, height),
+  };
+}

--- a/src/components/shared/liquid-glass/liquid-glass-utils.ts
+++ b/src/components/shared/liquid-glass/liquid-glass-utils.ts
@@ -32,6 +32,10 @@ export function lensMapToDataUrl(
   width: number,
   height: number,
 ): string {
+  if (typeof document === 'undefined') {
+    return '';
+  }
+
   const canvas = document.createElement('canvas');
   canvas.width = width;
   canvas.height = height;

--- a/src/components/shared/liquid-glass/types.ts
+++ b/src/components/shared/liquid-glass/types.ts
@@ -97,7 +97,9 @@ export function resolveLiquidGlassPhysics(
   overrides?: Partial<LiquidGlassPhysics>,
 ): LiquidGlassPhysics {
   const base =
-    intensity === 'subtle' ? PRICING_HEADER_PHYSICS : MARKETING_HEADER_PHYSICS;
+    intensity === 'subtle'
+      ? PRICING_HEADER_PHYSICS
+      : DEFAULT_LIQUID_GLASS_PHYSICS;
 
   return {
     ...base,

--- a/src/components/shared/liquid-glass/types.ts
+++ b/src/components/shared/liquid-glass/types.ts
@@ -92,6 +92,7 @@ export const MARKETING_CTA_PHYSICS: LiquidGlassPhysics = {
   specularAngle: 120,
 };
 
+/** Merges intensity preset physics with optional per-surface overrides. */
 export function resolveLiquidGlassPhysics(
   intensity: LiquidGlassProps['intensity'] = 'default',
   overrides?: Partial<LiquidGlassPhysics>,

--- a/src/components/shared/liquid-glass/types.ts
+++ b/src/components/shared/liquid-glass/types.ts
@@ -1,0 +1,106 @@
+export type LiquidGlassLens = {
+  width: number;
+  height: number;
+  borderRadius: number;
+};
+
+export type LiquidGlassPhysics = {
+  /** Refraction / displacement strength passed to feDisplacementMap. */
+  scale: number;
+  /** Lens dome depth (0–1). */
+  depth: number;
+  /** Spherical-cap exponent; higher = tighter center bulge. */
+  curvature: number;
+  /** Radial outward bias added to displacement. */
+  splay: number;
+  /** Chromatic fringe strength (0–1). */
+  chroma: number;
+  blur?: number;
+  glow?: number;
+  edgeHighlight?: number;
+  specularAngle?: number;
+};
+
+export type LiquidGlassProps = {
+  lens: LiquidGlassLens;
+  physics?: Partial<LiquidGlassPhysics>;
+  className?: string;
+  /** Static glassmorphism classes when reduced-motion or SVG filters are unavailable. */
+  fallbackClassName?: string;
+  children: React.ReactNode;
+  /** Lighter preset for /pricing and other subtle surfaces. */
+  intensity?: 'default' | 'subtle';
+};
+
+export type LiquidGlassLayerProps = Omit<LiquidGlassProps, 'children'> & {
+  /**
+   * Decorative layers should never own layout height. Keep clipping and filter
+   * bounds scoped to this layer rather than the interactive surface above it.
+   */
+  'aria-hidden'?: true;
+};
+
+/** Default physics merged with `intensity="default"` and partial overrides. */
+export const DEFAULT_LIQUID_GLASS_PHYSICS: LiquidGlassPhysics = {
+  scale: 24,
+  depth: 0.8,
+  curvature: 1.5,
+  splay: 2,
+  chroma: 0.15,
+  blur: 0,
+  glow: 0,
+  edgeHighlight: 0.4,
+  specularAngle: 135,
+};
+
+/** Marketing header shell — flat lens; uniform scrim + subtle edge refraction only. */
+export const MARKETING_HEADER_PHYSICS: LiquidGlassPhysics = {
+  scale: 8,
+  depth: 0.25,
+  curvature: 1,
+  splay: 0,
+  chroma: 0,
+  blur: 0,
+  glow: 0,
+  edgeHighlight: 0,
+  specularAngle: 135,
+};
+
+/** Lighter header preset for /pricing. */
+export const PRICING_HEADER_PHYSICS: LiquidGlassPhysics = {
+  scale: 6,
+  depth: 0.2,
+  curvature: 1,
+  splay: 0,
+  chroma: 0,
+  blur: 0,
+  glow: 0,
+  edgeHighlight: 0,
+  specularAngle: 135,
+};
+
+/** Small-lens preset for marketing CTAs (~button-sized regions). */
+export const MARKETING_CTA_PHYSICS: LiquidGlassPhysics = {
+  scale: 18,
+  depth: 0.6,
+  curvature: 1.8,
+  splay: 1.5,
+  chroma: 0.2,
+  blur: 0,
+  glow: 0.3,
+  edgeHighlight: 0.5,
+  specularAngle: 120,
+};
+
+export function resolveLiquidGlassPhysics(
+  intensity: LiquidGlassProps['intensity'] = 'default',
+  overrides?: Partial<LiquidGlassPhysics>,
+): LiquidGlassPhysics {
+  const base =
+    intensity === 'subtle' ? PRICING_HEADER_PHYSICS : MARKETING_HEADER_PHYSICS;
+
+  return {
+    ...base,
+    ...overrides,
+  };
+}

--- a/src/components/shared/liquid-glass/use-liquid-glass-runtime.ts
+++ b/src/components/shared/liquid-glass/use-liquid-glass-runtime.ts
@@ -43,6 +43,9 @@ function getSvgFilterSupportSnapshot(): boolean {
   );
 }
 
+/**
+ * Client runtime gate for liquid glass: hydration, SVG filter support, and reduced-motion preference.
+ */
 export function useLiquidGlassRuntime(): {
   isMounted: boolean;
   isSupported: boolean;

--- a/src/components/shared/liquid-glass/use-liquid-glass-runtime.ts
+++ b/src/components/shared/liquid-glass/use-liquid-glass-runtime.ts
@@ -1,0 +1,70 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+
+function noopSubscribe(): () => void {
+  return () => {};
+}
+
+function getPrefersReducedMotionSnapshot(): boolean {
+  if (
+    typeof window === 'undefined' ||
+    typeof window.matchMedia !== 'function'
+  ) {
+    return false;
+  }
+
+  return window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
+function subscribePrefersReducedMotion(onStoreChange: () => void): () => void {
+  if (
+    typeof window === 'undefined' ||
+    typeof window.matchMedia !== 'function'
+  ) {
+    return noopSubscribe();
+  }
+
+  const mediaQuery = window.matchMedia(REDUCED_MOTION_QUERY);
+  mediaQuery.addEventListener('change', onStoreChange);
+  return () => mediaQuery.removeEventListener('change', onStoreChange);
+}
+
+function getSvgFilterSupportSnapshot(): boolean {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return false;
+  }
+
+  return (
+    typeof SVGFEDisplacementMapElement !== 'undefined' &&
+    typeof SVGFEImageElement !== 'undefined'
+  );
+}
+
+export function useLiquidGlassRuntime(): {
+  isMounted: boolean;
+  isSupported: boolean;
+  prefersReducedMotion: boolean;
+} {
+  const isMounted = useSyncExternalStore(
+    noopSubscribe,
+    () => true,
+    () => false,
+  );
+
+  const isSupported = useSyncExternalStore(
+    noopSubscribe,
+    getSvgFilterSupportSnapshot,
+    () => false,
+  );
+
+  const prefersReducedMotion = useSyncExternalStore(
+    subscribePrefersReducedMotion,
+    getPrefersReducedMotionSnapshot,
+    () => false,
+  );
+
+  return { isMounted, isSupported, prefersReducedMotion };
+}

--- a/src/components/shared/nav/DesktopHeader.tsx
+++ b/src/components/shared/nav/DesktopHeader.tsx
@@ -1,12 +1,13 @@
 'use client';
 
+import type { HeaderShellVariant } from '@/components/shared/nav/header-shell';
 import type { NavItem } from '@/features/navigation';
 import type { SubscriptionTier } from '@/shared/types/billing.types';
 
 import AuthControls from '@/components/shared/AuthControls';
 import BrandLogo from '@/components/shared/BrandLogo';
 import DesktopNavigation from '@/components/shared/nav/DesktopNavigation';
-import { desktopHeaderShellClass } from '@/components/shared/nav/header-shell';
+import HeaderLiquidGlassShell from '@/components/shared/nav/HeaderLiquidGlassShell';
 import { ThemeToggle } from '@/components/shared/ThemeToggle';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
@@ -14,6 +15,7 @@ import { Plus } from 'lucide-react';
 import Link from 'next/link';
 
 interface DesktopHeaderProps {
+  headerVariant: HeaderShellVariant;
   pathname: string;
   navItems: NavItem[];
   tier?: SubscriptionTier;
@@ -27,26 +29,29 @@ interface DesktopHeaderProps {
  * Layout: brand (left) | navigation (center) | auth controls (right)
  */
 export default function DesktopHeader({
+  headerVariant,
   pathname,
   navItems,
   tier,
   isAuthenticated,
   showClerkUserButton,
 }: DesktopHeaderProps) {
-  return (
-    <div className={desktopHeaderShellClass(pathname)}>
+  const headerContent = (
+    <>
       {/* Brand (left) */}
-      <div className='flex items-center'>
+      <div className='relative z-10 flex items-center'>
         <BrandLogo />
       </div>
 
-      {/* Navigation (center) */}
-      <div className='flex justify-center'>
-        <DesktopNavigation pathname={pathname} navItems={navItems} />
+      {/* Navigation (visually centered in header bar) */}
+      <div className='pointer-events-none absolute left-1/2 z-10 flex -translate-x-1/2 items-center'>
+        <div className='pointer-events-auto'>
+          <DesktopNavigation pathname={pathname} navItems={navItems} />
+        </div>
       </div>
 
       {/* Auth controls (right) */}
-      <div className='flex items-center justify-end gap-1'>
+      <div className='relative z-10 flex items-center justify-end gap-1'>
         <Button
           variant='ghost'
           size='sm'
@@ -69,6 +74,12 @@ export default function DesktopHeader({
           showClerkUserButton={showClerkUserButton}
         />
       </div>
-    </div>
+    </>
+  );
+
+  return (
+    <HeaderLiquidGlassShell layout='desktop' variant={headerVariant}>
+      {headerContent}
+    </HeaderLiquidGlassShell>
   );
 }

--- a/src/components/shared/nav/DesktopHeader.tsx
+++ b/src/components/shared/nav/DesktopHeader.tsx
@@ -43,11 +43,9 @@ export default function DesktopHeader({
         <BrandLogo />
       </div>
 
-      {/* Navigation (visually centered in header bar) */}
-      <div className='pointer-events-none absolute left-1/2 z-10 flex -translate-x-1/2 items-center'>
-        <div className='pointer-events-auto'>
-          <DesktopNavigation pathname={pathname} navItems={navItems} />
-        </div>
+      {/* Navigation (center column) */}
+      <div className='relative z-10 flex min-w-0 justify-center'>
+        <DesktopNavigation pathname={pathname} navItems={navItems} />
       </div>
 
       {/* Auth controls (right) */}

--- a/src/components/shared/nav/DesktopNavigation.tsx
+++ b/src/components/shared/nav/DesktopNavigation.tsx
@@ -120,7 +120,7 @@ export default function DesktopNavigation({
   };
 
   return (
-    <nav className='hidden flex-nowrap items-center gap-6 md:flex'>
+    <nav className='hidden flex-nowrap items-center gap-4 md:flex lg:gap-6'>
       {navItems.map((item) => renderNavItem(item))}
     </nav>
   );

--- a/src/components/shared/nav/DesktopNavigation.tsx
+++ b/src/components/shared/nav/DesktopNavigation.tsx
@@ -30,7 +30,7 @@ interface DropdownNavItemProps {
  */
 function getNavItemClass(isActive: boolean): string {
   return cn(
-    'flex items-center gap-1 text-sm font-medium transition',
+    'flex shrink-0 items-center gap-1 whitespace-nowrap text-sm font-medium transition',
     'hover:text-primary dark:hover:text-primary',
     'focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none',
     isActive ? 'text-primary dark:text-primary' : 'text-muted-foreground',
@@ -120,7 +120,7 @@ export default function DesktopNavigation({
   };
 
   return (
-    <nav className='hidden items-center gap-6 md:flex'>
+    <nav className='hidden flex-nowrap items-center gap-6 md:flex'>
       {navItems.map((item) => renderNavItem(item))}
     </nav>
   );

--- a/src/components/shared/nav/HeaderLiquidGlassShell.tsx
+++ b/src/components/shared/nav/HeaderLiquidGlassShell.tsx
@@ -6,6 +6,7 @@ import {
   LiquidGlassLayer,
   MARKETING_HEADER_PHYSICS,
   PRICING_HEADER_PHYSICS,
+  type LiquidGlassPhysics,
 } from '@/components/shared/liquid-glass';
 import {
   desktopHeaderShellClass,
@@ -13,7 +14,6 @@ import {
   mobileHeaderShellClass,
   type HeaderShellLayout,
   type HeaderShellVariant,
-  usesLiquidGlassHeader,
 } from '@/components/shared/nav/header-shell';
 
 interface HeaderLiquidGlassShellProps {
@@ -21,6 +21,14 @@ interface HeaderLiquidGlassShellProps {
   layout: HeaderShellLayout;
   variant: HeaderShellVariant;
 }
+
+type GlassHeaderVariant = Exclude<HeaderShellVariant, 'opaque'>;
+
+const HEADER_VARIANT_PHYSICS: Record<GlassHeaderVariant, LiquidGlassPhysics> = {
+  marketing: MARKETING_HEADER_PHYSICS,
+  pricing: PRICING_HEADER_PHYSICS,
+  protected: MARKETING_HEADER_PHYSICS,
+};
 
 /**
  * Header layout shell that layers {@link LiquidGlassLayer} behind nav chrome on glass routes.
@@ -35,7 +43,7 @@ export default function HeaderLiquidGlassShell({
       ? desktopHeaderShellClass(variant)
       : mobileHeaderShellClass(variant);
 
-  if (!usesLiquidGlassHeader(variant)) {
+  if (variant === 'opaque') {
     return <div className={shellClassName}>{children}</div>;
   }
 
@@ -44,11 +52,7 @@ export default function HeaderLiquidGlassShell({
       <div className='pointer-events-none absolute inset-0 z-0 overflow-hidden rounded-2xl'>
         <LiquidGlassLayer
           lens={{ width: 0, height: 0, borderRadius: 16 }}
-          physics={
-            variant === 'pricing'
-              ? PRICING_HEADER_PHYSICS
-              : MARKETING_HEADER_PHYSICS
-          }
+          physics={HEADER_VARIANT_PHYSICS[variant]}
           fallbackClassName={headerGlassSurfaceClass(variant, layout)}
           className='size-full rounded-2xl'
         />

--- a/src/components/shared/nav/HeaderLiquidGlassShell.tsx
+++ b/src/components/shared/nav/HeaderLiquidGlassShell.tsx
@@ -22,6 +22,9 @@ interface HeaderLiquidGlassShellProps {
   variant: HeaderShellVariant;
 }
 
+/**
+ * Header layout shell that layers {@link LiquidGlassLayer} behind nav chrome on glass routes.
+ */
 export default function HeaderLiquidGlassShell({
   children,
   layout,

--- a/src/components/shared/nav/HeaderLiquidGlassShell.tsx
+++ b/src/components/shared/nav/HeaderLiquidGlassShell.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import { LiquidGlassLayer } from '@/components/shared/liquid-glass';
+import {
+  desktopHeaderShellClass,
+  headerGlassIntensity,
+  headerGlassSurfaceClass,
+  mobileHeaderShellClass,
+  type HeaderShellLayout,
+  type HeaderShellVariant,
+  usesLiquidGlassHeader,
+} from '@/components/shared/nav/header-shell';
+
+interface HeaderLiquidGlassShellProps {
+  children: ReactNode;
+  layout: HeaderShellLayout;
+  variant: HeaderShellVariant;
+}
+
+export default function HeaderLiquidGlassShell({
+  children,
+  layout,
+  variant,
+}: HeaderLiquidGlassShellProps) {
+  const shellClassName =
+    layout === 'desktop'
+      ? desktopHeaderShellClass(variant)
+      : mobileHeaderShellClass(variant);
+
+  if (!usesLiquidGlassHeader(variant)) {
+    return <div className={shellClassName}>{children}</div>;
+  }
+
+  return (
+    <div className={shellClassName}>
+      <div className='pointer-events-none absolute inset-0 z-0 overflow-hidden rounded-2xl'>
+        <LiquidGlassLayer
+          lens={{ width: 0, height: 0, borderRadius: 16 }}
+          intensity={headerGlassIntensity(variant)}
+          fallbackClassName={headerGlassSurfaceClass(variant, layout)}
+          className='size-full rounded-2xl'
+        />
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/components/shared/nav/HeaderLiquidGlassShell.tsx
+++ b/src/components/shared/nav/HeaderLiquidGlassShell.tsx
@@ -2,10 +2,13 @@
 
 import type { ReactNode } from 'react';
 
-import { LiquidGlassLayer } from '@/components/shared/liquid-glass';
+import {
+  LiquidGlassLayer,
+  MARKETING_HEADER_PHYSICS,
+  PRICING_HEADER_PHYSICS,
+} from '@/components/shared/liquid-glass';
 import {
   desktopHeaderShellClass,
-  headerGlassIntensity,
   headerGlassSurfaceClass,
   mobileHeaderShellClass,
   type HeaderShellLayout,
@@ -38,7 +41,11 @@ export default function HeaderLiquidGlassShell({
       <div className='pointer-events-none absolute inset-0 z-0 overflow-hidden rounded-2xl'>
         <LiquidGlassLayer
           lens={{ width: 0, height: 0, borderRadius: 16 }}
-          intensity={headerGlassIntensity(variant)}
+          physics={
+            variant === 'pricing'
+              ? PRICING_HEADER_PHYSICS
+              : MARKETING_HEADER_PHYSICS
+          }
           fallbackClassName={headerGlassSurfaceClass(variant, layout)}
           className='size-full rounded-2xl'
         />

--- a/src/components/shared/nav/MobileHeader.tsx
+++ b/src/components/shared/nav/MobileHeader.tsx
@@ -1,10 +1,11 @@
 'use client';
 
+import type { HeaderShellVariant } from '@/components/shared/nav/header-shell';
 import type { SubscriptionTier } from '@/shared/types/billing.types';
 
 import AuthControls from '@/components/shared/AuthControls';
 import BrandLogo from '@/components/shared/BrandLogo';
-import { mobileHeaderShellClass } from '@/components/shared/nav/header-shell';
+import HeaderLiquidGlassShell from '@/components/shared/nav/HeaderLiquidGlassShell';
 import MobileNavigation from '@/components/shared/nav/MobileNavigation';
 import { ThemeToggle } from '@/components/shared/ThemeToggle';
 import { Button } from '@/components/ui/button';
@@ -18,6 +19,7 @@ import { Plus } from 'lucide-react';
 import Link from 'next/link';
 
 interface MobileHeaderProps {
+  headerVariant: HeaderShellVariant;
   pathname: string;
   navItems: NavItem[];
   tier?: SubscriptionTier;
@@ -30,27 +32,32 @@ interface MobileHeaderProps {
  * shows inline nav links instead.
  */
 export default function MobileHeader({
+  headerVariant,
   pathname,
   navItems,
   tier,
   isAuthenticated,
   showClerkUserButton,
 }: MobileHeaderProps) {
-  return (
-    <div className={mobileHeaderShellClass(pathname)}>
-      <div className='flex shrink-0'>
-        <MobileNavigation pathname={pathname} navItems={navItems} />
+  const headerContent = (
+    <>
+      <div className='relative z-10 flex shrink-0'>
+        <MobileNavigation
+          headerVariant={headerVariant}
+          pathname={pathname}
+          navItems={navItems}
+        />
       </div>
 
-      <div className='flex min-w-0 items-center justify-center overflow-hidden' />
+      <div className='relative z-10 flex min-w-0 items-center justify-center overflow-hidden' />
 
-      <div className='pointer-events-none absolute left-1/2 flex -translate-x-1/2 items-center'>
+      <div className='pointer-events-none absolute left-1/2 z-10 flex -translate-x-1/2 items-center'>
         <div className='pointer-events-auto'>
           <BrandLogo size='sm' />
         </div>
       </div>
 
-      <div className='flex min-w-0 shrink-0 items-center gap-1'>
+      <div className='relative z-10 flex min-w-0 shrink-0 items-center gap-1'>
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
@@ -82,6 +89,12 @@ export default function MobileHeader({
           />
         </div>
       </div>
-    </div>
+    </>
+  );
+
+  return (
+    <HeaderLiquidGlassShell layout='mobile' variant={headerVariant}>
+      {headerContent}
+    </HeaderLiquidGlassShell>
   );
 }

--- a/src/components/shared/nav/MobileNavigation.tsx
+++ b/src/components/shared/nav/MobileNavigation.tsx
@@ -3,7 +3,10 @@
 import type { NavItem } from '@/features/navigation';
 
 import BrandLogo from '../BrandLogo';
-import { isMarketingHeaderPath } from '@/components/shared/nav/header-shell';
+import {
+  type HeaderShellVariant,
+  usesLiquidGlassHeader,
+} from '@/components/shared/nav/header-shell';
 import { isNavItemActive } from '@/components/shared/nav/nav-active';
 import { Button } from '@/components/ui/button';
 import {
@@ -22,6 +25,7 @@ import Link from 'next/link';
 import { useState } from 'react';
 
 interface MobileNavigationProps {
+  headerVariant: HeaderShellVariant;
   pathname: string;
   navItems: NavItem[];
 }
@@ -30,11 +34,12 @@ interface MobileNavigationProps {
  * Mobile navigation component with left-sliding sheet.
  */
 export default function MobileNavigation({
+  headerVariant,
   pathname,
   navItems,
 }: MobileNavigationProps) {
   const [open, setOpen] = useState(false);
-  const isMarketing = isMarketingHeaderPath(pathname);
+  const usesGlassHeader = usesLiquidGlassHeader(headerVariant);
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
@@ -45,7 +50,7 @@ export default function MobileNavigation({
             size='icon-sm'
             onClick={() => setOpen(true)}
             className={
-              isMarketing
+              usesGlassHeader
                 ? 'rounded-xl bg-white/40 text-muted-foreground shadow-sm backdrop-blur-sm transition-colors hover:bg-white/60 dark:bg-white/10 dark:hover:bg-white/20'
                 : 'rounded-xl bg-muted text-muted-foreground shadow-sm transition-colors hover:bg-muted/80'
             }
@@ -61,7 +66,7 @@ export default function MobileNavigation({
       <SheetContent
         side='left'
         className={
-          isMarketing
+          usesGlassHeader
             ? 'w-72 border-r border-white/30 bg-white/65 p-0 shadow-lg backdrop-blur-xl dark:border-white/10 dark:bg-card/55'
             : 'w-72 border-r border-border bg-card p-0 shadow-lg'
         }
@@ -104,7 +109,7 @@ export default function MobileNavigation({
                   className={`rounded-xl px-4 py-3 text-sm font-medium transition-colors ${
                     isActive
                       ? 'bg-primary text-white shadow-md'
-                      : isMarketing
+                      : usesGlassHeader
                         ? 'text-muted-foreground hover:bg-white/60 hover:text-primary dark:hover:bg-white/10 dark:hover:text-primary'
                         : 'text-muted-foreground hover:bg-muted hover:text-primary'
                   }`}

--- a/src/components/shared/nav/SiteHeaderChrome.tsx
+++ b/src/components/shared/nav/SiteHeaderChrome.tsx
@@ -4,6 +4,7 @@ import type { NavItem } from '@/features/navigation';
 import type { SubscriptionTier } from '@/shared/types/billing.types';
 
 import DesktopHeader from './DesktopHeader';
+import { getHeaderShellVariant } from './header-shell';
 import MobileHeader from './MobileHeader';
 import { usePathname } from 'next/navigation';
 
@@ -25,10 +26,12 @@ export default function SiteHeaderChrome({
   showClerkUserButton,
 }: SiteHeaderChromeProps) {
   const pathname = usePathname();
+  const headerVariant = getHeaderShellVariant(pathname);
 
   return (
     <>
       <MobileHeader
+        headerVariant={headerVariant}
         pathname={pathname}
         navItems={navItems}
         tier={tier}
@@ -36,6 +39,7 @@ export default function SiteHeaderChrome({
         showClerkUserButton={showClerkUserButton}
       />
       <DesktopHeader
+        headerVariant={headerVariant}
         pathname={pathname}
         navItems={navItems}
         tier={tier}

--- a/src/components/shared/nav/header-shell.ts
+++ b/src/components/shared/nav/header-shell.ts
@@ -14,7 +14,7 @@ const PRICING_SHELL_BORDER = 'border-white/25 dark:border-white/10';
 const PRICING_SHELL_SURFACE = 'bg-white/20 dark:bg-white/5';
 
 const GLASS_DESKTOP_STRUCTURE_BASE =
-  'relative hidden w-full isolate grid-cols-3 items-center overflow-hidden rounded-2xl border px-5 py-2.5 shadow-lg md:grid';
+  'relative hidden w-full isolate grid-cols-[auto_minmax(0,1fr)_auto] items-center overflow-hidden rounded-2xl border px-5 py-2.5 shadow-lg md:grid';
 
 const GLASS_DESKTOP_SURFACE =
   'rounded-2xl bg-white/20 backdrop-blur-sm dark:bg-white/10';
@@ -26,7 +26,7 @@ const GLASS_MOBILE_SURFACE =
   'rounded-2xl bg-white/20 backdrop-blur-sm dark:bg-white/10';
 
 const APP_DESKTOP_SHELL =
-  'hidden w-full grid-cols-3 items-center rounded-2xl border border-border bg-card px-5 py-2.5 shadow-sm md:grid';
+  'hidden w-full grid-cols-[auto_minmax(0,1fr)_auto] items-center rounded-2xl border border-border bg-card px-5 py-2.5 shadow-sm md:grid';
 
 const APP_MOBILE_SHELL =
   'relative grid w-full grid-cols-[auto_1fr_auto] items-center gap-2 rounded-2xl border border-border bg-card px-3 py-2 shadow-sm sm:px-4 sm:py-2.5 md:hidden';
@@ -43,6 +43,7 @@ function matchesPathOrDescendant(pathname: string, path: string): boolean {
   return pathname === path || pathname.startsWith(`${path}/`);
 }
 
+/** True for marketing surfaces that use the glass header shell (home, landing, about, pricing). */
 export function isMarketingHeaderPath(pathname: string): boolean {
   return (
     pathname === ROUTES.HOME ||
@@ -52,16 +53,19 @@ export function isMarketingHeaderPath(pathname: string): boolean {
   );
 }
 
+/** True when the pathname is the pricing route (subtle glass intensity). */
 export function isPricingPath(pathname: string): boolean {
   return pathname === ROUTES.PRICING;
 }
 
+/** True for authenticated app areas that use the protected glass header variant. */
 export function isProtectedHeaderPath(pathname: string): boolean {
   return PROTECTED_HEADER_PREFIXES.some((prefix) =>
     matchesPathOrDescendant(pathname, prefix),
   );
 }
 
+/** Maps the current pathname to a header shell variant for layout and glass presets. */
 export function getHeaderShellVariant(pathname: string): HeaderShellVariant {
   if (isPricingPath(pathname)) {
     return 'pricing';
@@ -78,10 +82,12 @@ export function getHeaderShellVariant(pathname: string): HeaderShellVariant {
   return 'opaque';
 }
 
+/** Whether the variant renders a liquid-glass layer instead of an opaque card shell. */
 export function usesLiquidGlassHeader(variant: HeaderShellVariant): boolean {
   return variant !== 'opaque';
 }
 
+/** Liquid-glass physics intensity preset for the header variant. */
 export function headerGlassIntensity(
   variant: HeaderShellVariant,
 ): 'default' | 'subtle' {
@@ -95,6 +101,7 @@ function glassShellBorderClass(variant: HeaderShellVariant): string {
   );
 }
 
+/** Tailwind surface classes for the glass scrim behind header content. */
 export function headerGlassSurfaceClass(
   variant: HeaderShellVariant,
   layout: HeaderShellLayout,
@@ -105,6 +112,7 @@ export function headerGlassSurfaceClass(
   return cn(surface, variant === 'pricing' && PRICING_SHELL_SURFACE);
 }
 
+/** Desktop header grid shell classes for the resolved variant. */
 export function desktopHeaderShellClass(variant: HeaderShellVariant): string {
   if (usesLiquidGlassHeader(variant)) {
     return cn(GLASS_DESKTOP_STRUCTURE_BASE, glassShellBorderClass(variant));
@@ -113,6 +121,7 @@ export function desktopHeaderShellClass(variant: HeaderShellVariant): string {
   return APP_DESKTOP_SHELL;
 }
 
+/** Mobile header grid shell classes for the resolved variant. */
 export function mobileHeaderShellClass(variant: HeaderShellVariant): string {
   if (usesLiquidGlassHeader(variant)) {
     return cn(GLASS_MOBILE_STRUCTURE_BASE, glassShellBorderClass(variant));

--- a/src/components/shared/nav/header-shell.ts
+++ b/src/components/shared/nav/header-shell.ts
@@ -14,13 +14,13 @@ const PRICING_SHELL_BORDER = 'border-white/25 dark:border-white/10';
 const PRICING_SHELL_SURFACE = 'bg-white/20 dark:bg-white/5';
 
 const GLASS_DESKTOP_STRUCTURE_BASE =
-  'relative hidden w-full isolate grid-cols-[auto_minmax(0,1fr)_auto] items-center overflow-hidden rounded-2xl border px-5 py-2.5 shadow-lg md:grid';
+  'relative hidden w-full isolate grid-cols-[auto_minmax(0,1fr)_auto] items-center rounded-2xl border px-5 py-2.5 shadow-lg md:grid';
 
 const GLASS_DESKTOP_SURFACE =
   'rounded-2xl bg-white/20 backdrop-blur-sm dark:bg-white/10';
 
 const GLASS_MOBILE_STRUCTURE_BASE =
-  'relative grid w-full isolate grid-cols-[auto_1fr_auto] items-center gap-2 overflow-hidden rounded-2xl border px-3 py-2 shadow-lg sm:px-4 sm:py-2.5 md:hidden';
+  'relative grid w-full isolate grid-cols-[auto_1fr_auto] items-center gap-2 rounded-2xl border px-3 py-2 shadow-lg sm:px-4 sm:py-2.5 md:hidden';
 
 const GLASS_MOBILE_SURFACE =
   'rounded-2xl bg-white/20 backdrop-blur-sm dark:bg-white/10';

--- a/src/components/shared/nav/header-shell.ts
+++ b/src/components/shared/nav/header-shell.ts
@@ -1,20 +1,47 @@
 import { ROUTES } from '@/features/navigation';
 import { cn } from '@/lib/utils';
 
-const PRICING_SHELL_OVERRIDE =
-  'border border-white/25 bg-white/20 shadow-lg backdrop-blur-xl dark:border-white/10 dark:bg-card/20';
+export type HeaderShellVariant =
+  | 'marketing'
+  | 'pricing'
+  | 'protected'
+  | 'opaque';
 
-const MARKETING_DESKTOP_SHELL =
-  'hidden w-full grid-cols-3 items-center rounded-2xl border border-white/40 bg-black/5 px-5 py-2.5 shadow-lg backdrop-blur-xl md:grid dark:border-white/10 dark:bg-card/50';
+export type HeaderShellLayout = 'desktop' | 'mobile';
+
+const PRICING_SHELL_BORDER = 'border-white/25 dark:border-white/10';
+
+const PRICING_SHELL_SURFACE = 'bg-white/20 dark:bg-white/5';
+
+const GLASS_DESKTOP_STRUCTURE_BASE =
+  'relative hidden w-full items-center justify-between overflow-hidden rounded-2xl border px-5 py-2.5 shadow-lg md:flex';
+
+const GLASS_DESKTOP_SURFACE =
+  'rounded-2xl bg-white/20 backdrop-blur-sm dark:bg-white/10';
+
+const GLASS_MOBILE_STRUCTURE_BASE =
+  'relative grid w-full isolate grid-cols-[auto_1fr_auto] items-center gap-2 overflow-hidden rounded-2xl border px-3 py-2 shadow-lg sm:px-4 sm:py-2.5 md:hidden';
+
+const GLASS_MOBILE_SURFACE =
+  'rounded-2xl bg-white/20 backdrop-blur-sm dark:bg-white/10';
 
 const APP_DESKTOP_SHELL =
-  'hidden w-full grid-cols-3 items-center rounded-2xl border border-border bg-card/95 px-5 py-2.5 shadow-sm md:grid dark:bg-card/95';
-
-const MARKETING_MOBILE_SHELL =
-  'relative grid w-full grid-cols-[auto_1fr_auto] items-center gap-2 rounded-2xl border border-white/40 bg-black/5 px-3 py-2 shadow-lg backdrop-blur-xl sm:px-4 sm:py-2.5 md:hidden dark:border-white/10 dark:bg-card/50';
+  'relative hidden w-full items-center justify-between rounded-2xl border border-border bg-card px-5 py-2.5 shadow-sm md:flex';
 
 const APP_MOBILE_SHELL =
-  'relative grid w-full grid-cols-[auto_1fr_auto] items-center gap-2 rounded-2xl border border-border bg-card/95 px-3 py-2 shadow-sm sm:px-4 sm:py-2.5 md:hidden dark:bg-card/95';
+  'relative grid w-full grid-cols-[auto_1fr_auto] items-center gap-2 rounded-2xl border border-border bg-card px-3 py-2 shadow-sm sm:px-4 sm:py-2.5 md:hidden';
+
+const PROTECTED_HEADER_PREFIXES = [
+  ROUTES.DASHBOARD,
+  ROUTES.PLANS.ROOT,
+  ROUTES.SETTINGS.ROOT,
+  ROUTES.ANALYTICS.ROOT,
+  '/account',
+] as const;
+
+function matchesPathOrDescendant(pathname: string, path: string): boolean {
+  return pathname === path || pathname.startsWith(`${path}/`);
+}
 
 export function isMarketingHeaderPath(pathname: string): boolean {
   return (
@@ -25,27 +52,70 @@ export function isMarketingHeaderPath(pathname: string): boolean {
   );
 }
 
-function isPricingPath(pathname: string): boolean {
+export function isPricingPath(pathname: string): boolean {
   return pathname === ROUTES.PRICING;
 }
 
-export function desktopHeaderShellClass(pathname: string): string {
+export function isProtectedHeaderPath(pathname: string): boolean {
+  return PROTECTED_HEADER_PREFIXES.some((prefix) =>
+    matchesPathOrDescendant(pathname, prefix),
+  );
+}
+
+export function getHeaderShellVariant(pathname: string): HeaderShellVariant {
+  if (isPricingPath(pathname)) {
+    return 'pricing';
+  }
+
   if (isMarketingHeaderPath(pathname)) {
-    return cn(
-      MARKETING_DESKTOP_SHELL,
-      isPricingPath(pathname) && PRICING_SHELL_OVERRIDE,
-    );
+    return 'marketing';
+  }
+
+  if (isProtectedHeaderPath(pathname)) {
+    return 'protected';
+  }
+
+  return 'opaque';
+}
+
+export function usesLiquidGlassHeader(variant: HeaderShellVariant): boolean {
+  return variant !== 'opaque';
+}
+
+export function headerGlassIntensity(
+  variant: HeaderShellVariant,
+): 'default' | 'subtle' {
+  return variant === 'pricing' ? 'subtle' : 'default';
+}
+
+function glassShellBorderClass(variant: HeaderShellVariant): string {
+  return cn(
+    'border-white/40 dark:border-white/15',
+    variant === 'pricing' && PRICING_SHELL_BORDER,
+  );
+}
+
+export function headerGlassSurfaceClass(
+  variant: HeaderShellVariant,
+  layout: HeaderShellLayout,
+): string {
+  const surface =
+    layout === 'desktop' ? GLASS_DESKTOP_SURFACE : GLASS_MOBILE_SURFACE;
+
+  return cn(surface, variant === 'pricing' && PRICING_SHELL_SURFACE);
+}
+
+export function desktopHeaderShellClass(variant: HeaderShellVariant): string {
+  if (usesLiquidGlassHeader(variant)) {
+    return cn(GLASS_DESKTOP_STRUCTURE_BASE, glassShellBorderClass(variant));
   }
 
   return APP_DESKTOP_SHELL;
 }
 
-export function mobileHeaderShellClass(pathname: string): string {
-  if (isMarketingHeaderPath(pathname)) {
-    return cn(
-      MARKETING_MOBILE_SHELL,
-      isPricingPath(pathname) && PRICING_SHELL_OVERRIDE,
-    );
+export function mobileHeaderShellClass(variant: HeaderShellVariant): string {
+  if (usesLiquidGlassHeader(variant)) {
+    return cn(GLASS_MOBILE_STRUCTURE_BASE, glassShellBorderClass(variant));
   }
 
   return APP_MOBILE_SHELL;

--- a/src/components/shared/nav/header-shell.ts
+++ b/src/components/shared/nav/header-shell.ts
@@ -14,7 +14,7 @@ const PRICING_SHELL_BORDER = 'border-white/25 dark:border-white/10';
 const PRICING_SHELL_SURFACE = 'bg-white/20 dark:bg-white/5';
 
 const GLASS_DESKTOP_STRUCTURE_BASE =
-  'relative hidden w-full items-center justify-between overflow-hidden rounded-2xl border px-5 py-2.5 shadow-lg md:flex';
+  'relative hidden w-full isolate grid-cols-3 items-center overflow-hidden rounded-2xl border px-5 py-2.5 shadow-lg md:grid';
 
 const GLASS_DESKTOP_SURFACE =
   'rounded-2xl bg-white/20 backdrop-blur-sm dark:bg-white/10';
@@ -26,7 +26,7 @@ const GLASS_MOBILE_SURFACE =
   'rounded-2xl bg-white/20 backdrop-blur-sm dark:bg-white/10';
 
 const APP_DESKTOP_SHELL =
-  'relative hidden w-full items-center justify-between rounded-2xl border border-border bg-card px-5 py-2.5 shadow-sm md:flex';
+  'hidden w-full grid-cols-3 items-center rounded-2xl border border-border bg-card px-5 py-2.5 shadow-sm md:grid';
 
 const APP_MOBILE_SHELL =
   'relative grid w-full grid-cols-[auto_1fr_auto] items-center gap-2 rounded-2xl border border-border bg-card px-3 py-2 shadow-sm sm:px-4 sm:py-2.5 md:hidden';

--- a/src/components/shared/nav/header-shell.ts
+++ b/src/components/shared/nav/header-shell.ts
@@ -47,7 +47,7 @@ function matchesPathOrDescendant(pathname: string, path: string): boolean {
 export function isMarketingHeaderPath(pathname: string): boolean {
   return (
     pathname === ROUTES.HOME ||
-    pathname === '/landing' ||
+    pathname === ROUTES.LANDING ||
     pathname === ROUTES.ABOUT ||
     pathname === ROUTES.PRICING
   );

--- a/src/features/navigation/routes.ts
+++ b/src/features/navigation/routes.ts
@@ -5,6 +5,7 @@
  */
 export const ROUTES = {
   HOME: '/',
+  LANDING: '/landing',
   DASHBOARD: '/dashboard',
   AUTH: {
     SIGN_IN: '/auth/sign-in',

--- a/tests/unit/components/liquid-glass/LiquidGlass.spec.tsx
+++ b/tests/unit/components/liquid-glass/LiquidGlass.spec.tsx
@@ -107,6 +107,11 @@ describe('LiquidGlass', () => {
 
   it('defers the displacement filter until the container has dimensions', () => {
     mockMotionPreference(false);
+    enableDynamicLiquidGlass();
+    const generateLensMapSpy = vi.spyOn(
+      generateLensMapModule,
+      'generateLensMap',
+    );
     vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
       width: 0,
       height: 0,
@@ -130,6 +135,7 @@ describe('LiquidGlass', () => {
     );
 
     expect(document.querySelector('filter')).toBeNull();
+    expect(generateLensMapSpy).not.toHaveBeenCalled();
   });
 
   it('updates auto-sized lenses when ResizeObserver reports a new size', () => {

--- a/tests/unit/components/liquid-glass/LiquidGlass.spec.tsx
+++ b/tests/unit/components/liquid-glass/LiquidGlass.spec.tsx
@@ -1,0 +1,74 @@
+import {
+  LiquidGlass,
+  LiquidGlassLayer,
+} from '@/components/shared/liquid-glass';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+function mockMotionPreference(matches: boolean): void {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+describe('LiquidGlass', () => {
+  it('keeps the decorative glass layer behind interactive content', () => {
+    mockMotionPreference(false);
+
+    render(
+      <LiquidGlass
+        lens={{ width: 32, height: 16, borderRadius: 8 }}
+        fallbackClassName='bg-white/40 backdrop-blur-sm'
+      >
+        <button type='button'>Open navigation</button>
+      </LiquidGlass>,
+    );
+
+    const button = screen.getByRole('button', { name: 'Open navigation' });
+    const shell = button.closest('[data-slot="liquid-glass"]');
+    const glassLayer = shell?.querySelector('[aria-hidden="true"]');
+
+    expect(button).toBeEnabled();
+    expect(glassLayer).toHaveClass(
+      'pointer-events-none',
+      'absolute',
+      'inset-0',
+      '-z-10',
+    );
+  });
+});
+
+describe('LiquidGlassLayer', () => {
+  it('renders as an inert decorative layer with fallback classes', () => {
+    mockMotionPreference(true);
+
+    render(
+      <LiquidGlassLayer
+        lens={{ width: 32, height: 16, borderRadius: 8 }}
+        fallbackClassName='bg-white/40 backdrop-blur-sm'
+        className='absolute inset-0 rounded-2xl'
+      />,
+    );
+
+    const layer = document.querySelector('[data-slot="liquid-glass-layer"]');
+
+    expect(layer).toHaveAttribute('aria-hidden', 'true');
+    expect(layer).toBeEmptyDOMElement();
+    expect(layer).toHaveClass(
+      'pointer-events-none',
+      'overflow-hidden',
+      'bg-white/40',
+      'backdrop-blur-sm',
+      'absolute',
+      'inset-0',
+      'rounded-2xl',
+    );
+  });
+});

--- a/tests/unit/components/liquid-glass/LiquidGlass.spec.tsx
+++ b/tests/unit/components/liquid-glass/LiquidGlass.spec.tsx
@@ -3,10 +3,10 @@ import {
   LiquidGlassLayer,
 } from '@/components/shared/liquid-glass';
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-function mockMotionPreference(matches: boolean): void {
-  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+function createMatchMediaMock(matches: boolean) {
+  return vi.fn().mockImplementation((query: string) => ({
     matches,
     media: query,
     onchange: null,
@@ -17,6 +17,14 @@ function mockMotionPreference(matches: boolean): void {
     dispatchEvent: vi.fn(),
   }));
 }
+
+function mockMotionPreference(matches: boolean): void {
+  vi.stubGlobal('matchMedia', createMatchMediaMock(matches));
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe('LiquidGlass', () => {
   it('keeps the decorative glass layer behind interactive content', () => {
@@ -42,6 +50,24 @@ describe('LiquidGlass', () => {
       'inset-0',
       '-z-10',
     );
+  });
+
+  it('falls back to static glass when matchMedia is unavailable', () => {
+    vi.stubGlobal('matchMedia', undefined);
+
+    render(
+      <LiquidGlass
+        lens={{ width: 32, height: 16, borderRadius: 8 }}
+        fallbackClassName='bg-white/40 backdrop-blur-sm'
+      >
+        <button type='button'>Open navigation</button>
+      </LiquidGlass>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Open navigation' }),
+    ).toBeEnabled();
+    expect(document.querySelector('filter')).toBeNull();
   });
 });
 

--- a/tests/unit/components/liquid-glass/LiquidGlass.spec.tsx
+++ b/tests/unit/components/liquid-glass/LiquidGlass.spec.tsx
@@ -1,6 +1,8 @@
 import {
+  DEFAULT_LIQUID_GLASS_PHYSICS,
   LiquidGlass,
   LiquidGlassLayer,
+  resolveLiquidGlassPhysics,
 } from '@/components/shared/liquid-glass';
 import { render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -95,6 +97,14 @@ describe('LiquidGlassLayer', () => {
       'absolute',
       'inset-0',
       'rounded-2xl',
+    );
+  });
+});
+
+describe('resolveLiquidGlassPhysics', () => {
+  it('uses the default preset for intensity="default"', () => {
+    expect(resolveLiquidGlassPhysics('default')).toEqual(
+      DEFAULT_LIQUID_GLASS_PHYSICS,
     );
   });
 });

--- a/tests/unit/components/liquid-glass/LiquidGlass.spec.tsx
+++ b/tests/unit/components/liquid-glass/LiquidGlass.spec.tsx
@@ -2,9 +2,11 @@ import {
   DEFAULT_LIQUID_GLASS_PHYSICS,
   LiquidGlass,
   LiquidGlassLayer,
+  PRICING_HEADER_PHYSICS,
   resolveLiquidGlassPhysics,
 } from '@/components/shared/liquid-glass';
-import { render, screen } from '@testing-library/react';
+import * as generateLensMapModule from '@/components/shared/liquid-glass/generate-lens-map';
+import { act, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 function createMatchMediaMock(matches: boolean) {
@@ -24,8 +26,17 @@ function mockMotionPreference(matches: boolean): void {
   vi.stubGlobal('matchMedia', createMatchMediaMock(matches));
 }
 
+function enableDynamicLiquidGlass(): void {
+  vi.stubGlobal('SVGFEDisplacementMapElement', class {});
+  vi.stubGlobal('SVGFEImageElement', class {});
+  vi.spyOn(generateLensMapModule, 'getLensMapDataUrl').mockReturnValue(
+    'data:image/png;base64,mock',
+  );
+}
+
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe('LiquidGlass', () => {
@@ -71,6 +82,98 @@ describe('LiquidGlass', () => {
     ).toBeEnabled();
     expect(document.querySelector('filter')).toBeNull();
   });
+
+  it('renders the SVG displacement filter when motion is allowed', () => {
+    mockMotionPreference(false);
+    enableDynamicLiquidGlass();
+
+    render(
+      <LiquidGlass
+        lens={{ width: 32, height: 16, borderRadius: 8 }}
+        fallbackClassName='bg-white/40 backdrop-blur-sm'
+      >
+        <button type='button'>Open navigation</button>
+      </LiquidGlass>,
+    );
+
+    expect(document.querySelector('feDisplacementMap')).not.toBeNull();
+    const glassLayer = screen
+      .getByRole('button', { name: 'Open navigation' })
+      .closest('[data-slot="liquid-glass"]')
+      ?.querySelector('[aria-hidden="true"]') as HTMLElement | null;
+
+    expect(glassLayer?.style.filter).toMatch(/^url\(#/);
+  });
+
+  it('defers the displacement filter until the container has dimensions', () => {
+    mockMotionPreference(false);
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      width: 0,
+      height: 0,
+      top: 0,
+      left: 0,
+      bottom: 0,
+      right: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+
+    render(
+      <LiquidGlass
+        lens={{ width: 0, height: 0, borderRadius: 8 }}
+        fallbackClassName='bg-white/40 backdrop-blur-sm'
+        className='h-16 w-32'
+      >
+        <button type='button'>Open navigation</button>
+      </LiquidGlass>,
+    );
+
+    expect(document.querySelector('filter')).toBeNull();
+  });
+
+  it('updates auto-sized lenses when ResizeObserver reports a new size', () => {
+    mockMotionPreference(false);
+    enableDynamicLiquidGlass();
+
+    let observerCallback: ResizeObserverCallback | undefined;
+    class TestResizeObserver {
+      observe() {}
+
+      unobserve() {}
+
+      disconnect() {}
+
+      constructor(callback: ResizeObserverCallback) {
+        observerCallback = callback;
+      }
+    }
+
+    vi.stubGlobal('ResizeObserver', TestResizeObserver);
+
+    render(
+      <LiquidGlass
+        lens={{ width: 0, height: 0, borderRadius: 8 }}
+        fallbackClassName='bg-white/40 backdrop-blur-sm'
+        className='h-16 w-32'
+      >
+        <button type='button'>Open navigation</button>
+      </LiquidGlass>,
+    );
+
+    act(() => {
+      observerCallback?.(
+        [
+          {
+            contentRect: { width: 128, height: 64 } as DOMRectReadOnly,
+          } as ResizeObserverEntry,
+        ],
+        {} as ResizeObserver,
+      );
+    });
+
+    expect(document.querySelector('feDisplacementMap')).not.toBeNull();
+  });
 });
 
 describe('LiquidGlassLayer', () => {
@@ -99,6 +202,49 @@ describe('LiquidGlassLayer', () => {
       'rounded-2xl',
     );
   });
+
+  it('applies rounded clipping styles while waiting for measurement', () => {
+    mockMotionPreference(false);
+
+    render(
+      <LiquidGlassLayer
+        lens={{ width: 0, height: 0, borderRadius: 16 }}
+        fallbackClassName='bg-white/40 backdrop-blur-sm'
+        className='size-full rounded-2xl'
+      />,
+    );
+
+    const layer = document.querySelector('[data-slot="liquid-glass-layer"]');
+
+    expect(layer).toHaveStyle({
+      borderRadius: '16px',
+      clipPath: 'inset(0 round 16px)',
+    });
+    expect(document.querySelector('filter')).toBeNull();
+  });
+
+  it('renders chromatic and edge-highlight filter nodes for CTA physics', () => {
+    mockMotionPreference(false);
+    enableDynamicLiquidGlass();
+
+    render(
+      <LiquidGlassLayer
+        lens={{ width: 48, height: 24, borderRadius: 12 }}
+        physics={{
+          scale: 18,
+          depth: 0.6,
+          curvature: 1.8,
+          splay: 1.5,
+          chroma: 0.2,
+          edgeHighlight: 0.5,
+        }}
+        fallbackClassName='bg-white/40 backdrop-blur-sm'
+      />,
+    );
+
+    expect(document.querySelector('feBlend[result="chroma"]')).not.toBeNull();
+    expect(document.querySelector('feSpecularLighting')).not.toBeNull();
+  });
 });
 
 describe('resolveLiquidGlassPhysics', () => {
@@ -106,5 +252,16 @@ describe('resolveLiquidGlassPhysics', () => {
     expect(resolveLiquidGlassPhysics('default')).toEqual(
       DEFAULT_LIQUID_GLASS_PHYSICS,
     );
+  });
+
+  it('uses the pricing preset for intensity="subtle"', () => {
+    expect(resolveLiquidGlassPhysics('subtle')).toEqual(PRICING_HEADER_PHYSICS);
+  });
+
+  it('merges physics overrides on top of the selected preset', () => {
+    expect(resolveLiquidGlassPhysics('default', { scale: 99 })).toEqual({
+      ...DEFAULT_LIQUID_GLASS_PHYSICS,
+      scale: 99,
+    });
   });
 });

--- a/tests/unit/components/liquid-glass/generate-lens-map.spec.ts
+++ b/tests/unit/components/liquid-glass/generate-lens-map.spec.ts
@@ -1,0 +1,102 @@
+import type { LiquidGlassLens } from '@/components/shared/liquid-glass/types';
+
+import {
+  clearLensMapCache,
+  generateLensMap,
+} from '@/components/shared/liquid-glass/generate-lens-map';
+import { describe, expect, it, beforeEach } from 'vitest';
+
+const NEUTRAL = 128;
+
+const testLens: LiquidGlassLens = {
+  width: 64,
+  height: 32,
+  borderRadius: 12,
+};
+
+const testPhysics = {
+  scale: 20,
+  depth: 0.7,
+  curvature: 1.4,
+  splay: 2,
+  chroma: 0.1,
+};
+
+function readPixel(
+  data: Uint8ClampedArray,
+  width: number,
+  x: number,
+  y: number,
+): { r: number; g: number; b: number; a: number } {
+  const index = (y * width + x) * 4;
+  return {
+    r: data[index] ?? 0,
+    g: data[index + 1] ?? 0,
+    b: data[index + 2] ?? 0,
+    a: data[index + 3] ?? 0,
+  };
+}
+
+describe('generateLensMap', () => {
+  beforeEach(() => {
+    clearLensMapCache();
+  });
+
+  it('leaves neutral pixels outside the rounded-rect lens', () => {
+    const { width, height, data } = generateLensMap(testLens, testPhysics);
+
+    const outsideSamples = [
+      [0, 0],
+      [width - 1, 0],
+      [0, height - 1],
+      [width - 1, height - 1],
+    ] as const;
+
+    for (const [x, y] of outsideSamples) {
+      const pixel = readPixel(data, width, x, y);
+      expect(pixel).toEqual({ r: NEUTRAL, g: NEUTRAL, b: NEUTRAL, a: 255 });
+    }
+  });
+
+  it('mirrors quadrant displacement across both axes', () => {
+    const { width, height, data } = generateLensMap(testLens, testPhysics);
+
+    const samples = [
+      [8, 6],
+      [12, 10],
+      [16, 8],
+    ] as const;
+
+    for (const [x, y] of samples) {
+      const topLeft = readPixel(data, width, x, y);
+      const topRight = readPixel(data, width, width - 1 - x, y);
+      const bottomLeft = readPixel(data, width, x, height - 1 - y);
+      const bottomRight = readPixel(data, width, width - 1 - x, height - 1 - y);
+
+      expect(topRight.r).toBe(256 - topLeft.r);
+      expect(topRight.g).toBe(topLeft.g);
+      expect(bottomLeft.r).toBe(topLeft.r);
+      expect(bottomLeft.g).toBe(256 - topLeft.g);
+      expect(bottomRight.r).toBe(256 - topLeft.r);
+      expect(bottomRight.g).toBe(256 - topLeft.g);
+    }
+  });
+
+  it('returns the same cached reference for identical inputs', () => {
+    const first = generateLensMap(testLens, testPhysics);
+    const second = generateLensMap(testLens, testPhysics);
+
+    expect(second).toBe(first);
+    expect(second.data).toBe(first.data);
+  });
+
+  it('produces deterministic output for fixed inputs', () => {
+    const first = generateLensMap(testLens, testPhysics);
+    clearLensMapCache();
+    const second = generateLensMap(testLens, testPhysics);
+
+    expect(Array.from(second.data)).toEqual(Array.from(first.data));
+    expect(second.scale).toBe(first.scale);
+    expect(second.chromaAmount).toBe(first.chromaAmount);
+  });
+});

--- a/tests/unit/components/liquid-glass/generate-lens-map.spec.ts
+++ b/tests/unit/components/liquid-glass/generate-lens-map.spec.ts
@@ -3,8 +3,10 @@ import type { LiquidGlassLens } from '@/components/shared/liquid-glass/types';
 import {
   clearLensMapCache,
   generateLensMap,
+  getLensMapDataUrl,
 } from '@/components/shared/liquid-glass/generate-lens-map';
-import { describe, expect, it, beforeEach } from 'vitest';
+import * as liquidGlassUtils from '@/components/shared/liquid-glass/liquid-glass-utils';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
 
 const NEUTRAL = 128;
 
@@ -130,5 +132,61 @@ describe('generateLensMap', () => {
 
     expect(rematerialized).not.toBe(oldest);
     expect(Array.from(rematerialized.data)).toEqual(Array.from(oldest.data));
+  });
+});
+
+describe('getLensMapDataUrl', () => {
+  beforeEach(() => {
+    clearLensMapCache();
+    vi.restoreAllMocks();
+  });
+
+  it('returns the same data URL for repeated calls on one map result', () => {
+    const mapResult = generateLensMap(testLens, testPhysics);
+    const lensMapToDataUrlSpy = vi
+      .spyOn(liquidGlassUtils, 'lensMapToDataUrl')
+      .mockReturnValue('data:image/png;base64,mock');
+
+    const first = getLensMapDataUrl(mapResult);
+    const second = getLensMapDataUrl(mapResult);
+
+    expect(first).toBe(second);
+    expect(lensMapToDataUrlSpy).toHaveBeenCalledTimes(1);
+    expect(lensMapToDataUrlSpy).toHaveBeenCalledWith(
+      mapResult.data,
+      mapResult.width,
+      mapResult.height,
+    );
+  });
+
+  it('reuses cached data URLs when generateLensMap returns a cached result', () => {
+    const mapResult = generateLensMap(testLens, testPhysics);
+    const lensMapToDataUrlSpy = vi
+      .spyOn(liquidGlassUtils, 'lensMapToDataUrl')
+      .mockReturnValue('data:image/png;base64,mock');
+
+    getLensMapDataUrl(mapResult);
+    getLensMapDataUrl(generateLensMap(testLens, testPhysics));
+
+    expect(lensMapToDataUrlSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('builds a new data URL when map inputs change', () => {
+    const firstMap = generateLensMap(testLens, testPhysics);
+    const secondMap = generateLensMap(
+      { ...testLens, width: testLens.width + 1 },
+      testPhysics,
+    );
+    const lensMapToDataUrlSpy = vi
+      .spyOn(liquidGlassUtils, 'lensMapToDataUrl')
+      .mockReturnValueOnce('data:image/png;base64,first')
+      .mockReturnValueOnce('data:image/png;base64,second');
+
+    const firstUrl = getLensMapDataUrl(firstMap);
+    const secondUrl = getLensMapDataUrl(secondMap);
+
+    expect(firstUrl).toBe('data:image/png;base64,first');
+    expect(secondUrl).toBe('data:image/png;base64,second');
+    expect(lensMapToDataUrlSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/unit/components/liquid-glass/generate-lens-map.spec.ts
+++ b/tests/unit/components/liquid-glass/generate-lens-map.spec.ts
@@ -99,4 +99,36 @@ describe('generateLensMap', () => {
     expect(second.scale).toBe(first.scale);
     expect(second.chromaAmount).toBe(first.chromaAmount);
   });
+
+  it('reuses cached maps when non-map physics fields differ', () => {
+    const first = generateLensMap(testLens, testPhysics);
+    const second = generateLensMap(testLens, {
+      ...testPhysics,
+      blur: 0.9,
+      glow: 0.8,
+      edgeHighlight: 0.7,
+      specularAngle: 45,
+    });
+
+    expect(second).toBe(first);
+  });
+
+  it('evicts the oldest cache entry when the cache is full', () => {
+    const oldestLens = { ...testLens, width: testLens.width };
+    const oldest = generateLensMap(oldestLens, testPhysics);
+
+    for (let index = 1; index <= 32; index += 1) {
+      generateLensMap(
+        { ...testLens, width: testLens.width + index },
+        testPhysics,
+      );
+    }
+
+    generateLensMap({ ...testLens, width: testLens.width + 33 }, testPhysics);
+
+    const rematerialized = generateLensMap(oldestLens, testPhysics);
+
+    expect(rematerialized).not.toBe(oldest);
+    expect(Array.from(rematerialized.data)).toEqual(Array.from(oldest.data));
+  });
 });

--- a/tests/unit/components/liquid-glass/liquid-glass-utils.spec.ts
+++ b/tests/unit/components/liquid-glass/liquid-glass-utils.spec.ts
@@ -1,0 +1,95 @@
+import {
+  buildMapSignature,
+  computeEffectiveLens,
+  lensMapToDataUrl,
+  MIN_MEASURED_SIZE,
+  specularLightPosition,
+} from '@/components/shared/liquid-glass/liquid-glass-utils';
+import { describe, expect, it, vi, afterEach } from 'vitest';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('computeEffectiveLens', () => {
+  it('uses explicit lens dimensions when width and height are positive', () => {
+    expect(
+      computeEffectiveLens(
+        { width: 120.6, height: 48.4, borderRadius: 8.2 },
+        { width: 200, height: 100 },
+      ),
+    ).toEqual({ width: 121, height: 48, borderRadius: 8 });
+  });
+
+  it('falls back to measured size when lens dimensions are zero', () => {
+    expect(
+      computeEffectiveLens(
+        { width: 0, height: 0, borderRadius: 16 },
+        { width: 320, height: 64 },
+      ),
+    ).toEqual({ width: 320, height: 64, borderRadius: 16 });
+  });
+
+  it('clamps measured dimensions to at least MIN_MEASURED_SIZE', () => {
+    expect(
+      computeEffectiveLens(
+        { width: 0, height: 0, borderRadius: 0 },
+        { width: 0, height: 0 },
+      ),
+    ).toEqual({
+      width: MIN_MEASURED_SIZE,
+      height: MIN_MEASURED_SIZE,
+      borderRadius: 0,
+    });
+  });
+});
+
+describe('buildMapSignature', () => {
+  it('joins lens geometry and map tuning into a stable signature', () => {
+    expect(
+      buildMapSignature({ width: 64, height: 32, borderRadius: 12 }, 20, 1.4),
+    ).toBe('64:32:12:20:1.4');
+  });
+});
+
+describe('specularLightPosition', () => {
+  it('derives light coordinates from angle and lens size', () => {
+    const light = specularLightPosition(0, 100, 50);
+
+    expect(light.x).toBeCloseTo(150);
+    expect(light.y).toBeCloseTo(25);
+    expect(light.z).toBe(100);
+  });
+});
+
+describe('lensMapToDataUrl', () => {
+  it('returns an empty string when canvas context is unavailable', () => {
+    const canvas = document.createElement('canvas');
+    vi.spyOn(canvas, 'getContext').mockReturnValue(null);
+    vi.spyOn(document, 'createElement').mockReturnValue(canvas);
+
+    const dataUrl = lensMapToDataUrl(new Uint8ClampedArray(4), 1, 1);
+
+    expect(dataUrl).toBe('');
+  });
+
+  it('delegates encoding to canvas when a 2d context is available', () => {
+    const canvas = document.createElement('canvas');
+    const toDataURL = vi
+      .fn()
+      .mockReturnValue('data:image/png;base64,mock-encoded');
+
+    vi.spyOn(canvas, 'getContext').mockReturnValue({
+      createImageData: () => ({ data: new Uint8ClampedArray(4) }),
+      putImageData: vi.fn(),
+    } as unknown as CanvasRenderingContext2D);
+    canvas.toDataURL = toDataURL;
+    vi.spyOn(document, 'createElement').mockReturnValue(canvas);
+
+    const data = new Uint8ClampedArray([255, 128, 64, 255]);
+    const dataUrl = lensMapToDataUrl(data, 1, 1);
+
+    expect(dataUrl).toBe('data:image/png;base64,mock-encoded');
+    expect(toDataURL).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/components/liquid-glass/use-liquid-glass-runtime.spec.tsx
+++ b/tests/unit/components/liquid-glass/use-liquid-glass-runtime.spec.tsx
@@ -1,0 +1,78 @@
+import { useLiquidGlassRuntime } from '@/components/shared/liquid-glass/use-liquid-glass-runtime';
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+function createMatchMediaMock(matches: boolean) {
+  const listeners = new Set<() => void>();
+
+  return vi.fn().mockImplementation((query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addEventListener: (_event: string, listener: () => void) => {
+      listeners.add(listener);
+    },
+    removeEventListener: (_event: string, listener: () => void) => {
+      listeners.delete(listener);
+    },
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    emitChange(nextMatches: boolean) {
+      matches = nextMatches;
+      for (const listener of listeners) {
+        listener();
+      }
+    },
+  }));
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useLiquidGlassRuntime', () => {
+  it('reports reduced motion when the media query matches', () => {
+    vi.stubGlobal('matchMedia', createMatchMediaMock(true));
+
+    const { result } = renderHook(() => useLiquidGlassRuntime());
+
+    expect(result.current.isMounted).toBe(true);
+    expect(result.current.prefersReducedMotion).toBe(true);
+  });
+
+  it('updates when the reduced-motion preference changes', () => {
+    const matchMedia = createMatchMediaMock(false);
+    vi.stubGlobal('matchMedia', matchMedia);
+
+    const { result } = renderHook(() => useLiquidGlassRuntime());
+    const mediaQuery = matchMedia.mock.results[0]?.value as {
+      emitChange: (nextMatches: boolean) => void;
+    };
+
+    act(() => {
+      mediaQuery.emitChange(true);
+    });
+
+    expect(result.current.prefersReducedMotion).toBe(true);
+  });
+
+  it('treats missing matchMedia as no reduced-motion preference', () => {
+    vi.stubGlobal('matchMedia', undefined);
+
+    const { result } = renderHook(() => useLiquidGlassRuntime());
+
+    expect(result.current.prefersReducedMotion).toBe(false);
+  });
+
+  it('detects SVG displacement filter support in the browser', () => {
+    vi.stubGlobal('matchMedia', createMatchMediaMock(false));
+
+    const { result } = renderHook(() => useLiquidGlassRuntime());
+
+    expect(result.current.isSupported).toBe(
+      typeof SVGFEDisplacementMapElement !== 'undefined' &&
+        typeof SVGFEImageElement !== 'undefined',
+    );
+  });
+});

--- a/tests/unit/components/marketing/LiquidGlassButton.spec.tsx
+++ b/tests/unit/components/marketing/LiquidGlassButton.spec.tsx
@@ -1,0 +1,24 @@
+import { LiquidGlassButton } from '@/app/(marketing)/_shared/LiquidGlassButton';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+describe('LiquidGlassButton', () => {
+  it('uses a semi-transparent surface so the glass layer shows through', () => {
+    render(<LiquidGlassButton>Get started</LiquidGlassButton>);
+
+    const button = screen.getByRole('button', { name: 'Get started' });
+
+    expect(button).toHaveClass('bg-primary/70', 'hover:bg-primary/80');
+    expect(button.className).not.toMatch(/\bbg-primary(?![/-])/);
+  });
+
+  it('keeps the decorative glass layer behind the interactive button', () => {
+    render(<LiquidGlassButton>Get started</LiquidGlassButton>);
+
+    const button = screen.getByRole('button', { name: 'Get started' });
+    const shell = button.closest('[data-slot="liquid-glass"]');
+    const glassLayer = shell?.querySelector('[aria-hidden="true"]');
+
+    expect(glassLayer).toHaveClass('pointer-events-none', 'absolute', '-z-10');
+  });
+});

--- a/tests/unit/components/nav/DesktopHeader.spec.tsx
+++ b/tests/unit/components/nav/DesktopHeader.spec.tsx
@@ -1,0 +1,98 @@
+import DesktopHeader from '@/components/shared/nav/DesktopHeader';
+import { desktopHeaderShellClass } from '@/components/shared/nav/header-shell';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import {
+  authenticatedNavItems,
+  unauthenticatedNavItems,
+} from '@/features/navigation';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@clerk/nextjs', () => ({
+  UserButton: () => <div data-testid='user-button'>Mocked UserButton</div>,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function renderDesktopHeader(
+  props: Partial<Parameters<typeof DesktopHeader>[0]> = {},
+) {
+  return render(
+    <TooltipProvider>
+      <div className='w-[768px]'>
+        <DesktopHeader
+          headerVariant='protected'
+          pathname='/dashboard'
+          navItems={authenticatedNavItems}
+          tier='starter'
+          isAuthenticated
+          showClerkUserButton
+          {...props}
+        />
+      </div>
+    </TooltipProvider>,
+  );
+}
+
+describe('DesktopHeader layout', () => {
+  it('uses side-auto center-flex grid so nav is not limited to one third width', () => {
+    expect(desktopHeaderShellClass('protected')).toContain(
+      'grid-cols-[auto_minmax(0,1fr)_auto]',
+    );
+    expect(desktopHeaderShellClass('protected')).not.toContain('grid-cols-3');
+  });
+
+  it('keeps authenticated nav items accessible at md width', () => {
+    renderDesktopHeader();
+
+    expect(
+      screen.getByRole('link', { name: 'Activity Feed' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Plans' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Analytics' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Settings' })).toBeInTheDocument();
+  });
+
+  it('centers navigation between brand and auth controls', () => {
+    const { container } = renderDesktopHeader();
+
+    const shell = container.firstElementChild?.firstElementChild;
+    const navColumn = screen.getByRole('navigation').parentElement;
+
+    expect(shell?.className).toContain('grid-cols-[auto_minmax(0,1fr)_auto]');
+    expect(navColumn).toHaveClass('min-w-0', 'justify-center');
+  });
+
+  it('renders unauthenticated nav links without clipping at md width', () => {
+    const { container } = render(
+      <TooltipProvider>
+        <div className='w-[768px]'>
+          <DesktopHeader
+            headerVariant='marketing'
+            pathname='/landing'
+            navItems={unauthenticatedNavItems}
+            isAuthenticated={false}
+            showClerkUserButton
+          />
+        </div>
+      </TooltipProvider>,
+    );
+
+    for (const item of unauthenticatedNavItems) {
+      expect(
+        screen.getByRole('link', { name: item.label }),
+      ).toBeInTheDocument();
+    }
+
+    const nav = container.querySelector('nav');
+    expect(nav).not.toBeNull();
+    expect(within(nav!).getAllByRole('link')).toHaveLength(
+      unauthenticatedNavItems.length,
+    );
+  });
+});

--- a/tests/unit/components/nav/header-liquid-glass-shell.spec.tsx
+++ b/tests/unit/components/nav/header-liquid-glass-shell.spec.tsx
@@ -53,4 +53,20 @@ describe('HeaderLiquidGlassShell', () => {
 
     expect(layer).toHaveClass('bg-white/20', 'dark:bg-white/5');
   });
+
+  it('clips the glass layer on an inner wrapper so the shell can show focus rings', () => {
+    render(
+      <HeaderLiquidGlassShell layout='desktop' variant='marketing'>
+        <span>Marketing header</span>
+      </HeaderLiquidGlassShell>,
+    );
+
+    const shell = screen.getByText('Marketing header').parentElement;
+    const glassClipWrapper = document.querySelector(
+      '[data-slot="liquid-glass-layer"]',
+    )?.parentElement;
+
+    expect(shell?.className).not.toContain('overflow-hidden');
+    expect(glassClipWrapper).toHaveClass('overflow-hidden', 'rounded-2xl');
+  });
 });

--- a/tests/unit/components/nav/header-liquid-glass-shell.spec.tsx
+++ b/tests/unit/components/nav/header-liquid-glass-shell.spec.tsx
@@ -1,0 +1,43 @@
+import HeaderLiquidGlassShell from '@/components/shared/nav/HeaderLiquidGlassShell';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+describe('HeaderLiquidGlassShell', () => {
+  it('renders children without a liquid glass layer on opaque routes', () => {
+    render(
+      <HeaderLiquidGlassShell layout='desktop' variant='opaque'>
+        <span>Header content</span>
+      </HeaderLiquidGlassShell>,
+    );
+
+    expect(screen.getByText('Header content')).toBeInTheDocument();
+    expect(
+      document.querySelector('[data-slot="liquid-glass-layer"]'),
+    ).toBeNull();
+  });
+
+  it('mounts a decorative liquid glass layer for marketing routes', () => {
+    render(
+      <HeaderLiquidGlassShell layout='desktop' variant='marketing'>
+        <span>Marketing header</span>
+      </HeaderLiquidGlassShell>,
+    );
+
+    expect(screen.getByText('Marketing header')).toBeInTheDocument();
+    expect(
+      document.querySelector('[data-slot="liquid-glass-layer"]'),
+    ).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('uses the pricing glass surface classes on pricing routes', () => {
+    render(
+      <HeaderLiquidGlassShell layout='mobile' variant='pricing'>
+        <span>Pricing header</span>
+      </HeaderLiquidGlassShell>,
+    );
+
+    const layer = document.querySelector('[data-slot="liquid-glass-layer"]');
+
+    expect(layer).toHaveClass('bg-white/20', 'dark:bg-white/5');
+  });
+});

--- a/tests/unit/components/nav/header-liquid-glass-shell.spec.tsx
+++ b/tests/unit/components/nav/header-liquid-glass-shell.spec.tsx
@@ -29,6 +29,19 @@ describe('HeaderLiquidGlassShell', () => {
     ).toHaveAttribute('aria-hidden', 'true');
   });
 
+  it('mounts a decorative liquid glass layer for protected routes', () => {
+    render(
+      <HeaderLiquidGlassShell layout='desktop' variant='protected'>
+        <span>Protected header</span>
+      </HeaderLiquidGlassShell>,
+    );
+
+    expect(screen.getByText('Protected header')).toBeInTheDocument();
+    expect(
+      document.querySelector('[data-slot="liquid-glass-layer"]'),
+    ).toHaveAttribute('aria-hidden', 'true');
+  });
+
   it('uses the pricing glass surface classes on pricing routes', () => {
     render(
       <HeaderLiquidGlassShell layout='mobile' variant='pricing'>

--- a/tests/unit/components/nav/header-shell.spec.ts
+++ b/tests/unit/components/nav/header-shell.spec.ts
@@ -41,6 +41,9 @@ describe('header shell variants', () => {
   it('keeps protected routes on the rounded glass shell classes', () => {
     expect(desktopHeaderShellClass('protected')).toContain('rounded-2xl');
     expect(desktopHeaderShellClass('protected')).toContain('border-white/40');
+    expect(desktopHeaderShellClass('protected')).toContain(
+      'grid-cols-[auto_minmax(0,1fr)_auto]',
+    );
     expect(mobileHeaderShellClass('protected')).toContain('rounded-2xl');
     expect(headerGlassSurfaceClass('protected', 'desktop')).toContain(
       'dark:bg-white/10',

--- a/tests/unit/components/nav/header-shell.spec.ts
+++ b/tests/unit/components/nav/header-shell.spec.ts
@@ -45,7 +45,13 @@ describe('header shell variants', () => {
     expect(desktopHeaderShellClass('protected')).toContain(
       'grid-cols-[auto_minmax(0,1fr)_auto]',
     );
+    expect(desktopHeaderShellClass('protected')).not.toContain(
+      'overflow-hidden',
+    );
     expect(mobileHeaderShellClass('protected')).toContain('rounded-2xl');
+    expect(mobileHeaderShellClass('protected')).not.toContain(
+      'overflow-hidden',
+    );
     expect(headerGlassSurfaceClass('protected', 'desktop')).toContain(
       'dark:bg-white/10',
     );

--- a/tests/unit/components/nav/header-shell.spec.ts
+++ b/tests/unit/components/nav/header-shell.spec.ts
@@ -6,11 +6,12 @@ import {
   mobileHeaderShellClass,
   usesLiquidGlassHeader,
 } from '@/components/shared/nav/header-shell';
+import { ROUTES } from '@/features/navigation';
 import { describe, expect, it } from 'vitest';
 
 describe('header shell variants', () => {
   it('uses glass variants for marketing and protected app routes', () => {
-    expect(getHeaderShellVariant('/landing')).toBe('marketing');
+    expect(getHeaderShellVariant(ROUTES.LANDING)).toBe('marketing');
     expect(getHeaderShellVariant('/about')).toBe('marketing');
     expect(getHeaderShellVariant('/pricing')).toBe('pricing');
     expect(getHeaderShellVariant('/dashboard')).toBe('protected');

--- a/tests/unit/components/nav/header-shell.spec.ts
+++ b/tests/unit/components/nav/header-shell.spec.ts
@@ -1,0 +1,49 @@
+import {
+  desktopHeaderShellClass,
+  getHeaderShellVariant,
+  headerGlassIntensity,
+  headerGlassSurfaceClass,
+  mobileHeaderShellClass,
+  usesLiquidGlassHeader,
+} from '@/components/shared/nav/header-shell';
+import { describe, expect, it } from 'vitest';
+
+describe('header shell variants', () => {
+  it('uses glass variants for marketing and protected app routes', () => {
+    expect(getHeaderShellVariant('/landing')).toBe('marketing');
+    expect(getHeaderShellVariant('/about')).toBe('marketing');
+    expect(getHeaderShellVariant('/pricing')).toBe('pricing');
+    expect(getHeaderShellVariant('/dashboard')).toBe('protected');
+    expect(getHeaderShellVariant('/plans/plan_123')).toBe('protected');
+    expect(getHeaderShellVariant('/settings/billing')).toBe('protected');
+    expect(getHeaderShellVariant('/analytics/usage')).toBe('protected');
+  });
+
+  it('keeps auth and non-header product surfaces opaque', () => {
+    expect(getHeaderShellVariant('/auth/sign-in')).toBe('opaque');
+    expect(getHeaderShellVariant('/maintenance')).toBe('opaque');
+    expect(getHeaderShellVariant('/api/v1/plans')).toBe('opaque');
+  });
+
+  it('maps only opaque routes away from liquid glass', () => {
+    expect(usesLiquidGlassHeader('marketing')).toBe(true);
+    expect(usesLiquidGlassHeader('pricing')).toBe(true);
+    expect(usesLiquidGlassHeader('protected')).toBe(true);
+    expect(usesLiquidGlassHeader('opaque')).toBe(false);
+  });
+
+  it('uses subtle liquid glass only on pricing', () => {
+    expect(headerGlassIntensity('marketing')).toBe('default');
+    expect(headerGlassIntensity('protected')).toBe('default');
+    expect(headerGlassIntensity('pricing')).toBe('subtle');
+  });
+
+  it('keeps protected routes on the rounded glass shell classes', () => {
+    expect(desktopHeaderShellClass('protected')).toContain('rounded-2xl');
+    expect(desktopHeaderShellClass('protected')).toContain('border-white/40');
+    expect(mobileHeaderShellClass('protected')).toContain('rounded-2xl');
+    expect(headerGlassSurfaceClass('protected', 'desktop')).toContain(
+      'dark:bg-white/10',
+    );
+  });
+});

--- a/tests/unit/components/nav/mobile-navigation.spec.tsx
+++ b/tests/unit/components/nav/mobile-navigation.spec.tsx
@@ -1,0 +1,79 @@
+import MobileNavigation from '@/components/shared/nav/MobileNavigation';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const navItems = [
+  { href: '/dashboard', label: 'Dashboard' },
+  { href: '/plans', label: 'Plans' },
+];
+
+function renderMobileNavigation(
+  headerVariant: 'marketing' | 'opaque' = 'marketing',
+) {
+  return render(
+    <TooltipProvider>
+      <MobileNavigation
+        headerVariant={headerVariant}
+        pathname='/dashboard'
+        navItems={navItems}
+      />
+    </TooltipProvider>,
+  );
+}
+
+describe('MobileNavigation', () => {
+  it('opens the navigation sheet and lists primary links', async () => {
+    const user = userEvent.setup();
+
+    renderMobileNavigation('marketing');
+
+    await user.click(screen.getByRole('button', { name: 'Open menu' }));
+
+    expect(
+      screen.getByRole('navigation', { name: 'Mobile navigation' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Dashboard' })).toHaveAttribute(
+      'href',
+      '/dashboard',
+    );
+    expect(
+      screen.getByRole('link', { name: 'Create New Plan' }),
+    ).toHaveAttribute('href', '/plans/new');
+  });
+
+  it('uses glass styling for the menu trigger on liquid glass routes', () => {
+    renderMobileNavigation('marketing');
+
+    expect(screen.getByRole('button', { name: 'Open menu' })).toHaveClass(
+      'backdrop-blur-sm',
+    );
+  });
+
+  it('uses opaque styling for the menu trigger on non-glass routes', () => {
+    renderMobileNavigation('opaque');
+
+    expect(screen.getByRole('button', { name: 'Open menu' })).toHaveClass(
+      'bg-muted',
+    );
+    expect(screen.getByRole('button', { name: 'Open menu' })).not.toHaveClass(
+      'backdrop-blur-sm',
+    );
+  });
+});

--- a/tests/unit/setup.ts
+++ b/tests/unit/setup.ts
@@ -88,6 +88,17 @@ if (typeof Element.prototype.scrollIntoView !== 'function') {
   Element.prototype.scrollIntoView = () => {};
 }
 
+// LiquidGlass measures container size via ResizeObserver (not provided by jsdom).
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class {
+    observe() {}
+
+    unobserve() {}
+
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}
+
 // Extend expect with jest-dom matchers
 import '@testing-library/jest-dom';
 


### PR DESCRIPTION
## Summary

- Add reusable liquid glass primitives (`LiquidGlass`, `LiquidGlassLayer`, displacement lens map) with reduced-motion and unsupported-browser fallbacks.
- Introduce `HeaderLiquidGlassShell` and route-aware header variants so marketing and protected app routes share the same glass navbar treatment, while auth and other opaque routes keep the existing `bg-card` shell.
- Wire marketing CTAs through `LiquidGlassButton` and document header-only liquid glass usage in the style guide.

## Test plan

- [ ] Verify marketing routes (`/landing`, `/about`, `/pricing`) show rounded liquid glass header in light and dark mode
- [ ] Verify protected app routes (`/dashboard`, `/plans`, `/settings`, `/analytics`) use the same glass header shell
- [ ] Confirm `/auth/sign-in` still uses the opaque header shell
- [ ] Check mobile nav sheet/hamburger styling on glass vs opaque routes
- [ ] Confirm marketing CTAs render with liquid glass and readable labels
- [ ] Run `pnpm exec vitest run tests/unit/components/nav/header-shell.spec.ts tests/unit/components/liquid-glass/`
- [ ] Run `pnpm check:type` and `pnpm check:lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Fixed-header SVG filters on every glass route may affect scroll performance on Safari/iOS; protected routes now share translucent chrome, which is a visible UX change across core app surfaces.
> 
> **Overview**
> Adds a **liquid glass** UI layer (SVG displacement lenses with glassmorphism fallbacks) and wires it into site chrome and marketing CTAs, with route-aware header behavior.
> 
> **New primitives** under `@/components/shared/liquid-glass`: `LiquidGlass` / `LiquidGlassLayer`, cached displacement map generation, runtime gating for `prefers-reduced-motion` and SVG filter support, and marketing presets (`MARKETING_HEADER_PHYSICS`, `PRICING_HEADER_PHYSICS`, `MARKETING_CTA_PHYSICS`). **`LiquidGlassButton`** wraps primary marketing CTAs (hero + `MarketingCta`).
> 
> **Header routing** is refactored: `getHeaderShellVariant` picks `marketing` | `pricing` | `protected` | `opaque`; protected app paths (`/dashboard`, `/plans`, `/settings`, `/analytics`, `/account`) now use the same glass shell as marketing instead of opaque `bg-card`. **`HeaderLiquidGlassShell`** layers `LiquidGlassLayer` behind desktop/mobile headers; auth and other routes stay opaque. Desktop nav grid becomes `auto / minmax(0,1fr) / auto` to reduce link clipping; mobile nav/sheet styling keys off `usesLiquidGlassHeader` instead of marketing-only checks.
> 
> **Docs & misc:** style guide documents liquid glass scope (header + opt-in CTAs only). Settings sidebar inactive links drop sidebar-specific backgrounds. Lockfile pins `undici@7.28.0` and `piscina@4.9.3`. Broad unit test coverage for liquid glass and nav shells; jsdom gets a `ResizeObserver` stub.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6821089727423ec6b79183fb36ce69770e283489. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->