### PR TITLE
Serialize duplicate plan and user provisioning

### DIFF
--- a/src/features/plans/lifecycle/adapters/plan-persistence-adapter.ts
+++ b/src/features/plans/lifecycle/adapters/plan-persistence-adapter.ts
@@ -9,11 +9,9 @@ import type { DbClient } from '@/lib/db/types';
 import {
   atomicCheckAndInsertPlan,
   findCappedPlanWithoutModules,
-  findRecentDuplicatePlan,
   markPlanGenerationFailure,
   markPlanGenerationSuccess,
 } from './plan-persistence-store';
-import { PlanLimitReachedError } from '@/features/plans/errors';
 
 export class PlanPersistenceAdapter implements PlanPersistencePort {
   constructor(private readonly dbClient: DbClient) {}
@@ -22,33 +20,11 @@ export class PlanPersistenceAdapter implements PlanPersistencePort {
     userId: string,
     planData: PlanInsertData,
   ): Promise<AtomicInsertResult> {
-    try {
-      const result = await atomicCheckAndInsertPlan(
-        userId,
-        planData,
-        this.dbClient,
-      );
-      return { success: true, id: result.id };
-    } catch (error) {
-      if (error instanceof PlanLimitReachedError) {
-        return {
-          success: false,
-          reason: 'Plan limit reached for current subscription tier',
-        };
-      }
-      throw error;
-    }
+    return atomicCheckAndInsertPlan(userId, planData, this.dbClient);
   }
 
   async findCappedPlanWithoutModules(userId: string): Promise<string | null> {
     return findCappedPlanWithoutModules(userId, this.dbClient);
-  }
-
-  async findRecentDuplicatePlan(
-    userId: string,
-    normalizedTopic: string,
-  ): Promise<string | null> {
-    return findRecentDuplicatePlan(userId, normalizedTopic, this.dbClient);
   }
 
   async markGenerationSuccess(planId: string): Promise<void> {

--- a/src/features/plans/lifecycle/adapters/plan-persistence-store.ts
+++ b/src/features/plans/lifecycle/adapters/plan-persistence-store.ts
@@ -3,15 +3,13 @@
  * Do not import outside lifecycle adapters / composition roots.
  */
 
+import type { AtomicInsertResult } from '@/features/plans/lifecycle/types';
 import type { DbClient, DbTransaction } from '@/lib/db/types';
 import type { PlanGenerationCoreFields } from '@/shared/types/ai-provider.types';
 
 import { getGenerationAttemptCap } from '@/features/ai/generation-policy';
 import { selectUserSubscriptionTierForUpdate } from '@/features/billing/metered-reservation';
-import {
-  PlanCreationError,
-  PlanLimitReachedError,
-} from '@/features/plans/errors';
+import { PlanCreationError } from '@/features/plans/errors';
 import { countPlansContributingToCap } from '@/features/plans/quota/check-plan-limit';
 import { PLAN_GENERATING_INSERT_DEFAULTS } from '@/lib/db/queries/helpers/plan-generation-status';
 import { logger } from '@/lib/logging/logger';
@@ -103,9 +101,29 @@ export async function atomicCheckAndInsertPlan(
     origin: 'ai' | 'manual' | 'template';
   },
   dbClient: DbClient,
-): Promise<{ id: string }> {
+): Promise<AtomicInsertResult> {
   return dbClient.transaction(async (tx) => {
     const user = await selectUserSubscriptionTierForUpdate(tx, userId);
+
+    const windowStart = new Date(
+      Date.now() - DUPLICATE_DETECTION_WINDOW_SECONDS * 1000,
+    );
+    const [duplicate] = await tx
+      .select({ id: learningPlans.id })
+      .from(learningPlans)
+      .where(
+        and(
+          eq(learningPlans.userId, userId),
+          sql`lower(${learningPlans.topic}) = lower(${planData.topic})`,
+          gte(learningPlans.createdAt, windowStart),
+          sql`${learningPlans.generationStatus} IN ('generating', 'ready')`,
+        ),
+      )
+      .limit(1);
+
+    if (duplicate) {
+      return { status: 'duplicate', existingPlanId: duplicate.id };
+    }
 
     const tier = user.subscriptionTier;
     const tierConfig = TIER_LIMITS[tier];
@@ -118,7 +136,7 @@ export async function atomicCheckAndInsertPlan(
       const currentCount = await countPlansContributingToCap(tx, userId);
 
       if (currentCount >= limit) {
-        throw new PlanLimitReachedError(currentCount, limit);
+        return { status: 'limit_reached', currentCount, limit };
       }
     }
 
@@ -135,7 +153,7 @@ export async function atomicCheckAndInsertPlan(
       throw new PlanCreationError();
     }
 
-    return plan;
+    return { status: 'created', id: plan.id };
   });
 }
 
@@ -188,31 +206,6 @@ export async function markPlanGenerationFailure(
       'markPlanGenerationFailure: no rows updated — plan may have been deleted',
     );
   }
-}
-
-export async function findRecentDuplicatePlan(
-  userId: string,
-  normalizedTopic: string,
-  dbClient: DbClient,
-): Promise<string | null> {
-  const windowStart = new Date(
-    Date.now() - DUPLICATE_DETECTION_WINDOW_SECONDS * 1000,
-  );
-
-  const [row] = await dbClient
-    .select({ id: learningPlans.id })
-    .from(learningPlans)
-    .where(
-      and(
-        eq(learningPlans.userId, userId),
-        sql`lower(${learningPlans.topic}) = lower(${normalizedTopic})`,
-        gte(learningPlans.createdAt, windowStart),
-        sql`${learningPlans.generationStatus} IN ('generating', 'ready')`,
-      ),
-    )
-    .limit(1);
-
-  return row?.id ?? null;
 }
 
 export async function findCappedPlanWithoutModules(

--- a/src/features/plans/lifecycle/creation-pipeline.ts
+++ b/src/features/plans/lifecycle/creation-pipeline.ts
@@ -146,14 +146,25 @@ export async function insertCreatedPlan(params: {
 
   const insertResult = await planPersistence.atomicInsertPlan(userId, planData);
 
-  if (!insertResult.success) {
+  if (insertResult.status === 'duplicate') {
+    logger.info(
+      { userId, existingPlanId: insertResult.existingPlanId },
+      `${getCreateLogBase(lifecycleLabel)}: duplicate detected`,
+    );
+    return {
+      status: 'duplicate_detected',
+      existingPlanId: insertResult.existingPlanId,
+    };
+  }
+
+  if (insertResult.status === 'limit_reached') {
     logger.info(
       { userId },
       `${getCreateLogBase(lifecycleLabel)}: quota rejected (plan limit)`,
     );
     return {
       status: 'quota_rejected',
-      reason: insertResult.reason,
+      reason: 'Plan limit reached for current subscription tier',
     };
   }
 

--- a/src/features/plans/lifecycle/origin-strategies/create-ai-plan.ts
+++ b/src/features/plans/lifecycle/origin-strategies/create-ai-plan.ts
@@ -39,21 +39,6 @@ export async function createAiPlanWithStrategy(
   }
 
   const normalizedTopic = input.topic.trim();
-  const existingPlanId = await ports.planPersistence.findRecentDuplicatePlan(
-    input.userId,
-    normalizedTopic,
-  );
-  if (existingPlanId) {
-    logger.info(
-      { userId: input.userId, existingPlanId },
-      `${getCreateLogBase('create')}: duplicate detected`,
-    );
-    return {
-      status: 'duplicate_detected',
-      existingPlanId,
-    };
-  }
-
   return insertCreatedPlan({
     planPersistence: ports.planPersistence,
     userId: input.userId,

--- a/src/features/plans/lifecycle/origin-strategies/types.ts
+++ b/src/features/plans/lifecycle/origin-strategies/types.ts
@@ -5,8 +5,5 @@ import type { PlanPersistencePort } from '@/features/plans/lifecycle/ports';
  * Keep these ports small so strategy modules cannot reach unrelated lifecycle concerns.
  */
 export type PlanCreationStrategyPorts = {
-  planPersistence: Pick<
-    PlanPersistencePort,
-    'atomicInsertPlan' | 'findRecentDuplicatePlan'
-  >;
+  planPersistence: Pick<PlanPersistencePort, 'atomicInsertPlan'>;
 };

--- a/src/features/plans/lifecycle/ports.ts
+++ b/src/features/plans/lifecycle/ports.ts
@@ -27,8 +27,6 @@ import type { FailureClassification } from '@/shared/types/failure-classificatio
  * inside one transaction.
  * @property findCappedPlanWithoutModules Finds a plan that exhausted generation
  * attempts before modules were created.
- * @property findRecentDuplicatePlan Finds a recent duplicate plan with the same
- * normalized topic inside the deduplication window.
  * @property markGenerationSuccess Marks generation as successful for a plan.
  * @property markGenerationFailure Marks generation as failed for a plan.
  */
@@ -42,12 +40,6 @@ export interface PlanPersistencePort {
   findCappedPlanWithoutModules(
     this: void,
     userId: string,
-  ): Promise<string | null>;
-
-  findRecentDuplicatePlan(
-    this: void,
-    userId: string,
-    normalizedTopic: string,
   ): Promise<string | null>;
 
   markGenerationSuccess(this: void, planId: string): Promise<void>;

--- a/src/features/plans/lifecycle/types.ts
+++ b/src/features/plans/lifecycle/types.ts
@@ -33,8 +33,13 @@ export type PlanInsertData = Readonly<PlanGenerationCoreFields> & {
 
 /** Result of an atomic plan insert operation. */
 export type AtomicInsertResult =
-  | { readonly success: true; readonly id: string }
-  | { readonly success: false; readonly reason: string };
+  | { readonly status: 'created'; readonly id: string }
+  | { readonly status: 'duplicate'; readonly existingPlanId: string }
+  | {
+      readonly status: 'limit_reached';
+      readonly currentCount: number;
+      readonly limit: number;
+    };
 
 /** Result of a duration cap check. */
 export type DurationCapResult = {

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -12,7 +12,7 @@ import { AuthError } from './errors';
 import { createRequestContext, withRequestContext } from '@/lib/api/context';
 import { auth, getSessionSafe } from '@/lib/auth/server';
 import { appEnv, devAuthEnv, localProductTestingEnv } from '@/lib/config/env';
-import { createUser, getUserByAuthId } from '@/lib/db/queries/users';
+import { getOrCreateUser, getUserByAuthId } from '@/lib/db/queries/users';
 import { getDb } from '@supabase/runtime';
 
 export type { PlainHandler } from '@/lib/api/types/auth.types';
@@ -94,7 +94,7 @@ async function ensureUserRecord(
     throw new AuthError('Auth user must have an email address.');
   }
 
-  const created = await createUser(
+  const created = await getOrCreateUser(
     {
       authUserId,
       email,

--- a/src/lib/db/queries/users.ts
+++ b/src/lib/db/queries/users.ts
@@ -170,6 +170,33 @@ export async function createUser(
 }
 
 /**
+ * Creates a user when absent, or returns the row created by a concurrent request.
+ * Email conflicts belonging to a different auth identity remain database errors.
+ */
+export async function getOrCreateUser(
+  userData: CreateUserData,
+  dbClient?: UsersDbClient,
+  deps: UsersQueryDeps = defaultUsersQueryDeps,
+): Promise<DbUser | undefined> {
+  const client = dbClient ?? deps.getDb();
+  const inserted = await client
+    .insert(users)
+    .values({
+      authUserId: userData.authUserId,
+      email: userData.email,
+      name: userData.name,
+    })
+    .onConflictDoNothing({ target: users.authUserId })
+    .returning();
+
+  if (inserted[0]) {
+    return inserted[0];
+  }
+
+  return getUserByAuthId(userData.authUserId, client);
+}
+
+/**
  * Updates a user's preferred AI model.
  *
  * @param userId - Internal user ID

--- a/tests/helpers/plan-persistence.ts
+++ b/tests/helpers/plan-persistence.ts
@@ -11,8 +11,11 @@ export async function atomicInsertPlanOrThrow(
 ): Promise<{ id: string }> {
   const adapter = new PlanPersistenceAdapter(db);
   const result = await adapter.atomicInsertPlan(userId, planData);
-  if (result.success) {
+  if (result.status === 'created') {
     return { id: result.id };
   }
-  throw new Error(result.reason);
+  if (result.status === 'duplicate') {
+    throw new Error(`Duplicate plan: ${result.existingPlanId}`);
+  }
+  throw new Error('Plan limit reached for current subscription tier');
 }

--- a/tests/integration/db/user-provisioning-concurrency.spec.ts
+++ b/tests/integration/db/user-provisioning-concurrency.spec.ts
@@ -1,0 +1,53 @@
+import { getOrCreateUser } from '@/lib/db/queries/users';
+import { users } from '@supabase/schema';
+import { db } from '@supabase/service-role';
+import { buildTestAuthUserId, buildTestEmail } from '@tests/helpers/testIds';
+import { eq } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+
+describe('concurrent user provisioning', () => {
+  it('resolves simultaneous first requests to the same user row', async () => {
+    const authUserId = buildTestAuthUserId('user-provisioning-race');
+    const input = {
+      authUserId,
+      email: buildTestEmail(authUserId),
+      name: 'Concurrent User',
+    };
+
+    const [first, second] = await Promise.all([
+      getOrCreateUser(input, db),
+      getOrCreateUser(input, db),
+    ]);
+
+    expect(first?.id).toBeDefined();
+    expect(second?.id).toBe(first?.id);
+    const rows = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.authUserId, authUserId));
+    expect(rows).toHaveLength(1);
+  });
+
+  it('does not transfer an existing email to another auth identity', async () => {
+    const firstAuthUserId = buildTestAuthUserId('user-email-owner');
+    const secondAuthUserId = buildTestAuthUserId('user-email-conflict');
+    const email = buildTestEmail(firstAuthUserId);
+
+    const owner = await getOrCreateUser(
+      { authUserId: firstAuthUserId, email, name: 'Email Owner' },
+      db,
+    );
+
+    await expect(
+      getOrCreateUser(
+        { authUserId: secondAuthUserId, email, name: 'Conflicting User' },
+        db,
+      ),
+    ).rejects.toThrow();
+
+    const rows = await db.select().from(users).where(eq(users.email, email));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe(owner?.id);
+    expect(rows[0]?.authUserId).toBe(firstAuthUserId);
+  });
+});

--- a/tests/integration/features/plans/lifecycle/plan-persistence-adapter.spec.ts
+++ b/tests/integration/features/plans/lifecycle/plan-persistence-adapter.spec.ts
@@ -30,8 +30,8 @@ describe('PlanPersistenceAdapter (integration)', () => {
       topic: `${planPayload.topic} insert`,
     });
 
-    expect(result.success).toBe(true);
-    if (!result.success) return;
+    expect(result.status).toBe('created');
+    if (result.status !== 'created') return;
 
     const [row] = await db
       .select()
@@ -57,7 +57,7 @@ describe('PlanPersistenceAdapter (integration)', () => {
         ...planPayload,
         topic: `${planPayload.topic} cap ${i}`,
       });
-      expect(r.success).toBe(true);
+      expect(r.status).toBe('created');
     }
 
     const rejected = await adapter.atomicInsertPlan(userId, {
@@ -65,12 +65,10 @@ describe('PlanPersistenceAdapter (integration)', () => {
       topic: `${planPayload.topic} cap overflow`,
     });
 
-    expect(rejected.success).toBe(false);
-    if (rejected.success) return;
-    expect(rejected.reason).toMatch(/limit reached/i);
+    expect(rejected.status).toBe('limit_reached');
   });
 
-  it('findRecentDuplicatePlan returns the recent plan id for the same topic', async () => {
+  it('atomicInsertPlan returns the recent plan id for the same topic', async () => {
     const authUserId = buildTestAuthUserId('persist-adapter-dup');
     const userId = await ensureUser({
       authUserId,
@@ -84,11 +82,53 @@ describe('PlanPersistenceAdapter (integration)', () => {
       ...planPayload,
       topic,
     });
-    expect(inserted.success).toBe(true);
-    if (!inserted.success) return;
+    expect(inserted.status).toBe('created');
+    if (inserted.status !== 'created') return;
 
-    const dupId = await adapter.findRecentDuplicatePlan(userId, topic);
-    expect(dupId).toBe(inserted.id);
+    const duplicate = await adapter.atomicInsertPlan(userId, {
+      ...planPayload,
+      topic,
+    });
+    expect(duplicate).toEqual({
+      status: 'duplicate',
+      existingPlanId: inserted.id,
+    });
+  });
+
+  it('serializes simultaneous identical plan creation into one row', async () => {
+    const authUserId = buildTestAuthUserId('persist-adapter-concurrent-dup');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+      subscriptionTier: 'free',
+    });
+    const adapter = new PlanPersistenceAdapter(db);
+    const topic = `${planPayload.topic} concurrent duplicate`;
+
+    const results = await Promise.all([
+      adapter.atomicInsertPlan(userId, { ...planPayload, topic }),
+      adapter.atomicInsertPlan(userId, { ...planPayload, topic }),
+    ]);
+
+    const created = results.find((result) => result.status === 'created');
+    const duplicate = results.find((result) => result.status === 'duplicate');
+    expect(created?.status).toBe('created');
+    expect(duplicate).toEqual({
+      status: 'duplicate',
+      existingPlanId: created?.status === 'created' ? created.id : undefined,
+    });
+
+    const rows = await db
+      .select({ id: learningPlans.id })
+      .from(learningPlans)
+      .where(eq(learningPlans.userId, userId));
+    expect(rows).toHaveLength(1);
+
+    const secondDistinct = await adapter.atomicInsertPlan(userId, {
+      ...planPayload,
+      topic: `${topic} distinct`,
+    });
+    expect(secondDistinct.status).toBe('created');
   });
 
   it('markGenerationSuccess updates persisted flags', async () => {
@@ -104,8 +144,8 @@ describe('PlanPersistenceAdapter (integration)', () => {
       ...planPayload,
       topic: `${planPayload.topic} status-success`,
     });
-    expect(inserted.success).toBe(true);
-    if (!inserted.success) return;
+    expect(inserted.status).toBe('created');
+    if (inserted.status !== 'created') return;
 
     await adapter.markGenerationSuccess(inserted.id);
 
@@ -131,8 +171,8 @@ describe('PlanPersistenceAdapter (integration)', () => {
       ...planPayload,
       topic: `${planPayload.topic} status-fail`,
     });
-    expect(inserted.success).toBe(true);
-    if (!inserted.success) return;
+    expect(inserted.status).toBe('created');
+    if (inserted.status !== 'created') return;
 
     await adapter.markGenerationFailure(inserted.id);
 
@@ -158,8 +198,8 @@ describe('PlanPersistenceAdapter (integration)', () => {
       ...planPayload,
       topic: `${planPayload.topic} capped`,
     });
-    expect(inserted.success).toBe(true);
-    if (!inserted.success) return;
+    expect(inserted.status).toBe('created');
+    if (inserted.status !== 'created') return;
 
     for (let i = 0; i < cap; i++) {
       await db.insert(generationAttempts).values({

--- a/tests/unit/api/auth.spec.ts
+++ b/tests/unit/api/auth.spec.ts
@@ -12,13 +12,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   getUserByAuthId: vi.fn(),
-  createUser: vi.fn(),
+  getOrCreateUser: vi.fn(),
   getSession: vi.fn(),
 }));
 
 vi.mock('@/lib/db/queries/users', () => ({
   getUserByAuthId: mocks.getUserByAuthId,
-  createUser: mocks.createUser,
+  getOrCreateUser: mocks.getOrCreateUser,
 }));
 
 vi.mock('@/lib/auth/server', () => ({
@@ -28,13 +28,13 @@ vi.mock('@/lib/auth/server', () => ({
 }));
 
 const mockGetUserByAuthId = mocks.getUserByAuthId;
-const mockCreateUser = mocks.createUser;
+const mockGetOrCreateUser = mocks.getOrCreateUser;
 const mockGetSession = mocks.getSession;
 
 describe('auth helpers', () => {
   beforeEach(() => {
     mockGetUserByAuthId.mockReset();
-    mockCreateUser.mockReset();
+    mockGetOrCreateUser.mockReset();
     mockGetSession.mockReset();
     clearTestUser();
   });
@@ -58,7 +58,7 @@ describe('auth helpers', () => {
     mockGetUserByAuthId.mockResolvedValue(user);
 
     await expect(requireCurrentUserRecord()).resolves.toEqual(user);
-    expect(mockCreateUser).not.toHaveBeenCalled();
+    expect(mockGetOrCreateUser).not.toHaveBeenCalled();
   });
 
   it('requireCurrentUserRecord provisions a missing user from Clerk session data', async () => {
@@ -80,10 +80,10 @@ describe('auth helpers', () => {
         },
       },
     });
-    mockCreateUser.mockResolvedValue(created);
+    mockGetOrCreateUser.mockResolvedValue(created);
 
     await expect(requireCurrentUserRecord()).resolves.toEqual(created);
-    expect(mockCreateUser).toHaveBeenCalledWith(
+    expect(mockGetOrCreateUser).toHaveBeenCalledWith(
       {
         authUserId: 'auth_created',
         email: 'created@example.com',
@@ -99,7 +99,7 @@ describe('auth helpers', () => {
     mockGetSession.mockResolvedValue({ data: null });
 
     await expect(requireCurrentUserRecord()).rejects.toBeInstanceOf(AuthError);
-    expect(mockCreateUser).not.toHaveBeenCalled();
+    expect(mockGetOrCreateUser).not.toHaveBeenCalled();
   });
 
   it('requireCurrentUserRecord fails closed when the Clerk user has no email', async () => {
@@ -116,7 +116,7 @@ describe('auth helpers', () => {
     });
 
     await expect(requireCurrentUserRecord()).rejects.toBeInstanceOf(AuthError);
-    expect(mockCreateUser).not.toHaveBeenCalled();
+    expect(mockGetOrCreateUser).not.toHaveBeenCalled();
   });
 
   it('withServerComponentContext installs request context in test mode', async () => {

--- a/tests/unit/features/plans/lifecycle/adapters/plan-persistence-adapter.spec.ts
+++ b/tests/unit/features/plans/lifecycle/adapters/plan-persistence-adapter.spec.ts
@@ -3,12 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('@/features/plans/lifecycle/adapters/plan-persistence-store', () => ({
   atomicCheckAndInsertPlan: vi.fn(),
   findCappedPlanWithoutModules: vi.fn(),
-  findRecentDuplicatePlan: vi.fn(),
   markPlanGenerationFailure: vi.fn(),
   markPlanGenerationSuccess: vi.fn(),
 }));
 
-import { PlanLimitReachedError } from '@/features/plans/errors';
 import { PlanPersistenceAdapter } from '@/features/plans/lifecycle/adapters/plan-persistence-adapter';
 import * as persistenceStore from '@/features/plans/lifecycle/adapters/plan-persistence-store';
 import { makeDbClient } from '@tests/fixtures/db-mocks';
@@ -29,15 +27,18 @@ describe('PlanPersistenceAdapter', () => {
     vi.clearAllMocks();
   });
 
-  it('atomicInsertPlan returns failure when store throws PlanLimitReachedError', async () => {
-    vi.mocked(persistenceStore.atomicCheckAndInsertPlan).mockRejectedValue(
-      new PlanLimitReachedError(),
-    );
+  it('atomicInsertPlan returns the explicit limit result from the store', async () => {
+    vi.mocked(persistenceStore.atomicCheckAndInsertPlan).mockResolvedValue({
+      status: 'limit_reached',
+      currentCount: 3,
+      limit: 3,
+    });
     const adapter = new PlanPersistenceAdapter(fakeDb);
     const result = await adapter.atomicInsertPlan('user-1', planData);
     expect(result).toEqual({
-      success: false,
-      reason: 'Plan limit reached for current subscription tier',
+      status: 'limit_reached',
+      currentCount: 3,
+      limit: 3,
     });
   });
 
@@ -52,10 +53,11 @@ describe('PlanPersistenceAdapter', () => {
 
   it('atomicInsertPlan returns success when store inserts', async () => {
     vi.mocked(persistenceStore.atomicCheckAndInsertPlan).mockResolvedValue({
+      status: 'created',
       id: 'plan-1',
     });
     const adapter = new PlanPersistenceAdapter(fakeDb);
     const result = await adapter.atomicInsertPlan('user-1', planData);
-    expect(result).toEqual({ success: true, id: 'plan-1' });
+    expect(result).toEqual({ status: 'created', id: 'plan-1' });
   });
 });

--- a/tests/unit/features/plans/lifecycle/lifecycle-test-helpers.ts
+++ b/tests/unit/features/plans/lifecycle/lifecycle-test-helpers.ts
@@ -34,11 +34,10 @@ export function createMockPorts(
   const defaults = {
     planPersistence: {
       atomicInsertPlan: async () => ({
-        success: true as const,
+        status: 'created' as const,
         id: 'plan-123',
       }),
       findCappedPlanWithoutModules: async () => null,
-      findRecentDuplicatePlan: async () => null,
       markGenerationSuccess: vi.fn().mockResolvedValue(undefined),
       markGenerationFailure: vi.fn().mockResolvedValue(undefined),
     },

--- a/tests/unit/features/plans/lifecycle/process-generation.spec.ts
+++ b/tests/unit/features/plans/lifecycle/process-generation.spec.ts
@@ -34,11 +34,10 @@ function createMockPorts(
   return {
     planPersistence: {
       atomicInsertPlan: async () => ({
-        success: true as const,
+        status: 'created' as const,
         id: 'plan-123',
       }),
       findCappedPlanWithoutModules: async () => null,
-      findRecentDuplicatePlan: async () => null,
       markGenerationSuccess: vi.fn().mockResolvedValue(undefined),
       markGenerationFailure: vi.fn().mockResolvedValue(undefined),
     },

--- a/tests/unit/features/plans/lifecycle/service.spec.ts
+++ b/tests/unit/features/plans/lifecycle/service.spec.ts
@@ -42,8 +42,9 @@ describe('PlanLifecycleService', () => {
         planPersistence: {
           ...createMockPorts().planPersistence,
           atomicInsertPlan: async () => ({
-            success: false as const,
-            reason: 'Plan limit reached for current subscription tier',
+            status: 'limit_reached' as const,
+            currentCount: 3,
+            limit: 3,
           }),
         },
       });
@@ -155,7 +156,7 @@ describe('PlanLifecycleService', () => {
           ...createMockPorts().planPersistence,
           atomicInsertPlan: async (_userId, planData) => {
             capturedData = planData;
-            return { success: true as const, id: 'plan-789' };
+            return { status: 'created' as const, id: 'plan-789' };
           },
         },
         quota: {
@@ -190,7 +191,7 @@ describe('PlanLifecycleService', () => {
           ...createMockPorts().planPersistence,
           atomicInsertPlan: async (_userId, planData) => {
             capturedData = planData;
-            return { success: true as const, id: 'plan-trim' };
+            return { status: 'created' as const, id: 'plan-trim' };
           },
         },
       });
@@ -205,7 +206,10 @@ describe('PlanLifecycleService', () => {
       ports = createMockPorts({
         planPersistence: {
           ...createMockPorts().planPersistence,
-          findRecentDuplicatePlan: async () => 'existing-plan-id',
+          atomicInsertPlan: async () => ({
+            status: 'duplicate' as const,
+            existingPlanId: 'existing-plan-id',
+          }),
         },
       });
       service = new PlanLifecycleService(ports);
@@ -218,34 +222,35 @@ describe('PlanLifecycleService', () => {
       }
     });
 
-    it('does not call atomicInsertPlan when duplicate is detected', async () => {
-      const insertSpy = vi
-        .fn()
-        .mockResolvedValue({ success: true as const, id: 'plan-new' });
+    it('maps the atomic duplicate outcome without reporting creation', async () => {
+      const insertSpy = vi.fn().mockResolvedValue({
+        status: 'duplicate' as const,
+        existingPlanId: 'existing-plan-id',
+      });
       ports = createMockPorts({
         planPersistence: {
           ...createMockPorts().planPersistence,
-          findRecentDuplicatePlan: async () => 'existing-plan-id',
           atomicInsertPlan: insertSpy,
         },
       });
       service = new PlanLifecycleService(ports);
 
-      await service.createPlan(validInput);
+      const result = await service.createPlan(validInput);
 
-      expect(insertSpy).not.toHaveBeenCalled();
+      expect(insertSpy).toHaveBeenCalledOnce();
+      expect(result.status).toBe('duplicate_detected');
     });
 
-    it('passes userId and trimmed topic to findRecentDuplicatePlan', async () => {
+    it('passes userId and trimmed topic to atomicInsertPlan', async () => {
       let capturedUserId: string | undefined;
       let capturedTopic: string | undefined;
       ports = createMockPorts({
         planPersistence: {
           ...createMockPorts().planPersistence,
-          findRecentDuplicatePlan: async (userId, topic) => {
+          atomicInsertPlan: async (userId, planData) => {
             capturedUserId = userId;
-            capturedTopic = topic;
-            return null;
+            capturedTopic = planData.topic;
+            return { status: 'created' as const, id: 'plan-new' };
           },
         },
       });
@@ -261,7 +266,6 @@ describe('PlanLifecycleService', () => {
     });
 
     it('proceeds to create plan when no duplicate exists', async () => {
-      // Default mock returns null for findRecentDuplicatePlan
       const result = await service.createPlan(validInput);
 
       expect(result.status).toBe('success');


### PR DESCRIPTION
## Findings

Addresses findings 4 and 9: duplicate-plan detection occurred outside the serialized transaction, and first-request user provisioning used a check-then-insert race.

## Behavioral invariants

- The 60-second duplicate lookup runs after the per-user row lock and before quota counting/insertion.
- Atomic plan creation returns explicit `created`, `duplicate`, or `limit_reached` outcomes.
- Two simultaneous identical plan requests create one row and return one created result plus one duplicate result referencing that row.
- User provisioning uses `ON CONFLICT (auth_user_id) DO NOTHING RETURNING`, then fetches the winner by auth ID.
- Strict `createUser` behavior remains unchanged, and a conflicting email owned by another auth identity still fails.

## Intentionally unchanged

- Plan duration and attempt-cap gates remain outside the atomic persistence operation.
- Plan generation/finalization behavior is unchanged.
- No schema migration or uniqueness constraint change was required.

## Validation

- Plan persistence integration suite — passed (7 tests)
- Concurrent user provisioning plus API provisioning — passed (3 tests)
- Focused lifecycle unit suites — passed (20 tests)
- Auth/user query unit suites — passed (13 tests)
- `pnpm test` — passed
- `pnpm check:full` — passed
- Thermos correctness/security review of `origin/develop...HEAD` — no findings
- Thermos code-quality review of `origin/develop...HEAD` — no findings

## Rollout and observation

- No migration is required.
- Observe duplicate-detected and user-provisioning error rates after merge.

## Remaining risk

- Duplicate identity remains defined by case-insensitive topic equality within 60 seconds and generating/ready states.
- Serialization depends on the existing per-user row lock; callers must continue using the atomic persistence boundary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches plan quota/dedup persistence and auth user provisioning paths; behavior depends on existing per-user row locks and duplicate rules (60s window, generating/ready only), with no schema migration.
> 
> **Overview**
> Fixes race windows where duplicate plan checks ran outside the insert transaction and first-time user rows could be double-created under concurrent requests.
> 
> **Plan creation** moves the 60-second, case-insensitive topic duplicate lookup into `atomicCheckAndInsertPlan`, after the per-user `FOR UPDATE` lock and before quota counting/insert. `atomicInsertPlan` now returns explicit outcomes (`created`, `duplicate`, `limit_reached`) instead of success/failure or thrown `PlanLimitReachedError`; the creation pipeline and AI strategy no longer call a separate `findRecentDuplicatePlan` before insert.
> 
> **User provisioning** switches auth `ensureUserRecord` from `createUser` to new `getOrCreateUser` (`INSERT … ON CONFLICT (auth_user_id) DO NOTHING`, then fetch by auth id), with integration coverage for concurrent first requests and unchanged email-conflict behavior across auth identities.
> 
> Tests and mocks are updated for the new result shapes, including concurrent duplicate plan creation asserting a single row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 578f18db6e502a41011b54930fcac527ee6f82de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->