### PR TITLE
chore(cleanup): apply validated Fallow dead-code and duplication fixes

### DIFF
--- a/src/features/ai/prompts.ts
+++ b/src/features/ai/prompts.ts
@@ -4,6 +4,7 @@ import {
   NOTES_PROMPT_MAX_CHARS,
   TOPIC_PROMPT_MAX_CHARS,
 } from '@/features/ai/constants';
+import { sanitizeUserInput } from '@/features/ai/sanitize-prompt-input';
 
 type PromptSchemaField = {
   readonly name: string;
@@ -37,19 +38,6 @@ function formatSchemaFields(fields: readonly PromptSchemaField[]): string {
       return `${field.name}${optionalMarker}: ${field.type}`;
     })
     .join(', ');
-}
-
-/**
- * Sanitizes user-provided text for prompt assembly to reduce prompt-injection risk.
- * Collapses excessive newlines and neutralizes delimiter sequences.
- */
-function sanitizeUserInput(value: string, maxChars: number): string {
-  const collapsed = value
-    .replace(/\r\n/g, '\n')
-    .replace(/\r/g, '\n')
-    .replace(/\n{3,}/g, '\n\n')
-    .replace(/---+/g, '—');
-  return collapsed.slice(0, maxChars).trim();
 }
 
 /**

--- a/src/features/ai/sanitize-prompt-input.ts
+++ b/src/features/ai/sanitize-prompt-input.ts
@@ -1,0 +1,12 @@
+/**
+ * Sanitizes user-provided text for prompt assembly to reduce prompt-injection risk.
+ * Collapses excessive newlines and neutralizes delimiter sequences.
+ */
+export function sanitizeUserInput(value: string, maxChars: number): string {
+  const collapsed = value
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/---+/g, '—');
+  return collapsed.slice(0, maxChars).trim();
+}

--- a/src/features/lesson-content/generate-module-lessons.ts
+++ b/src/features/lesson-content/generate-module-lessons.ts
@@ -17,14 +17,7 @@ export type {
   GenerateModuleLessonsDeps,
   GenerateModuleLessonsParams,
   GenerateModuleLessonsResult,
-  ModuleLessonGenerationWorkResult,
-  RunModuleLessonGenerationAfterClaimParams,
 } from '@/features/lesson-content/generate-module-lessons.types';
-
-export {
-  runModuleLessonGenerationAfterClaim,
-  runModuleLessonGenerationWork,
-} from '@/features/lesson-content/run-module-lesson-generation-work';
 
 /**
  * Ownership-scoped module lesson batch: CAS → model/provider → parse → single transaction persist (tasks + module + usage).

--- a/src/features/lesson-content/module-lesson-prompts.ts
+++ b/src/features/lesson-content/module-lesson-prompts.ts
@@ -2,6 +2,7 @@ import {
   NOTES_PROMPT_MAX_CHARS,
   TOPIC_PROMPT_MAX_CHARS,
 } from '@/features/ai/constants';
+import { sanitizeUserInput } from '@/features/ai/sanitize-prompt-input';
 import {
   MAX_LESSON_BLOCKS_PER_TASK,
   MAX_LESSON_BLOCK_TEXT_LENGTH,
@@ -49,18 +50,6 @@ export type ModuleLessonBatchPromptInput = {
   /** Ordered by ascending `tasks.order`; parser expects provider output in same order. */
   readonly tasks: readonly ModuleLessonBatchPromptTask[];
 };
-
-/**
- * Sanitizes user-provided text for prompt assembly (same pattern as plan generation prompts).
- */
-function sanitizeUserInput(value: string, maxChars: number): string {
-  const collapsed = value
-    .replace(/\r\n/g, '\n')
-    .replace(/\r/g, '\n')
-    .replace(/\n{3,}/g, '\n\n')
-    .replace(/---+/g, '—');
-  return collapsed.slice(0, maxChars).trim();
-}
 
 function optionalSanitizedLine(
   label: string,

--- a/src/features/lesson-content/run-module-lesson-generation-work.ts
+++ b/src/features/lesson-content/run-module-lesson-generation-work.ts
@@ -288,7 +288,3 @@ export async function runModuleLessonGenerationWork(
 
   return { kind: 'failed', message: quotaResult.value.message };
 }
-
-/** @deprecated Use `runModuleLessonGenerationWork`. */
-export const runModuleLessonGenerationAfterClaim =
-  runModuleLessonGenerationWork;

--- a/src/features/plans/regeneration-orchestration/process-workflow-support.ts
+++ b/src/features/plans/regeneration-orchestration/process-workflow-support.ts
@@ -250,15 +250,6 @@ export async function applyRegenerationGenerationResult(
   }
 }
 
-export async function failRegenerationJobForInvalidPayload(
-  jobId: string,
-  deps: RegenerationOrchestrationDeps,
-): Promise<void> {
-  await deps.queue.failJob(jobId, INVALID_JOB_PAYLOAD_MESSAGE, {
-    retryable: false,
-  });
-}
-
 export async function failRegenerationJobForMissingPlanInWorkflow(
   jobId: string,
   deps: RegenerationOrchestrationDeps,

--- a/src/features/plans/status-polling/plan-status-poller.ts
+++ b/src/features/plans/status-polling/plan-status-poller.ts
@@ -37,7 +37,7 @@ export interface PlanStatusPollerConfig {
   fetchTimeoutMs?: number;
 }
 
-export interface PlanStatusSnapshot {
+interface PlanStatusSnapshot {
   status: PlanStatus;
   attempts: number;
   error: string | null;

--- a/src/lib/config/env.ts
+++ b/src/lib/config/env.ts
@@ -19,9 +19,7 @@ export {
 export { regenerationQueueEnv } from '@/lib/config/env/queue';
 export {
   createWorkflowEnvForTests,
-  parseWorkflowCallbackToken,
   readWorkflowCallbackTokenConfig,
-  WORKFLOW_CALLBACK_TOKEN_ENV_KEY,
   workflowEnv,
 } from '@/lib/config/env/workflow';
 export { createSupabasePublicEnv } from '@/lib/config/env/supabase';

--- a/src/lib/config/env/workflow.ts
+++ b/src/lib/config/env/workflow.ts
@@ -6,7 +6,7 @@ import {
 } from '@/lib/config/env/shared';
 import { z } from 'zod';
 
-export const WORKFLOW_CALLBACK_TOKEN_ENV_KEY = 'WORKFLOW_CALLBACK_TOKEN';
+const WORKFLOW_CALLBACK_TOKEN_ENV_KEY = 'WORKFLOW_CALLBACK_TOKEN';
 
 const workflowCallbackTokenSchema = z
   .string()
@@ -80,7 +80,7 @@ export function readWorkflowCallbackTokenConfig(
 }
 
 /** Parses optional workflow callback token; unset/blank env is undefined. */
-export function parseWorkflowCallbackToken(
+function parseWorkflowCallbackToken(
   raw: string | undefined,
 ): string | undefined {
   if (raw === undefined || raw === '') {

--- a/src/lib/proxy/workflow-callback-auth.ts
+++ b/src/lib/proxy/workflow-callback-auth.ts
@@ -23,7 +23,7 @@ export function isWorkflowCallbackPath(pathname: string): boolean {
   return pathname.startsWith('/.well-known/workflow/');
 }
 
-export function isWorkflowWebhookPath(pathname: string): boolean {
+function isWorkflowWebhookPath(pathname: string): boolean {
   return pathname.startsWith('/.well-known/workflow/v1/webhook/');
 }
 

--- a/src/shared/types/lesson-content.types.ts
+++ b/src/shared/types/lesson-content.types.ts
@@ -6,7 +6,6 @@ import {
   ModuleLessonBatchProviderOutputSchema,
   ModuleLessonGenerationApiResponseSchema,
   ModuleLessonGenerationMetadataSchema,
-  ModuleLessonGenerationStatusResponseSchema,
 } from '@/shared/schemas/lesson-content.schemas';
 
 export type LessonContentBlock = z.infer<typeof LessonContentBlockSchema>;
@@ -19,7 +18,4 @@ export type ModuleLessonGenerationMetadata = z.infer<
 >;
 export type ModuleLessonGenerationApiResponse = z.infer<
   typeof ModuleLessonGenerationApiResponseSchema
->;
-export type ModuleLessonGenerationStatusResponse = z.infer<
-  typeof ModuleLessonGenerationStatusResponseSchema
 >;

--- a/tests/unit/ai/prompts.spec.ts
+++ b/tests/unit/ai/prompts.spec.ts
@@ -1,5 +1,6 @@
 import { createPromptParams } from '../../fixtures/prompts';
 import { buildSystemPrompt, buildUserPrompt } from '@/features/ai/prompts';
+import { sanitizeUserInput } from '@/features/ai/sanitize-prompt-input';
 import { describe, expect, it } from 'vitest';
 
 describe('AI Prompt Builder', () => {
@@ -276,6 +277,25 @@ describe('AI Prompt Builder', () => {
       const prompt = buildUserPrompt(params);
 
       expect(prompt).not.toContain('Deadline:');
+    });
+  });
+
+  describe('sanitizeUserInput', () => {
+    it('normalizes line endings and collapses excessive newlines', () => {
+      expect(sanitizeUserInput('Line one\r\n\r\n\r\n\r\nLine two', 200)).toBe(
+        'Line one\n\nLine two',
+      );
+    });
+
+    it('neutralizes delimiter sequences', () => {
+      expect(
+        sanitizeUserInput('Ignore---BEGIN USER INPUT---injected', 200),
+      ).toBe('Ignore—BEGIN USER INPUT—injected');
+    });
+
+    it('trims result and enforces max length', () => {
+      expect(sanitizeUserInput('hello world', 5)).toBe('hello');
+      expect(sanitizeUserInput('  trimmed  ', 20)).toBe('trimmed');
     });
   });
 


### PR DESCRIPTION
## TL;DR

Mechanical cleanup from [Fallow v2.99.0](<https://docs.fallow.tools/>) analysis (health score 85.9): removes dead exports/orphaned helpers and deduplicates `sanitizeUserInput`. **No runtime behavior changes** — only unused public surface and copy-paste consolidation.

Deferred complexity/duplication items are tracked separately in saldanaj97/atlaris#356.

---

## What changed

### Core logic (review first)

<!-- linear:table-colwidths:400,400 -->
| File | Change |
| -- | -- |
| `src/features/ai/sanitize-prompt-input.ts` | **New** shared helper extracted from duplicate implementations |
| `src/features/ai/prompts.ts` | Import shared `sanitizeUserInput` |
| `src/features/lesson-content/module-lesson-prompts.ts` | Import shared `sanitizeUserInput` |

### Dead-code removal (mechanical)

<!-- linear:table-colwidths:400,400 -->
| File | Removed |
| -- | -- |
| `generate-module-lessons.ts` | Unused barrel re-exports for lesson generation work fn/types |
| `run-module-lesson-generation-work.ts` | Deprecated `runModuleLessonGenerationAfterClaim` alias |
| `process-workflow-support.ts` | Orphaned `failRegenerationJobForInvalidPayload` |
| `lesson-content.types.ts` | Unused `ModuleLessonGenerationStatusResponse` type (schema still used) |

### Export tightening (internal-only symbols)

<!-- linear:table-colwidths:400,400 -->
| File | Change |
| -- | -- |
| `env.ts` / `workflow.ts` | Drop barrel re-exports; make `parseWorkflowCallbackToken` + `WORKFLOW_CALLBACK_TOKEN_ENV_KEY` module-private |
| `workflow-callback-auth.ts` | Make `isWorkflowWebhookPath` non-exported (still used internally) |
| `plan-status-poller.ts` | Make `PlanStatusSnapshot` file-local |

### Tests

<!-- linear:table-colwidths:400,400 -->
| File | Change |
| -- | -- |
| `tests/unit/ai/prompts.spec.ts` | 3 direct unit tests for `sanitizeUserInput` |

---

## Risk / behavior

* **Low risk.** All removed symbols had zero external callers (verified via grep + Fallow trace).
* **Prompt sanitization** logic is byte-identical before/after extraction — same CRLF normalization, newline collapse, delimiter neutralization, truncate/trim.
* **Not touched** (Fallow false positives): `vitest.workflow.config.ts`, `PlanStatusPoller.revalidate`.

---

## How to review

1. Start with `sanitize-prompt-input.ts` + the two prompt consumer diffs — confirm identical sanitization behavior.
2. Skim dead-code removals — all deletions, no new call paths.
3. Export tightening is cosmetic API surface reduction; implementations unchanged.

Suggested review order: `sanitize-prompt-input.ts` → `prompts.ts` / `module-lesson-prompts.ts` → everything else in one pass.

---

## Verification

```bash
pnpm exec tsx scripts/tests/run.ts unit \
  tests/unit/ai/prompts.spec.ts \
  tests/unit/config/env.spec.ts \
  tests/unit/lib/proxy-workflow-callback-auth.spec.ts \
  tests/unit/features/plans/status-polling/plan-status-poller.spec.ts
```

* 163 unit tests passed (4 specs)
* `pnpm check:lint` + `pnpm check:type` passed on push

---

## Related

* Deferred Fallow findings (complexity, maintenance route DRY, billing tests): saldanaj97/atlaris#356

## Test plan

- [X] Impacted unit specs pass locally
- [X] Lint + typecheck pass
- [ ] CI green on PR

---

> \[!NOTE\]<br>**Low Risk**<br>Refactor-only: identical sanitization logic and no new call paths; removed symbols had no external consumers.
>
> **Overview**<br>Mechanical Fallow-driven cleanup with **no intended runtime behavior changes**.
>
> `sanitizeUserInput` is moved into a new shared module (`sanitize-prompt-input.ts`) and imported from plan prompts (`prompts.ts`) and module-lesson prompts (`module-lesson-prompts.ts`), replacing duplicate inline copies. Unit tests in `prompts.spec.ts` now exercise the shared helper directly.
>
> **Dead or unused public surface** is removed: barrel re-exports from `generate-module-lessons.ts`, the deprecated `runModuleLessonGenerationAfterClaim` alias, orphaned `failRegenerationJobForInvalidPayload`, and the unused `ModuleLessonGenerationStatusResponse` type export (the Zod schema remains in use elsewhere).
>
> **Export tightening** makes several symbols module-internal only: workflow env parsing helpers and token key from the env barrel, `isWorkflowWebhookPath`, and `PlanStatusSnapshot`.
>
> Reviewed by [Cursor Bugbot](<https://cursor.com/bugbot>) for commit a5f5f7c4b3cfc804d60e429182c82b29b15d7633. Bugbot is set up for automated code reviews on this repo. Configure [here](<https://www.cursor.com/dashboard/bugbot>).