### PR TITLE
Harden Stripe webhook lifecycle and customer provisioning

### DIFF
--- a/src/app/api/v1/stripe/webhook/route.ts
+++ b/src/app/api/v1/stripe/webhook/route.ts
@@ -14,6 +14,33 @@ import {
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
+const WEBHOOK_MAX_BYTES = 256 * 1024;
+
+async function readUtf8BodyCapped(req: Request): Promise<string | null> {
+  if (!req.body) {
+    return '';
+  }
+
+  const reader = req.body.getReader();
+  const decoder = new TextDecoder();
+  let body = '';
+  let bytesRead = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      return body + decoder.decode();
+    }
+
+    bytesRead += value.byteLength;
+    if (bytesRead > WEBHOOK_MAX_BYTES) {
+      await reader.cancel();
+      return null;
+    }
+    body += decoder.decode(value, { stream: true });
+  }
+}
+
 // Startup validation: STRIPE_WEBHOOK_DEV_MODE must only be enabled in development/test
 if (stripeEnv.webhookDevMode && !(appEnv.isDevelopment || appEnv.isTest)) {
   throw new Error(
@@ -56,6 +83,12 @@ export function createWebhookHandler(deps: WebhookHandlerDeps): PlainHandler {
       throw error;
     }
 
+    const signatureHeader = req.headers.get('stripe-signature');
+    if (!signatureHeader) {
+      logger.warn('Stripe webhook missing signature');
+      return respond('missing signature', { status: 400 });
+    }
+
     const contentLengthHeader = req.headers.get('content-length');
     const contentLengthParsed =
       contentLengthHeader !== null ? Number(contentLengthHeader) : Number.NaN;
@@ -64,12 +97,21 @@ export function createWebhookHandler(deps: WebhookHandlerDeps): PlainHandler {
         ? contentLengthParsed
         : null;
 
-    const rawBody = await req.text();
-    const signatureHeader = req.headers.get('stripe-signature');
+    if (contentLength !== null && contentLength > WEBHOOK_MAX_BYTES) {
+      logger.warn(
+        { contentLength, maxBytes: WEBHOOK_MAX_BYTES },
+        'Stripe webhook payload too large (content-length)',
+      );
+      return respond('payload too large', { status: 413 });
+    }
 
-    if (!signatureHeader) {
-      logger.warn('Stripe webhook missing signature');
-      return respond('missing signature', { status: 400 });
+    const rawBody = await readUtf8BodyCapped(req);
+    if (rawBody === null) {
+      logger.warn(
+        { maxBytes: WEBHOOK_MAX_BYTES },
+        'Stripe webhook payload too large while streaming',
+      );
+      return respond('payload too large', { status: 413 });
     }
 
     const result = await deps.boundary.acceptWebhook({

--- a/src/features/billing/stripe-commerce/reconciliation.ts
+++ b/src/features/billing/stripe-commerce/reconciliation.ts
@@ -34,7 +34,7 @@ import {
 import { createCustomer } from '@/features/billing/subscriptions';
 import { stripeWebhookEvents } from '@supabase/schema';
 import { db as serviceRoleDb } from '@supabase/service-role';
-import { eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 
 type Logger = ReturnType<typeof createLogger>;
@@ -98,18 +98,6 @@ function throwIfAborted(signal?: AbortSignal): void {
   throw error;
 }
 
-async function updateUsersByStripeCustomerId(
-  customerId: string,
-  set: UpdateUsersByStripeCustomerIdSet,
-  deps: Pick<TransitionDeps, 'db' | 'users'>,
-) {
-  return deps.db
-    .update(deps.users)
-    .set(set)
-    .where(eq(deps.users.stripeCustomerId, customerId))
-    .returning({ userId: deps.users.id });
-}
-
 async function getUsersByStripeCustomerId(
   customerId: string,
   deps: Pick<TransitionDeps, 'db' | 'users'>,
@@ -127,6 +115,7 @@ async function getUsersByStripeCustomerId(
 
 async function updateUsersByIds(
   userIds: string[],
+  subscriptionId: string,
   set: UpdateUsersByStripeCustomerIdSet,
   deps: Pick<TransitionDeps, 'db' | 'users'>,
 ) {
@@ -137,8 +126,21 @@ async function updateUsersByIds(
   return deps.db
     .update(deps.users)
     .set(set)
-    .where(inArray(deps.users.id, userIds))
+    .where(
+      and(
+        inArray(deps.users.id, userIds),
+        eq(deps.users.stripeSubscriptionId, subscriptionId),
+      ),
+    )
     .returning({ userId: deps.users.id });
+}
+
+function getInvoiceSubscriptionId(invoice: Stripe.Invoice): string | null {
+  const subscription = invoice.parent?.subscription_details?.subscription;
+  if (typeof subscription === 'string') {
+    return subscription;
+  }
+  return subscription?.id ?? null;
 }
 
 export async function applySubscriptionSync(
@@ -179,26 +181,33 @@ export async function applySubscriptionDeleted(
     currentPeriodEnd !== null &&
     currentPeriodEnd.getTime() > Date.now();
 
-  const updatedUsers = await updateUsersByStripeCustomerId(
-    customerId,
-    shouldRetainEntitlements
-      ? {
-          subscriptionStatus: 'canceled',
-          stripeSubscriptionId: null,
-          subscriptionPeriodEnd: currentPeriodEnd,
-          cancelAtPeriodEnd: true,
-          updatedAt: new Date(),
-        }
-      : {
-          subscriptionTier: 'free',
-          subscriptionStatus: 'canceled',
-          stripeSubscriptionId: null,
-          subscriptionPeriodEnd: null,
-          cancelAtPeriodEnd: false,
-          updatedAt: new Date(),
-        },
-    deps,
-  );
+  const updatedUsers = await deps.db
+    .update(deps.users)
+    .set(
+      shouldRetainEntitlements
+        ? {
+            subscriptionStatus: 'canceled',
+            stripeSubscriptionId: null,
+            subscriptionPeriodEnd: currentPeriodEnd,
+            cancelAtPeriodEnd: true,
+            updatedAt: new Date(),
+          }
+        : {
+            subscriptionTier: 'free',
+            subscriptionStatus: 'canceled',
+            stripeSubscriptionId: null,
+            subscriptionPeriodEnd: null,
+            cancelAtPeriodEnd: false,
+            updatedAt: new Date(),
+          },
+    )
+    .where(
+      and(
+        eq(deps.users.stripeCustomerId, customerId),
+        eq(deps.users.stripeSubscriptionId, subscription.id),
+      ),
+    )
+    .returning({ userId: deps.users.id });
 
   throwIfAborted(options?.signal);
 
@@ -248,6 +257,15 @@ export async function applyPaymentFailed(
     return;
   }
 
+  const subscriptionId = getInvoiceSubscriptionId(invoice);
+  if (!subscriptionId) {
+    deps.logger.info(
+      { customerId, invoiceId: invoice.id },
+      'Skipped invoice.payment_failed without subscription identity',
+    );
+    return;
+  }
+
   const mappedUsers = await getUsersByStripeCustomerId(customerId, deps);
 
   throwIfAborted(options?.signal);
@@ -266,6 +284,7 @@ export async function applyPaymentFailed(
   const eligibleUsers = mappedUsers.filter(
     (user) =>
       user.stripeSubscriptionId !== null &&
+      user.stripeSubscriptionId === subscriptionId &&
       (user.subscriptionStatus === 'trialing' ||
         user.subscriptionStatus === 'active' ||
         user.subscriptionStatus === 'past_due'),
@@ -292,6 +311,7 @@ export async function applyPaymentFailed(
 
   const updatedUsers = await updateUsersByIds(
     eligibleUsers.map((user) => user.userId),
+    subscriptionId,
     {
       subscriptionStatus: 'past_due',
       updatedAt: new Date(),
@@ -446,10 +466,7 @@ async function dispatchVerifiedStripeEvent(
 
     case 'invoice.payment_succeeded': {
       const invoice = event.data.object as Stripe.Invoice;
-      const subscriptionId =
-        typeof invoice.subscription === 'string'
-          ? invoice.subscription
-          : invoice.subscription?.id;
+      const subscriptionId = getInvoiceSubscriptionId(invoice);
 
       if (!subscriptionId || !gateway) {
         const message = !subscriptionId

--- a/src/features/billing/subscriptions.ts
+++ b/src/features/billing/subscriptions.ts
@@ -5,7 +5,7 @@ import { getStripe } from './client';
 import { logger } from '@/lib/logging/logger';
 import { getDb } from '@supabase/runtime';
 import { users } from '@supabase/schema';
-import { eq, sql } from 'drizzle-orm';
+import { and, eq, isNull, sql } from 'drizzle-orm';
 
 const CUSTOMER_PROVISION_LOCK_KEY = 2;
 const CUSTOMER_PROVISION_REQUEST_TIMEOUT_MS = 10_000;
@@ -50,6 +50,7 @@ export async function createCustomer(
       },
       {
         timeout: CUSTOMER_PROVISION_REQUEST_TIMEOUT_MS,
+        idempotencyKey: `atlaris:customer-provisioning:v1:${userId}`,
       },
     );
     const stripeCallDurationMs = Date.now() - stripeCallStartedAt;
@@ -65,13 +66,20 @@ export async function createCustomer(
       );
     }
 
-    await tx
+    const updatedUsers = await tx
       .update(users)
       .set({
         stripeCustomerId: customer.id,
         updatedAt: new Date(),
       })
-      .where(eq(users.id, userId));
+      .where(and(eq(users.id, userId), isNull(users.stripeCustomerId)))
+      .returning({ userId: users.id });
+
+    if (updatedUsers.length !== 1) {
+      throw new Error(
+        `Stripe customer provisioning did not update exactly one user row (userId=${userId}, updated=${updatedUsers.length}).`,
+      );
+    }
 
     return customer.id;
   });

--- a/tests/fixtures/stripe-mocks.ts
+++ b/tests/fixtures/stripe-mocks.ts
@@ -123,8 +123,11 @@ export function makeStripeSubscription(
  * Build a partial Stripe.Invoice object suitable for webhook test fixtures.
  */
 export function makeStripeInvoice(
-  partial: DeepPartial<Stripe.Invoice> = {},
+  partial: Omit<DeepPartial<Stripe.Invoice>, 'subscription'> & {
+    subscription?: string | Stripe.Subscription | null;
+  } = {},
 ): Stripe.Invoice {
+  const { subscription, ...invoicePartial } = partial;
   return {
     id: partial.id ?? 'in_test',
     object: 'invoice',
@@ -132,6 +135,14 @@ export function makeStripeInvoice(
     status: 'paid',
     paid: true,
     metadata: {},
-    ...partial,
+    ...(subscription
+      ? {
+          parent: {
+            type: 'subscription_details',
+            subscription_details: { subscription, metadata: null },
+          },
+        }
+      : {}),
+    ...invoicePartial,
   } as Stripe.Invoice;
 }

--- a/tests/integration/stripe/api-routes.spec.ts
+++ b/tests/integration/stripe/api-routes.spec.ts
@@ -403,25 +403,21 @@ describe('Stripe API Routes', () => {
 
     it('handles subscription.deleted event and downgrades to free', async () => {
       const userId = await createAuthTestUser();
-      const { stripeCustomerId } = await markUserAsSubscribed(userId, {
-        subscriptionTier: 'pro',
-        subscriptionStatus: 'active',
-      });
+      const { stripeCustomerId, stripeSubscriptionId } =
+        await markUserAsSubscribed(userId, {
+          subscriptionTier: 'pro',
+          subscriptionStatus: 'active',
+        });
       await db
         .update(users)
         .set({ cancelAtPeriodEnd: true })
         .where(sql`id = ${userId}`);
-      const expectedSubscriptionId = buildStripeSubscriptionId(
-        userId,
-        'webhook-deleted',
-      );
-
       const event = makeStripeEvent({
         id: 'evt_sub_deleted',
         type: 'customer.subscription.deleted',
         livemode: false,
         dataObject: makeStripeSubscription({
-          id: expectedSubscriptionId,
+          id: stripeSubscriptionId,
           customer: stripeCustomerId,
         }),
       });

--- a/tests/integration/stripe/api-routes.spec.ts
+++ b/tests/integration/stripe/api-routes.spec.ts
@@ -566,6 +566,71 @@ describe('Stripe API Routes', () => {
 
       expect(response.status).toBe(400);
     });
+
+    it('rejects declared oversized payloads before invoking commerce', async () => {
+      const boundary = {
+        acceptWebhook: vi.fn(),
+      } as unknown as StripeCommerceBoundary;
+      const post = createWebhookHandler({ boundary });
+      const response = await post(
+        new Request('http://localhost/api/v1/stripe/webhook', {
+          method: 'POST',
+          headers: {
+            'stripe-signature': 'test_signature',
+            'content-length': String(256 * 1024 + 1),
+          },
+          body: 'small',
+        }),
+      );
+
+      expect(response.status).toBe(413);
+      expect(boundary.acceptWebhook).not.toHaveBeenCalled();
+    });
+
+    it('rejects chunked oversized payloads before invoking commerce', async () => {
+      const boundary = {
+        acceptWebhook: vi.fn(),
+      } as unknown as StripeCommerceBoundary;
+      const post = createWebhookHandler({ boundary });
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array(256 * 1024));
+          controller.enqueue(new Uint8Array([1]));
+          controller.close();
+        },
+      });
+      const response = await post(
+        new Request('http://localhost/api/v1/stripe/webhook', {
+          method: 'POST',
+          headers: { 'stripe-signature': 'test_signature' },
+          body: stream,
+          duplex: 'half',
+        } as RequestInit & { duplex: 'half' }),
+      );
+
+      expect(response.status).toBe(413);
+      expect(boundary.acceptWebhook).not.toHaveBeenCalled();
+    });
+
+    it('accepts a payload at the exact 256 KiB boundary', async () => {
+      const acceptWebhook = vi
+        .fn()
+        .mockResolvedValue({ status: 200, body: 'ok' });
+      const boundary = { acceptWebhook } as unknown as StripeCommerceBoundary;
+      const post = createWebhookHandler({ boundary });
+      const response = await post(
+        new Request('http://localhost/api/v1/stripe/webhook', {
+          method: 'POST',
+          headers: { 'stripe-signature': 'test_signature' },
+          body: 'a'.repeat(256 * 1024),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(acceptWebhook).toHaveBeenCalledWith(
+        expect.objectContaining({ rawBody: 'a'.repeat(256 * 1024) }),
+      );
+    });
   });
 
   describe('GET /api/v1/user/subscription', () => {

--- a/tests/integration/stripe/commerce-boundary.spec.ts
+++ b/tests/integration/stripe/commerce-boundary.spec.ts
@@ -92,7 +92,9 @@ describe('StripeCommerceBoundary', () => {
     vi.stubEnv('STRIPE_PRO_YEARLY_PRICE_ID', 'price_pro_yearly_approved');
 
     const userId = createId('user');
-    const customerProvisioningDb = buildMockCustomerProvisioningDb();
+    const customerProvisioningDb = buildMockCustomerProvisioningDb({
+      updateReturning: vi.fn().mockResolvedValue([{ userId }]),
+    });
     const requestDb = vi.fn(() => {
       throw new Error('request DB should not provision Stripe customers');
     });

--- a/tests/integration/stripe/create-checkout.spec.ts
+++ b/tests/integration/stripe/create-checkout.spec.ts
@@ -98,6 +98,7 @@ describe('POST /api/v1/stripe/create-checkout', () => {
       },
       {
         timeout: 10_000,
+        idempotencyKey: `atlaris:customer-provisioning:v1:${userId}`,
       },
     );
 

--- a/tests/integration/stripe/subscriptions.spec.ts
+++ b/tests/integration/stripe/subscriptions.spec.ts
@@ -81,6 +81,7 @@ describe('Subscription Management', () => {
         },
         {
           timeout: 10_000,
+          idempotencyKey: `atlaris:customer-provisioning:v1:${userId}`,
         },
       );
 
@@ -118,6 +119,26 @@ describe('Subscription Management', () => {
 
       expect(customerId).toBe(existingCustomerId);
       expect(createStripeCustomer).not.toHaveBeenCalled();
+    });
+
+    it('fails when the returned customer cannot be assigned to exactly one user', async () => {
+      const missingUserId = '00000000-0000-4000-8000-000000000099';
+      const createStripeCustomer = vi
+        .fn()
+        .mockResolvedValue({ id: 'cus_orphan' });
+      const mockStripe = makeStripeMock({
+        customers: { create: createStripeCustomer },
+      });
+
+      await expect(
+        createCustomer(missingUserId, 'missing@example.com', mockStripe),
+      ).rejects.toThrow('did not update exactly one user row');
+      expect(createStripeCustomer).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          idempotencyKey: `atlaris:customer-provisioning:v1:${missingUserId}`,
+        }),
+      );
     });
   });
 

--- a/tests/integration/stripe/subscriptions.spec.ts
+++ b/tests/integration/stripe/subscriptions.spec.ts
@@ -491,16 +491,43 @@ describe('Subscription Management', () => {
       expect(user?.cancelAtPeriodEnd).toBe(true);
     });
 
+    it('applySubscriptionDeleted ignores a stale subscription for the same customer', async () => {
+      const userId = await createUniqueUser();
+      const { stripeCustomerId, stripeSubscriptionId } =
+        await markUserAsSubscribed(userId, {
+          subscriptionTier: 'pro',
+          subscriptionStatus: 'active',
+        });
+
+      await applySubscriptionDeleted(
+        makeStripeSubscription({
+          id: `${stripeSubscriptionId}_stale`,
+          customer: stripeCustomerId,
+        }),
+        makeTransitionDeps(),
+      );
+
+      const [user] = await db
+        .select()
+        .from(users)
+        .where(sql`id = ${userId}`);
+      expect(user?.subscriptionTier).toBe('pro');
+      expect(user?.subscriptionStatus).toBe('active');
+      expect(user?.stripeSubscriptionId).toBe(stripeSubscriptionId);
+    });
+
     it('applyPaymentFailed marks the mapped user as past_due', async () => {
       const userId = await createUniqueUser();
-      const { stripeCustomerId } = await markUserAsSubscribed(userId, {
-        subscriptionTier: 'starter',
-        subscriptionStatus: 'active',
-      });
+      const { stripeCustomerId, stripeSubscriptionId } =
+        await markUserAsSubscribed(userId, {
+          subscriptionTier: 'starter',
+          subscriptionStatus: 'active',
+        });
 
       const invoice = makeStripeInvoice({
         id: 'in_payment_failed',
         customer: stripeCustomerId,
+        subscription: stripeSubscriptionId,
       });
 
       await applyPaymentFailed(invoice, makeTransitionDeps());
@@ -516,14 +543,16 @@ describe('Subscription Management', () => {
 
     it('applyPaymentFailed marks subscribed free-tier users as past_due', async () => {
       const userId = await createUniqueUser();
-      const { stripeCustomerId } = await markUserAsSubscribed(userId, {
-        subscriptionTier: 'free',
-        subscriptionStatus: 'active',
-      });
+      const { stripeCustomerId, stripeSubscriptionId } =
+        await markUserAsSubscribed(userId, {
+          subscriptionTier: 'free',
+          subscriptionStatus: 'active',
+        });
 
       const invoice = makeStripeInvoice({
         id: 'in_payment_failed_free_tier',
         customer: stripeCustomerId,
+        subscription: stripeSubscriptionId,
       });
 
       await applyPaymentFailed(invoice, makeTransitionDeps());
@@ -536,6 +565,31 @@ describe('Subscription Management', () => {
       expect(user?.subscriptionStatus).toBe('past_due');
       expect(user?.subscriptionTier).toBe('free');
       expect(user?.stripeSubscriptionId).not.toBeNull();
+    });
+
+    it('applyPaymentFailed ignores a stale subscription for the same customer', async () => {
+      const userId = await createUniqueUser();
+      const { stripeCustomerId, stripeSubscriptionId } =
+        await markUserAsSubscribed(userId, {
+          subscriptionTier: 'starter',
+          subscriptionStatus: 'active',
+        });
+
+      await applyPaymentFailed(
+        makeStripeInvoice({
+          id: 'in_stale_payment_failed',
+          customer: stripeCustomerId,
+          subscription: `${stripeSubscriptionId}_stale`,
+        }),
+        makeTransitionDeps(),
+      );
+
+      const [user] = await db
+        .select()
+        .from(users)
+        .where(sql`id = ${userId}`);
+      expect(user?.subscriptionStatus).toBe('active');
+      expect(user?.stripeSubscriptionId).toBe(stripeSubscriptionId);
     });
 
     it('applySubscriptionDeleted resolves when no mapped user exists', async () => {


### PR DESCRIPTION
## Findings

Addresses findings 2, 3, and 8: stale subscription events could mutate newer state, unauthenticated webhook bodies were buffered before validation/limits, and Stripe customer creation lacked external idempotency.

## Behavioral invariants

- Deletion and payment-failure transitions require matching customer and active subscription IDs, with the subscription predicate retained in SQL.
- Invoice subscription identity comes from `invoice.parent.subscription_details.subscription`.
- Missing or stale subscription events are logged no-ops.
- Webhook signatures and declared sizes are checked before body reads; streamed bodies are capped at exactly 256 KiB and canceled on overflow.
- Customer provisioning uses `atlaris:customer-provisioning:v1:${userId}` and commits only when exactly one previously-unassigned user row is updated.

## Intentionally unchanged

- The commerce boundary retains its post-buffer size check.
- Subscription creation/update synchronization and webhook deduplication remain unchanged.
- No schema migration or catalog behavior changed.

## Validation

- Stripe subscription integration suite — passed (16 tests)
- Webhook route pre-buffer cases — passed (4 tests)
- Customer provisioning cases — passed (3 tests)
- `pnpm test` — passed
- `pnpm check:full` — passed

## Rollout and observation

- Observe webhook 413/400 rates and stale-event no-op logs after merge.
- No migration or manual data repair is required.

## Remaining risk

- Streaming limits rely on Web Streams cancellation support in the Node runtime.
- Stripe idempotency retains the first request parameters for the stable user-scoped key; provisioning email/metadata must remain stable for that operation version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes subscription lifecycle writes and webhook ingress in payment-critical paths; incorrect subscription ID extraction could skip legitimate invoice events, though behavior is covered by new integration tests.
> 
> **Overview**
> Hardens Stripe webhook handling and billing reconciliation so stale or oversized traffic cannot corrupt subscription state or exhaust memory before validation.
> 
> The **webhook route** now requires `stripe-signature` and enforces a **256 KiB** cap via `content-length` and a streaming body reader that returns **413** without calling the commerce boundary when limits are exceeded.
> 
> **Reconciliation** ties `customer.subscription.deleted` and `invoice.payment_failed` updates to the **matching** `stripeSubscriptionId` (including SQL predicates on bulk updates). Invoice subscription identity is read from `invoice.parent.subscription_details.subscription`; missing or mismatched subscription IDs are logged no-ops instead of touching the current subscription.
> 
> **Customer provisioning** sends a per-user Stripe **idempotency key** and only persists `stripeCustomerId` when exactly one row with a null customer id is updated; otherwise provisioning fails loudly.
> 
> Tests and `makeStripeInvoice` fixtures were extended for payload limits, stale events, and provisioning edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c99f882a68e9a65f0c3856763b5197821c1ea085. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->