### PR TITLE
fix(ui): address React Doctor findings in liquid glass components

### DIFF
--- a/src/components/shared/liquid-glass/LiquidGlass.tsx
+++ b/src/components/shared/liquid-glass/LiquidGlass.tsx
@@ -3,62 +3,16 @@
 import type { LiquidGlassProps } from './types';
 
 import { generateLensMap } from './generate-lens-map';
-import { resolveLiquidGlassPhysics } from './types';
-import { cn } from '@/lib/utils';
 import {
-  useEffect,
-  useId,
-  useMemo,
-  useRef,
-  useState,
-  type CSSProperties,
-} from 'react';
-
-const MIN_MEASURED_SIZE = 1;
-
-function supportsSvgDisplacementFilters(): boolean {
-  if (typeof window === 'undefined' || typeof document === 'undefined') {
-    return false;
-  }
-
-  return (
-    typeof SVGFEDisplacementMapElement !== 'undefined' &&
-    typeof SVGFEImageElement !== 'undefined'
-  );
-}
-
-function lensMapToDataUrl(
-  data: Uint8ClampedArray,
-  width: number,
-  height: number,
-): string {
-  const canvas = document.createElement('canvas');
-  canvas.width = width;
-  canvas.height = height;
-
-  const context = canvas.getContext('2d');
-  if (!context) {
-    return '';
-  }
-
-  const imageData = context.createImageData(width, height);
-  imageData.data.set(data);
-  context.putImageData(imageData, 0, 0);
-  return canvas.toDataURL();
-}
-
-function specularLightPosition(
-  angleDegrees: number,
-  width: number,
-  height: number,
-): { x: number; y: number; z: number } {
-  const radians = (angleDegrees * Math.PI) / 180;
-  return {
-    x: width / 2 + Math.cos(radians) * width,
-    y: height / 2 + Math.sin(radians) * height,
-    z: Math.max(width, height),
-  };
-}
+  buildMapSignature,
+  computeEffectiveLens,
+  lensMapToDataUrl,
+  specularLightPosition,
+} from './liquid-glass-utils';
+import { resolveLiquidGlassPhysics } from './types';
+import { useLiquidGlassRuntime } from './use-liquid-glass-runtime';
+import { cn } from '@/lib/utils';
+import { useEffect, useId, useRef, useState, type CSSProperties } from 'react';
 
 export function LiquidGlass({
   lens,
@@ -70,71 +24,21 @@ export function LiquidGlass({
 }: LiquidGlassProps) {
   const baseFilterId = useId();
   const containerRef = useRef<HTMLDivElement>(null);
-  const [filterRevision, setFilterRevision] = useState(0);
   const [measuredSize, setMeasuredSize] = useState({
     width: lens.width,
     height: lens.height,
   });
-  const [isMounted, setIsMounted] = useState(false);
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
-  const [isSupported, setIsSupported] = useState(true);
+  const { isMounted, isSupported, prefersReducedMotion } =
+    useLiquidGlassRuntime();
 
   const resolvedPhysics = resolveLiquidGlassPhysics(intensity, physics);
-
-  const effectiveLens = useMemo(
-    () => ({
-      width:
-        lens.width > 0
-          ? Math.round(lens.width)
-          : Math.max(MIN_MEASURED_SIZE, measuredSize.width),
-      height:
-        lens.height > 0
-          ? Math.round(lens.height)
-          : Math.max(MIN_MEASURED_SIZE, measuredSize.height),
-      borderRadius: Math.max(0, Math.round(lens.borderRadius)),
-    }),
-    [
-      lens.borderRadius,
-      lens.height,
-      lens.width,
-      measuredSize.height,
-      measuredSize.width,
-    ],
+  const effectiveLens = computeEffectiveLens(lens, measuredSize);
+  const mapResult = generateLensMap(effectiveLens, resolvedPhysics);
+  const mapSignature = buildMapSignature(
+    effectiveLens,
+    mapResult.scale,
+    mapResult.chromaAmount,
   );
-
-  const mapResult = useMemo(
-    () => generateLensMap(effectiveLens, resolvedPhysics),
-    [effectiveLens, resolvedPhysics],
-  );
-
-  const mapSignature = useMemo(
-    () =>
-      `${effectiveLens.width}:${effectiveLens.height}:${effectiveLens.borderRadius}:${mapResult.scale}:${mapResult.chromaAmount}`,
-    [
-      effectiveLens.borderRadius,
-      effectiveLens.height,
-      effectiveLens.width,
-      mapResult.chromaAmount,
-      mapResult.scale,
-    ],
-  );
-
-  useEffect(() => {
-    setIsMounted(true);
-    setIsSupported(supportsSvgDisplacementFilters());
-
-    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-    const syncReducedMotion = () => {
-      setPrefersReducedMotion(mediaQuery.matches);
-    };
-
-    syncReducedMotion();
-    mediaQuery.addEventListener('change', syncReducedMotion);
-
-    return () => {
-      mediaQuery.removeEventListener('change', syncReducedMotion);
-    };
-  }, []);
 
   useEffect(() => {
     const node = containerRef.current;
@@ -150,8 +54,8 @@ export function LiquidGlass({
 
       const { width, height } = entry.contentRect;
       setMeasuredSize({
-        width: Math.max(MIN_MEASURED_SIZE, Math.round(width)),
-        height: Math.max(MIN_MEASURED_SIZE, Math.round(height)),
+        width: Math.max(1, Math.round(width)),
+        height: Math.max(1, Math.round(height)),
       });
     });
 
@@ -162,29 +66,15 @@ export function LiquidGlass({
     };
   }, [lens.height, lens.width]);
 
-  useEffect(() => {
-    setFilterRevision((revision) => revision + 1);
-  }, [mapSignature]);
-
-  const displacementMapUrl = useMemo(() => {
-    if (!isMounted || prefersReducedMotion || !isSupported) {
-      return '';
-    }
-
-    return lensMapToDataUrl(mapResult.data, mapResult.width, mapResult.height);
-  }, [
-    isMounted,
-    isSupported,
-    mapResult.data,
-    mapResult.height,
-    mapResult.width,
-    prefersReducedMotion,
-  ]);
+  const displacementMapUrl =
+    isMounted && !prefersReducedMotion && isSupported
+      ? lensMapToDataUrl(mapResult.data, mapResult.width, mapResult.height)
+      : '';
 
   const useStaticFallback =
     !isMounted || prefersReducedMotion || !isSupported || !displacementMapUrl;
 
-  const filterId = `${baseFilterId}-liquid-glass-${filterRevision}`;
+  const filterId = `${baseFilterId}-liquid-glass-${mapSignature.replace(/:/g, '-')}`;
   const filterStyle: CSSProperties | undefined = useStaticFallback
     ? undefined
     : { filter: `url(#${filterId})` };

--- a/src/components/shared/liquid-glass/LiquidGlassLayer.tsx
+++ b/src/components/shared/liquid-glass/LiquidGlassLayer.tsx
@@ -3,62 +3,16 @@
 import type { LiquidGlassLayerProps } from './types';
 
 import { generateLensMap } from './generate-lens-map';
-import { resolveLiquidGlassPhysics } from './types';
-import { cn } from '@/lib/utils';
 import {
-  useEffect,
-  useId,
-  useMemo,
-  useRef,
-  useState,
-  type CSSProperties,
-} from 'react';
-
-const MIN_MEASURED_SIZE = 1;
-
-function supportsSvgDisplacementFilters(): boolean {
-  if (typeof window === 'undefined' || typeof document === 'undefined') {
-    return false;
-  }
-
-  return (
-    typeof SVGFEDisplacementMapElement !== 'undefined' &&
-    typeof SVGFEImageElement !== 'undefined'
-  );
-}
-
-function lensMapToDataUrl(
-  data: Uint8ClampedArray,
-  width: number,
-  height: number,
-): string {
-  const canvas = document.createElement('canvas');
-  canvas.width = width;
-  canvas.height = height;
-
-  const context = canvas.getContext('2d');
-  if (!context) {
-    return '';
-  }
-
-  const imageData = context.createImageData(width, height);
-  imageData.data.set(data);
-  context.putImageData(imageData, 0, 0);
-  return canvas.toDataURL();
-}
-
-function specularLightPosition(
-  angleDegrees: number,
-  width: number,
-  height: number,
-): { x: number; y: number; z: number } {
-  const radians = (angleDegrees * Math.PI) / 180;
-  return {
-    x: width / 2 + Math.cos(radians) * width,
-    y: height / 2 + Math.sin(radians) * height,
-    z: Math.max(width, height),
-  };
-}
+  buildMapSignature,
+  computeEffectiveLens,
+  lensMapToDataUrl,
+  specularLightPosition,
+} from './liquid-glass-utils';
+import { resolveLiquidGlassPhysics } from './types';
+import { useLiquidGlassRuntime } from './use-liquid-glass-runtime';
+import { cn } from '@/lib/utils';
+import { useEffect, useId, useRef, useState, type CSSProperties } from 'react';
 
 export function LiquidGlassLayer({
   lens,
@@ -69,71 +23,21 @@ export function LiquidGlassLayer({
 }: LiquidGlassLayerProps) {
   const baseFilterId = useId();
   const layerRef = useRef<HTMLDivElement>(null);
-  const [filterRevision, setFilterRevision] = useState(0);
   const [measuredSize, setMeasuredSize] = useState({
     width: lens.width,
     height: lens.height,
   });
-  const [isMounted, setIsMounted] = useState(false);
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
-  const [isSupported, setIsSupported] = useState(true);
+  const { isMounted, isSupported, prefersReducedMotion } =
+    useLiquidGlassRuntime();
 
   const resolvedPhysics = resolveLiquidGlassPhysics(intensity, physics);
-
-  const effectiveLens = useMemo(
-    () => ({
-      width:
-        lens.width > 0
-          ? Math.round(lens.width)
-          : Math.max(MIN_MEASURED_SIZE, measuredSize.width),
-      height:
-        lens.height > 0
-          ? Math.round(lens.height)
-          : Math.max(MIN_MEASURED_SIZE, measuredSize.height),
-      borderRadius: Math.max(0, Math.round(lens.borderRadius)),
-    }),
-    [
-      lens.borderRadius,
-      lens.height,
-      lens.width,
-      measuredSize.height,
-      measuredSize.width,
-    ],
+  const effectiveLens = computeEffectiveLens(lens, measuredSize);
+  const mapResult = generateLensMap(effectiveLens, resolvedPhysics);
+  const mapSignature = buildMapSignature(
+    effectiveLens,
+    mapResult.scale,
+    mapResult.chromaAmount,
   );
-
-  const mapResult = useMemo(
-    () => generateLensMap(effectiveLens, resolvedPhysics),
-    [effectiveLens, resolvedPhysics],
-  );
-
-  const mapSignature = useMemo(
-    () =>
-      `${effectiveLens.width}:${effectiveLens.height}:${effectiveLens.borderRadius}:${mapResult.scale}:${mapResult.chromaAmount}`,
-    [
-      effectiveLens.borderRadius,
-      effectiveLens.height,
-      effectiveLens.width,
-      mapResult.chromaAmount,
-      mapResult.scale,
-    ],
-  );
-
-  useEffect(() => {
-    setIsMounted(true);
-    setIsSupported(supportsSvgDisplacementFilters());
-
-    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-    const syncReducedMotion = () => {
-      setPrefersReducedMotion(mediaQuery.matches);
-    };
-
-    syncReducedMotion();
-    mediaQuery.addEventListener('change', syncReducedMotion);
-
-    return () => {
-      mediaQuery.removeEventListener('change', syncReducedMotion);
-    };
-  }, []);
 
   useEffect(() => {
     const node = layerRef.current;
@@ -149,8 +53,8 @@ export function LiquidGlassLayer({
 
       const { width, height } = entry.contentRect;
       setMeasuredSize({
-        width: Math.max(MIN_MEASURED_SIZE, Math.round(width)),
-        height: Math.max(MIN_MEASURED_SIZE, Math.round(height)),
+        width: Math.max(1, Math.round(width)),
+        height: Math.max(1, Math.round(height)),
       });
     });
 
@@ -161,29 +65,15 @@ export function LiquidGlassLayer({
     };
   }, [lens.height, lens.width]);
 
-  useEffect(() => {
-    setFilterRevision((revision) => revision + 1);
-  }, [mapSignature]);
-
-  const displacementMapUrl = useMemo(() => {
-    if (!isMounted || prefersReducedMotion || !isSupported) {
-      return '';
-    }
-
-    return lensMapToDataUrl(mapResult.data, mapResult.width, mapResult.height);
-  }, [
-    isMounted,
-    isSupported,
-    mapResult.data,
-    mapResult.height,
-    mapResult.width,
-    prefersReducedMotion,
-  ]);
+  const displacementMapUrl =
+    isMounted && !prefersReducedMotion && isSupported
+      ? lensMapToDataUrl(mapResult.data, mapResult.width, mapResult.height)
+      : '';
 
   const useStaticFallback =
     !isMounted || prefersReducedMotion || !isSupported || !displacementMapUrl;
 
-  const filterId = `${baseFilterId}-liquid-glass-layer-${filterRevision}`;
+  const filterId = `${baseFilterId}-liquid-glass-layer-${mapSignature.replace(/:/g, '-')}`;
   const borderRadiusPx = effectiveLens.borderRadius;
   const roundedClipStyle: Pick<
     CSSProperties,

--- a/src/components/shared/liquid-glass/liquid-glass-utils.ts
+++ b/src/components/shared/liquid-glass/liquid-glass-utils.ts
@@ -1,0 +1,61 @@
+import type { LiquidGlassLens } from './types';
+
+export const MIN_MEASURED_SIZE = 1;
+
+export function computeEffectiveLens(
+  lens: LiquidGlassLens,
+  measuredSize: { width: number; height: number },
+): LiquidGlassLens {
+  return {
+    width:
+      lens.width > 0
+        ? Math.round(lens.width)
+        : Math.max(MIN_MEASURED_SIZE, measuredSize.width),
+    height:
+      lens.height > 0
+        ? Math.round(lens.height)
+        : Math.max(MIN_MEASURED_SIZE, measuredSize.height),
+    borderRadius: Math.max(0, Math.round(lens.borderRadius)),
+  };
+}
+
+export function buildMapSignature(
+  effectiveLens: LiquidGlassLens,
+  scale: number,
+  chromaAmount: number,
+): string {
+  return `${effectiveLens.width}:${effectiveLens.height}:${effectiveLens.borderRadius}:${scale}:${chromaAmount}`;
+}
+
+export function lensMapToDataUrl(
+  data: Uint8ClampedArray,
+  width: number,
+  height: number,
+): string {
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+
+  const context = canvas.getContext('2d');
+  if (!context) {
+    return '';
+  }
+
+  const imageData = context.createImageData(width, height);
+  imageData.data.set(data);
+  context.putImageData(imageData, 0, 0);
+  return canvas.toDataURL();
+}
+
+export function specularLightPosition(
+  angleDegrees: number,
+  width: number,
+  height: number,
+): { x: number; y: number; z: number } {
+  const radians = (angleDegrees * Math.PI) / 180;
+  return {
+    x: width / 2 + Math.cos(radians) * width,
+    y: height / 2 + Math.sin(radians) * height,
+    z: Math.max(width, height),
+  };
+}

--- a/src/components/shared/liquid-glass/use-liquid-glass-runtime.ts
+++ b/src/components/shared/liquid-glass/use-liquid-glass-runtime.ts
@@ -1,0 +1,70 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+
+function noopSubscribe(): () => void {
+  return () => {};
+}
+
+function getPrefersReducedMotionSnapshot(): boolean {
+  if (
+    typeof window === 'undefined' ||
+    typeof window.matchMedia !== 'function'
+  ) {
+    return false;
+  }
+
+  return window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
+function subscribePrefersReducedMotion(onStoreChange: () => void): () => void {
+  if (
+    typeof window === 'undefined' ||
+    typeof window.matchMedia !== 'function'
+  ) {
+    return noopSubscribe();
+  }
+
+  const mediaQuery = window.matchMedia(REDUCED_MOTION_QUERY);
+  mediaQuery.addEventListener('change', onStoreChange);
+  return () => mediaQuery.removeEventListener('change', onStoreChange);
+}
+
+function getSvgFilterSupportSnapshot(): boolean {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return false;
+  }
+
+  return (
+    typeof SVGFEDisplacementMapElement !== 'undefined' &&
+    typeof SVGFEImageElement !== 'undefined'
+  );
+}
+
+export function useLiquidGlassRuntime(): {
+  isMounted: boolean;
+  isSupported: boolean;
+  prefersReducedMotion: boolean;
+} {
+  const isMounted = useSyncExternalStore(
+    noopSubscribe,
+    () => true,
+    () => false,
+  );
+
+  const isSupported = useSyncExternalStore(
+    noopSubscribe,
+    getSvgFilterSupportSnapshot,
+    () => false,
+  );
+
+  const prefersReducedMotion = useSyncExternalStore(
+    subscribePrefersReducedMotion,
+    getPrefersReducedMotionSnapshot,
+    () => false,
+  );
+
+  return { isMounted, isSupported, prefersReducedMotion };
+}

--- a/tests/unit/components/liquid-glass/LiquidGlass.spec.tsx
+++ b/tests/unit/components/liquid-glass/LiquidGlass.spec.tsx
@@ -3,10 +3,10 @@ import {
   LiquidGlassLayer,
 } from '@/components/shared/liquid-glass';
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-function mockMotionPreference(matches: boolean): void {
-  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+function createMatchMediaMock(matches: boolean) {
+  return vi.fn().mockImplementation((query: string) => ({
     matches,
     media: query,
     onchange: null,
@@ -17,6 +17,14 @@ function mockMotionPreference(matches: boolean): void {
     dispatchEvent: vi.fn(),
   }));
 }
+
+function mockMotionPreference(matches: boolean): void {
+  vi.stubGlobal('matchMedia', createMatchMediaMock(matches));
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe('LiquidGlass', () => {
   it('keeps the decorative glass layer behind interactive content', () => {
@@ -42,6 +50,24 @@ describe('LiquidGlass', () => {
       'inset-0',
       '-z-10',
     );
+  });
+
+  it('falls back to static glass when matchMedia is unavailable', () => {
+    vi.stubGlobal('matchMedia', undefined);
+
+    render(
+      <LiquidGlass
+        lens={{ width: 32, height: 16, borderRadius: 8 }}
+        fallbackClassName='bg-white/40 backdrop-blur-sm'
+      >
+        <button type='button'>Open navigation</button>
+      </LiquidGlass>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Open navigation' }),
+    ).toBeEnabled();
+    expect(document.querySelector('filter')).toBeNull();
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses valid [React Doctor](https://react.doctor) findings from PR #354 on the liquid glass components.

### Valid findings fixed

| Finding | Fix |
| --- | --- |
| `set-state-in-effect` / `no-initialize-state` | Replaced mount-only `useEffect` state (`isMounted`, `isSupported`, `prefersReducedMotion`) with `useSyncExternalStore` in `useLiquidGlassRuntime` |
| `no-adjust-state-on-prop-change` / `no-chain-state-updates` | Removed `filterRevision` effect; SVG filter IDs now derive from `mapSignature` |
| `react-compiler-no-manual-memoization` / `no-usememo-simple-expression` | Removed redundant `useMemo` wrappers; React Compiler handles these derivations |
| CI `matchMedia is not a function` | Runtime hook guards missing `matchMedia`; tests use `vi.stubGlobal` + `afterEach` restore |

### Intentionally not changed

- **`prefer-useReducer`** — cosmetic grouping suggestion; no behavioral bug
- **`no-giant-component`** — SVG filter markup is inherently verbose; splitting would be a larger refactor outside this fix scope

## Test plan

- [x] `pnpm exec vitest run tests/unit/components/liquid-glass/ tests/unit/components/nav/header-shell.spec.ts`
- [x] `pnpm check:type`
- [x] `pnpm check:lint`
- [x] `npx react-doctor@latest src/components/shared/liquid-glass --verbose --scope changed` → 100/100
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91e4c4a8-4319-4fdc-8327-d7a8fbf35a85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91e4c4a8-4319-4fdc-8327-d7a8fbf35a85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

