### PR TITLE
Harden deployment tooling, privacy logs, and product claims

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -16,14 +16,14 @@ NEXT_PUBLIC_ENABLE_SENTRY=false
 # Enable the seeded local auth bypass for fast development.
 LOCAL_PRODUCT_TESTING=true
 
-# Seeded local auth user id created by `pnpm db:dev:bootstrap`.
-DEV_AUTH_USER_ID=local-product-testing-user
+# Seeded local auth user id created by `pnpm db:dev:reset`.
+DEV_AUTH_USER_ID=00000000-0000-4000-8000-000000000001
 
 # Seeded local auth email shown in local product testing.
-DEV_AUTH_USER_EMAIL=dev@example.com
+DEV_AUTH_USER_EMAIL=local-product-test@localhost.local
 
 # Seeded local auth display name shown in local product testing.
-DEV_AUTH_USER_NAME=Dev User
+DEV_AUTH_USER_NAME=Local Product Test
 
 # Local Supabase Postgres URL from `pnpm db:dev:start`.
 POSTGRES_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres

--- a/.github/workflows/production-db-migrations.yaml
+++ b/.github/workflows/production-db-migrations.yaml
@@ -25,12 +25,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@v1
+        uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf # v2.1.1
         with:
-          version: latest
+          version: 2.98.1
+
+      - name: Print Supabase CLI version
+        run: supabase --version
 
       - name: Link production project
         run: supabase link --project-ref "$SUPABASE_PROJECT_ID"

--- a/.github/workflows/staging-db-migrations.yaml
+++ b/.github/workflows/staging-db-migrations.yaml
@@ -25,12 +25,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@v1
+        uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf # v2.1.1
         with:
-          version: latest
+          version: 2.98.1
+
+      - name: Print Supabase CLI version
+        run: supabase --version
 
       - name: Link staging project
         run: supabase link --project-ref "$SUPABASE_PROJECT_ID"

--- a/docs/testing/smoke-test-results-2026-04-01.md
+++ b/docs/testing/smoke-test-results-2026-04-01.md
@@ -19,7 +19,7 @@
 
 ### Phase 0 — Environment Setup
 
-- `pnpm db:dev:bootstrap` passed
+- `pnpm db:dev:reset` passed
 - Anonymous server startup passed with no env validation errors
 - Authenticated server startup passed with no env validation errors
 
@@ -103,7 +103,7 @@
 ## Verification Commands
 
 ```bash
-pnpm db:dev:bootstrap
+pnpm db:dev:reset
 pnpm dev
 pnpm test:changed
 chrome-devtools navigate_page --url http://localhost:3000/landing

--- a/src/app/(marketing)/about/components/MissionSection.tsx
+++ b/src/app/(marketing)/about/components/MissionSection.tsx
@@ -22,10 +22,10 @@ export function MissionSection() {
             leave learners overwhelmed and without direction.
           </p>
           <p className='text-lg leading-relaxed text-muted-foreground'>
-            Atlaris transforms your learning goals into structured, time-blocked
-            plans tailored to your schedule. We generate modules, attach curated
-            resources to each lesson, and sync sessions to your calendar so
-            progress does not stall after week one.
+            Atlaris transforms your learning goals into structured plans that
+            build momentum. We generate focused modules, attach curated
+            resources to each lesson, and make progress visible so learning does
+            not stall after week one.
           </p>
         </div>
 
@@ -66,9 +66,9 @@ const HIGHLIGHTS: Highlight[] = [
   },
   {
     icon: <CalendarDays className='size-5 text-white' aria-hidden='true' />,
-    title: 'Calendar Sync',
+    title: 'Learning Momentum',
     description:
-      'Plans sync directly to Google Calendar so learning fits your life.',
+      'Clear milestones and visible progress keep each learning plan moving.',
   },
   {
     icon: <Library className='size-5 text-white' aria-hidden='true' />,

--- a/src/app/api/v1/plans/stream/route.ts
+++ b/src/app/api/v1/plans/stream/route.ts
@@ -51,7 +51,8 @@ function toPayloadLog(payload: unknown): Record<string, unknown> {
   };
 
   return {
-    topic: typeof maybePayload.topic === 'string' ? maybePayload.topic : null,
+    hasTopic:
+      typeof maybePayload.topic === 'string' && maybePayload.topic.length > 0,
     skillLevel:
       typeof maybePayload.skillLevel === 'string'
         ? maybePayload.skillLevel

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,14 +20,15 @@ const youngSerif = Young_Serif({
   variable: '--font-young-serif',
 });
 
+const metadataDescription =
+  'Create personalized learning plans with AI-generated modules and tasks. Track progress and learn smarter.';
+
 export const metadata: Metadata = {
   title: 'Atlaris - AI-Powered Learning Paths',
-  description:
-    'Create personalized learning plans with AI-generated modules and tasks. Track progress, sync to Google Calendar, and learn smarter.',
+  description: metadataDescription,
   openGraph: {
     title: 'Atlaris - AI-Powered Learning Paths',
-    description:
-      'Create personalized learning plans with AI-generated modules and tasks. Track progress, sync to Google Calendar, and learn smarter.',
+    description: metadataDescription,
     images: [
       { url: '/og-default.jpg', width: 1200, height: 630, alt: 'Atlaris' },
       {
@@ -43,8 +44,7 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'Atlaris - AI-Powered Learning Paths',
-    description:
-      'Create personalized learning plans with AI-generated modules and tasks.',
+    description: metadataDescription,
     images: ['/og-default.jpg'],
     site: '@atlarisapp',
     creator: '@atlarisapp',

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -10,9 +10,9 @@ insert into public.users (
 )
 values (
   '11111111-1111-4111-8111-111111111111'::uuid,
-  'user_33d1Ci8mqFZqiIb7pMYj0671CXj',
-  'local-dev@example.com',
-  'local-dev-free',
+  '00000000-0000-4000-8000-000000000001',
+  'local-product-test@localhost.local',
+  'Local Product Test',
   'free',
   false,
   0

--- a/tests/integration/api/plans-stream.spec.ts
+++ b/tests/integration/api/plans-stream.spec.ts
@@ -109,6 +109,41 @@ describe('POST /api/v1/plans/stream — HTTP preflight + default boundary smoke'
     });
   });
 
+  it('logs only structural topic metadata for identity-linked payloads', async () => {
+    const authUserId = buildTestAuthUserId('stream-private-topic-log');
+    await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+      subscriptionTier: 'pro',
+    });
+    setTestUser(authUserId);
+
+    const privateTopic = 'Private health diagnosis research';
+    const testLogger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const post = createStreamHandler({ logger: testLogger });
+    const response = await post(
+      new Request('http://localhost/api/v1/plans/stream', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ topic: privateTopic }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    const payloadCall = testLogger.info.mock.calls.find(
+      ([, message]) => message === 'Plan stream request payload received',
+    );
+    expect(payloadCall?.[0]).toMatchObject({
+      authUserId,
+      payload: { hasTopic: true },
+    });
+    expect(JSON.stringify(payloadCall?.[0])).not.toContain(privateTopic);
+  });
+
   it('warns when payload log fails and still returns an error response', async () => {
     const authUserId = buildTestAuthUserId('stream-payload-log-throw');
     await ensureUser({

--- a/tests/unit/config/local-product-testing-seed.spec.ts
+++ b/tests/unit/config/local-product-testing-seed.spec.ts
@@ -1,0 +1,37 @@
+import {
+  LOCAL_PRODUCT_TESTING_SEED_AUTH_USER_ID,
+  LOCAL_PRODUCT_TESTING_SEED_EMAIL,
+  LOCAL_PRODUCT_TESTING_SEED_NAME,
+  LOCAL_PRODUCT_TESTING_SEED_USER_ROW_ID,
+} from '@/lib/config/local-product-testing';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('local product-testing seed contract', () => {
+  it('keeps the committed SQL seed aligned with the TypeScript identity', () => {
+    const seedSql = readFileSync(resolve('supabase/seed.sql'), 'utf8');
+
+    expect(seedSql).toContain(
+      `'${LOCAL_PRODUCT_TESTING_SEED_USER_ROW_ID}'::uuid`,
+    );
+    expect(seedSql).toContain(`'${LOCAL_PRODUCT_TESTING_SEED_AUTH_USER_ID}'`);
+    expect(seedSql).toContain(`'${LOCAL_PRODUCT_TESTING_SEED_EMAIL}'`);
+    expect(seedSql).toContain(`'${LOCAL_PRODUCT_TESTING_SEED_NAME}'`);
+  });
+
+  it('keeps the local environment example aligned with the seed identity', () => {
+    const envExample = readFileSync(resolve('.env.local.example'), 'utf8');
+
+    expect(envExample).toContain(
+      `DEV_AUTH_USER_ID=${LOCAL_PRODUCT_TESTING_SEED_AUTH_USER_ID}`,
+    );
+    expect(envExample).toContain(
+      `DEV_AUTH_USER_EMAIL=${LOCAL_PRODUCT_TESTING_SEED_EMAIL}`,
+    );
+    expect(envExample).toContain(
+      `DEV_AUTH_USER_NAME=${LOCAL_PRODUCT_TESTING_SEED_NAME}`,
+    );
+    expect(envExample).toContain('created by `pnpm db:dev:reset`');
+  });
+});


### PR DESCRIPTION
## Findings

Addresses findings 1, 5, 10, and 11: mutable migration dependencies, inconsistent local seed identity, identity-linked raw topic logging, and calendar-sync product claims.

## Behavioral invariants

- Privileged migration workflows use immutable action SHAs and Supabase CLI 2.98.1, printing the installed version before linking.
- SQL seed data, TypeScript constants, and the local environment example identify the same deterministic local user.
- Plan request logs expose structural fields and `hasTopic`, never the topic text.
- Root metadata and the About mission describe shipped learning-plan behavior without claiming calendar sync is available.

## Intentionally unchanged

- Calendar sync is not implemented.
- README and Settings continue to identify calendar integration as coming soon.
- No database schema or hosted deployment behavior changed.

## Validation

- `SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit tests/unit/config/local-product-testing-seed.spec.ts` — passed (2 tests)
- `NODE_ENV=test pnpm vitest run --config vitest.config.ts --project integration tests/integration/api/plans-stream.spec.ts -t 'logs only structural topic metadata'` — passed (1 test)
- `pnpm test` — passed
- `pnpm check:full` — passed

## Rollout and observation

- After merge, confirm the staging migration workflow prints Supabase CLI 2.98.1 and completes.
- Production remains unchanged until the normal `main` deployment.

## Remaining risk

- The pinned CLI/action versions require deliberate future dependency updates.
- Copy outside the root metadata and About mission remains outside this finding set unless it represents the existing explicit coming-soon state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Plan-stream logging changes reduce PII exposure but touch an authenticated AI route; pinned migration workflows change how staging/production migrations run and need post-merge verification.
> 
> **Overview**
> Pins **staging and production** Supabase migration workflows to immutable `actions/checkout` and `supabase/setup-cli` SHAs, fixes **Supabase CLI 2.98.1**, and logs the installed CLI version before `db push`.
> 
> Aligns **local product-testing identity** across `supabase/seed.sql`, `.env.local.example`, and existing TypeScript seed constants (deterministic auth user id/email/name), documents **`pnpm db:dev:reset`** instead of bootstrap, and adds a unit test that keeps SQL, env example, and constants in sync.
> 
> **Plan stream** request logging no longer records raw `topic` text; it logs **`hasTopic`** plus other structural fields only, with an integration test asserting sensitive topic strings never appear in logs.
> 
> **Root metadata** and the **About** mission copy drop Google Calendar sync claims in favor of progress/momentum messaging; smoke-test notes reference the updated dev reset command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe2d0d252330e60ac19e7cdcef32e09efccba880. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->