### PR TITLE
Make workflow claims replay-safe and test production workflows

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -55,6 +55,7 @@ jobs:
               - 'tests/**'
               - 'scripts/**'
               - 'vitest.config.ts'
+              - 'vitest.workflow.config.ts'
               - 'tsconfig.json'
               - 'package.json'
               - 'pnpm-lock.yaml'
@@ -635,6 +636,37 @@ jobs:
             node_modules/.vitest
           key: ${{ steps.restore-vitest-cache.outputs.cache-primary-key || format('{0}-vitest-{1}-{2}', runner.os, hashFiles('pnpm-lock.yaml'), github.sha) }}
 
+  workflow-tests:
+    name: Production Workflow Tests
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Install pnpm
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
+        with:
+          version: 9
+      - name: Setup pnpm store cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ~/.local/share/pnpm/store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run production workflow tests
+        run: pnpm test:workflow
+
   all-checks-pr:
     name: All Checks Passed (PR)
     needs:
@@ -646,6 +678,7 @@ jobs:
         unit-tests,
         integration-light,
         security-tests,
+        workflow-tests,
       ]
     if: always()
     runs-on: ubuntu-latest
@@ -661,10 +694,11 @@ jobs:
             [unit-tests]="${{ needs['unit-tests'].result }}"
             [integration-light]="${{ needs['integration-light'].result }}"
             [security-tests]="${{ needs['security-tests'].result }}"
+            [workflow-tests]="${{ needs['workflow-tests'].result }}"
           )
 
           failed=0
-          for job in changes lint-and-type-check vulnerability-scan build unit-tests integration-light security-tests; do
+          for job in changes lint-and-type-check vulnerability-scan build unit-tests integration-light security-tests workflow-tests; do
             result="${results[$job]}"
             echo "${job} -> ${result}"
             # Treat 'success' as pass; allow 'skipped' (e.g., when changes filter is false)

--- a/docs/architecture/workflow-sdk.md
+++ b/docs/architecture/workflow-sdk.md
@@ -97,18 +97,19 @@ Workflow data for dev lives under `.next/workflow-data/` (not `.workflow-data/`,
 
 ## Testing
 
-Workflow SDK tests use a **separate** Vitest config so they do not share Testcontainers setup with DB/API integration tests. The unified integration runner still includes them as a workflow phase for full and changed integration-class runs:
+Workflow SDK tests use a **separate** Vitest config and their own isolated Testcontainers database. The changed integration runner includes a workflow phase, while full workflow coverage is an explicit phase in `pnpm test:all`:
 
 | Command                                       | Purpose                                                                                               |
 | --------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `pnpm test:integration`                       | DB/API integration tests, then the Workflow SDK Vitest harness                                        |
+| `pnpm test:integration`                       | DB/API integration tests only                                                                          |
 | `pnpm test:integration:changed`               | Changed DB/API integration tests, then changed Workflow SDK tests (passes when no workflow tests hit) |
-| `pnpm test:workflow`                          | Only the in-process Workflow SDK smoke (`tests/workflow/*.workflow.spec.ts`)                          |
+| `pnpm test:workflow`                          | Workflow SDK wiring and production entrypoints against isolated Postgres                              |
 | `pnpm exec vitest run --config vitest.config.ts --project unit tests/unit/...` | Unit tests for workflow helpers, wrappers, and orchestration (no runtime plugin) |
 
 - Config: `vitest.workflow.config.ts`
-- Bundle output: `.workflow-vitest/` (default discovery scope: `tests/helpers/workflow` only)
-- Override discovery roots: `WORKFLOW_VITEST_DIRS=.` (comma-separated) for full product workflow bundles
+- Bundle output: `.workflow-vitest/`
+- Default discovery: production workflow directories plus `tests/helpers/workflow`
+- Override discovery roots: `WORKFLOW_VITEST_DIRS=dir-a,dir-b` (comma-separated)
 
 Orchestration for product workflows is covered in `tests/unit/features/**/workflows/*.workflow.spec.ts` by calling workflow functions directly with mocked steps (per [Workflow SDK testing](https://workflow-sdk.dev/docs/testing)).
 

--- a/docs/development/commands.md
+++ b/docs/development/commands.md
@@ -74,8 +74,8 @@ pnpm test:unit                # Run all unit tests
 pnpm test:unit:changed        # Run unit tests for changed files only
 SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest --config vitest.config.ts --project unit tests/unit  # Unit watch mode
 pnpm test:integration:changed # Run changed integration + Workflow SDK tests
-pnpm test:integration         # Run full integration + Workflow SDK suites (heavier; use sparingly)
-pnpm test:workflow            # Run only the Workflow SDK Vitest harness
+pnpm test:integration         # Run the full DB/API integration suite (heavier; use sparingly)
+pnpm test:workflow            # Run Workflow SDK wiring + production entrypoints (Testcontainers)
 pnpm test:security            # Run RLS policy tests
 pnpm test:smoke               # Run Playwright smoke coverage
 pnpm test:all                 # Run lint, typecheck, unit, integration, workflow, and security suites

--- a/package.json
+++ b/package.json
@@ -24,15 +24,15 @@
     "test": "tsx scripts/tests/run-phases.ts test:unit:changed test:integration:changed",
     "test:unit": "SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit tests/unit",
     "test:unit:changed": "SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit --changed tests/unit",
-    "test:integration": "NODE_ENV=test pnpm vitest run --config vitest.config.ts --project integration tests/integration && pnpm test:workflow",
+    "test:integration": "NODE_ENV=test pnpm vitest run --config vitest.config.ts --project integration tests/integration",
     "test:integration:changed": "NODE_ENV=test pnpm vitest run --config vitest.config.ts --project integration --changed tests/integration && NODE_ENV=test pnpm vitest run --config vitest.workflow.config.ts --changed --passWithNoTests tests/workflow",
     "test:workflow": "NODE_ENV=test pnpm vitest run --config vitest.workflow.config.ts tests/workflow",
     "test:security": "NODE_ENV=test pnpm vitest run --config vitest.config.ts --project security tests/security",
     "test:smoke": "pnpm exec tsx scripts/tests/smoke/run.ts",
     "ui:capture-baseline": "tsx scripts/ui/capture-baseline.ts",
     "test:e2e": "NODE_ENV=test pnpm vitest run --config vitest.config.ts --project e2e tests/e2e",
-    "test:all": "tsx scripts/tests/run-phases.ts check:full test:unit test:integration test:security",
-    "test:all:e2e": "tsx scripts/tests/run-phases.ts check:full test:unit test:integration test:security test:e2e",
+    "test:all": "tsx scripts/tests/run-phases.ts check:full test:unit test:integration test:workflow test:security",
+    "test:all:e2e": "tsx scripts/tests/run-phases.ts check:full test:unit test:integration test:workflow test:security test:e2e",
     "prepare": "husky || true"
   },
   "dependencies": {

--- a/src/features/jobs/queue.ts
+++ b/src/features/jobs/queue.ts
@@ -68,8 +68,9 @@ export async function getNextJob(types: JobType[]): Promise<Job | null> {
 export async function claimRegenerationJob(
   jobId: string,
   expected: { planId: string; userId: string },
+  payload: JobPayload,
 ): Promise<Job | null> {
-  return claimRegenerationJobById(jobId, expected, db);
+  return claimRegenerationJobById(jobId, expected, payload, db);
 }
 
 export async function updateJobPayload(

--- a/src/features/lesson-content/generate-module-lessons.ts
+++ b/src/features/lesson-content/generate-module-lessons.ts
@@ -52,7 +52,7 @@ export async function generateModuleLessons(
     params.planId,
     params.moduleId,
     params.userId,
-    nowFn,
+    { now: nowFn },
   );
 
   if (claim.kind !== 'claimed') {

--- a/src/features/lesson-content/workflows/module-lesson-generation.steps.ts
+++ b/src/features/lesson-content/workflows/module-lesson-generation.steps.ts
@@ -51,9 +51,6 @@ export async function claimModuleLessonGenerationStep(
     input.userId,
     {
       workflow: {
-        userId: input.userId,
-        planId: input.planId,
-        moduleId: input.moduleId,
         runId,
         startedAt,
       },
@@ -74,7 +71,12 @@ export async function claimModuleLessonGenerationStep(
     return { kind: 'not_found', runId };
   }
 
-  return { kind: 'claimed', runId, load: claimedLoad, startedAt };
+  return {
+    kind: 'claimed',
+    runId,
+    load: claimedLoad,
+    startedAt: claim.workflowStartedAt ?? startedAt,
+  };
 }
 
 export async function runModuleLessonGenerationStep(

--- a/src/features/lesson-content/workflows/module-lesson-generation.steps.ts
+++ b/src/features/lesson-content/workflows/module-lesson-generation.steps.ts
@@ -10,7 +10,6 @@ import { runModuleLessonGenerationWork } from '@/features/lesson-content/run-mod
 import {
   claimModuleLessonGenerationOrDescribe,
   loadModuleLessonGenerationContext,
-  persistModuleLessonWorkflowRunMetadata,
 } from '@/lib/db/queries/module-lesson-generation';
 import { db as serviceRoleDb } from '@supabase/service-role';
 import { getWorkflowMetadata } from 'workflow';
@@ -39,15 +38,26 @@ export async function claimModuleLessonGenerationStep(
   if (preflight.kind === 'already_ready') {
     return { kind: 'already_ready', runId };
   }
-  if (preflight.kind === 'in_flight') {
-    return { kind: 'in_flight', runId };
-  }
+  const existingWorkflow = load?.module.lessonGenerationMetadata?.workflow;
+  const startedAt =
+    existingWorkflow?.runId === runId && existingWorkflow.startedAt
+      ? existingWorkflow.startedAt
+      : new Date().toISOString();
 
   const claim = await claimModuleLessonGenerationOrDescribe(
     serviceRoleDb,
     input.planId,
     input.moduleId,
     input.userId,
+    {
+      workflow: {
+        userId: input.userId,
+        planId: input.planId,
+        moduleId: input.moduleId,
+        runId,
+        startedAt,
+      },
+    },
   );
 
   if (claim.kind === 'already_ready') {
@@ -59,20 +69,10 @@ export async function claimModuleLessonGenerationStep(
   if (claim.kind === 'not_found') {
     return { kind: 'not_found', runId };
   }
-  if (preflight.kind !== 'eligible') {
-    return { kind: 'in_flight', runId };
+  const claimedLoad = load;
+  if (!claimedLoad) {
+    return { kind: 'not_found', runId };
   }
-
-  const claimedLoad = preflight.load;
-  const startedAt = new Date().toISOString();
-
-  await persistModuleLessonWorkflowRunMetadata(serviceRoleDb, {
-    userId: input.userId,
-    planId: input.planId,
-    moduleId: input.moduleId,
-    runId,
-    startedAt,
-  });
 
   return { kind: 'claimed', runId, load: claimedLoad, startedAt };
 }

--- a/src/features/plans/workflows/plan-regeneration.steps.ts
+++ b/src/features/plans/workflows/plan-regeneration.steps.ts
@@ -56,10 +56,23 @@ export async function claimPlanRegenerationJobStep(
     return { kind: 'claimed', runId };
   }
 
-  const claimed = await claimRegenerationJob(job.id, {
-    planId: input.planId,
-    userId: input.userId,
+  const payload = planRegenerationJobPayloadSchema.parse({
+    ...validation.payload,
+    workflow: {
+      provider: 'workflow-sdk' as const,
+      runId,
+      startedAt: new Date().toISOString(),
+    },
   });
+
+  const claimed = await claimRegenerationJob(
+    job.id,
+    {
+      planId: input.planId,
+      userId: input.userId,
+    },
+    payload,
+  );
 
   if (!claimed) {
     const latest = await loadJobById(input.jobId);
@@ -74,17 +87,6 @@ export async function claimPlanRegenerationJobStep(
     }
     return { kind: 'job-not-found', jobId: input.jobId };
   }
-
-  const payload = planRegenerationJobPayloadSchema.parse({
-    ...validation.payload,
-    workflow: {
-      provider: 'workflow-sdk' as const,
-      runId,
-      startedAt: new Date().toISOString(),
-    },
-  });
-
-  await updateJobPayload(job.id, payload);
 
   return { kind: 'claimed', runId };
 }

--- a/src/features/plans/workflows/plan-regeneration.steps.ts
+++ b/src/features/plans/workflows/plan-regeneration.steps.ts
@@ -81,6 +81,9 @@ export async function claimPlanRegenerationJobStep(
     }
     if (latest?.status === 'processing') {
       const run = latest.data.workflow?.runId;
+      if (run === runId) {
+        return { kind: 'claimed', runId };
+      }
       if (run) {
         return { kind: 'in-flight', jobId: job.id, runId: run };
       }

--- a/src/lib/db/queries/jobs/mutations.ts
+++ b/src/lib/db/queries/jobs/mutations.ts
@@ -156,6 +156,7 @@ export async function claimNextPendingJob(
 export async function claimRegenerationJobById(
   jobId: string,
   expected: { planId: string; userId: string },
+  payload: JobPayload,
   dbClient?: JobsDbClient,
 ): Promise<Job | null> {
   const client = dbClient ?? getDb();
@@ -186,6 +187,7 @@ export async function claimRegenerationJobById(
       .set({
         status: 'processing',
         startedAt: startTime,
+        payload,
         updatedAt: startTime,
       })
       .where(eq(jobQueue.id, jobId))

--- a/src/lib/db/queries/module-lesson-generation.ts
+++ b/src/lib/db/queries/module-lesson-generation.ts
@@ -158,17 +158,17 @@ export async function loadModuleLessonGenerationContext(
 }
 
 export type LessonGenerationClaimResult =
-  | { readonly kind: 'claimed' }
+  | {
+      readonly kind: 'claimed';
+      readonly workflowStartedAt: string | null;
+    }
   | { readonly kind: 'already_ready' }
   | { readonly kind: 'in_flight' }
   | { readonly kind: 'not_found' };
 
-export type PersistModuleLessonWorkflowRunInput = {
-  readonly userId: string;
-  readonly planId: string;
-  readonly moduleId: string;
+type ModuleLessonWorkflowClaimMetadata = {
   readonly runId: string;
-  readonly startedAt?: string;
+  readonly startedAt: string;
 };
 
 function truncateGenerationError(message: string): string {
@@ -267,7 +267,7 @@ export async function claimModuleLessonGenerationOrDescribe(
   userId: string,
   options?: {
     readonly now?: () => Date;
-    readonly workflow?: PersistModuleLessonWorkflowRunInput;
+    readonly workflow?: ModuleLessonWorkflowClaimMetadata;
   },
 ): Promise<LessonGenerationClaimResult> {
   const now = options?.now ?? (() => new Date());
@@ -281,7 +281,7 @@ export async function claimModuleLessonGenerationOrDescribe(
         },
       })
     : undefined;
-  const claimStartedAt = options?.workflow?.startedAt
+  const claimStartedAt = options?.workflow
     ? new Date(options.workflow.startedAt)
     : now();
   const attemptClaim = async (): Promise<boolean> => {
@@ -312,7 +312,10 @@ export async function claimModuleLessonGenerationOrDescribe(
 
   for (let attempt = 0; attempt < 2; attempt++) {
     if (await attemptClaim()) {
-      return { kind: 'claimed' };
+      return {
+        kind: 'claimed',
+        workflowStartedAt: options?.workflow?.startedAt ?? null,
+      };
     }
 
     const state = await readScopedModuleState(
@@ -333,7 +336,10 @@ export async function claimModuleLessonGenerationOrDescribe(
         options?.workflow &&
         state.metadata?.workflow?.runId === options.workflow.runId
       ) {
-        return { kind: 'claimed' };
+        return {
+          kind: 'claimed',
+          workflowStartedAt: state.metadata.workflow.startedAt ?? null,
+        };
       }
       return { kind: 'in_flight' };
     }
@@ -351,7 +357,10 @@ export async function claimModuleLessonGenerationOrDescribe(
       options?.workflow &&
       state.metadata?.workflow?.runId === options.workflow.runId
     ) {
-      return { kind: 'claimed' };
+      return {
+        kind: 'claimed',
+        workflowStartedAt: state.metadata.workflow.startedAt ?? null,
+      };
     }
     return { kind: 'in_flight' };
   }

--- a/src/lib/db/queries/module-lesson-generation.ts
+++ b/src/lib/db/queries/module-lesson-generation.ts
@@ -281,12 +281,15 @@ export async function claimModuleLessonGenerationOrDescribe(
         },
       })
     : undefined;
+  const claimStartedAt = options?.workflow?.startedAt
+    ? new Date(options.workflow.startedAt)
+    : now();
   const attemptClaim = async (): Promise<boolean> => {
     const touched = await dbClient
       .update(modules)
       .set({
         lessonGenerationStatus: 'generating',
-        lessonGenerationStartedAt: now(),
+        lessonGenerationStartedAt: claimStartedAt,
         lessonGenerationCompletedAt: null,
         lessonGenerationFailedAt: null,
         lessonGenerationError: null,

--- a/src/lib/db/queries/module-lesson-generation.ts
+++ b/src/lib/db/queries/module-lesson-generation.ts
@@ -228,14 +228,20 @@ export async function revertModuleLessonGeneratingToNotGenerated(
     );
 }
 
-async function readScopedModuleStatus(
+async function readScopedModuleState(
   dbClient: GenerationDb,
   planId: string,
   moduleId: string,
   userId: string,
-): Promise<InferSelectModel<typeof modules>['lessonGenerationStatus'] | null> {
+): Promise<{
+  status: InferSelectModel<typeof modules>['lessonGenerationStatus'];
+  metadata: ModuleLessonGenerationMetadata | null;
+} | null> {
   const [row] = await dbClient
-    .select({ status: modules.lessonGenerationStatus })
+    .select({
+      status: modules.lessonGenerationStatus,
+      metadata: modules.lessonGenerationMetadata,
+    })
     .from(modules)
     .innerJoin(learningPlans, eq(modules.planId, learningPlans.id))
     .where(
@@ -247,43 +253,7 @@ async function readScopedModuleStatus(
     )
     .limit(1);
 
-  return row?.status ?? null;
-}
-
-/**
- * Records Workflow SDK run metadata on a module already in `generating` state.
- */
-export async function persistModuleLessonWorkflowRunMetadata(
-  dbClient: GenerationDb,
-  input: PersistModuleLessonWorkflowRunInput,
-): Promise<void> {
-  const metadata = ModuleLessonGenerationMetadataSchema.parse({
-    version: 1,
-    workflow: {
-      provider: 'workflow-sdk',
-      runId: input.runId,
-      startedAt: input.startedAt,
-    },
-  });
-
-  const updated = await dbClient
-    .update(modules)
-    .set({ lessonGenerationMetadata: metadata })
-    .where(
-      and(
-        eq(modules.id, input.moduleId),
-        eq(modules.planId, input.planId),
-        eq(modules.lessonGenerationStatus, 'generating'),
-        moduleOwnedByUser(input.userId),
-      ),
-    )
-    .returning({ id: modules.id });
-
-  if (updated.length !== 1) {
-    throw new Error(
-      'Module lesson workflow metadata update did not match exactly one row',
-    );
-  }
+  return row ?? null;
 }
 
 /**
@@ -295,8 +265,22 @@ export async function claimModuleLessonGenerationOrDescribe(
   planId: string,
   moduleId: string,
   userId: string,
-  now: () => Date = () => new Date(),
+  options?: {
+    readonly now?: () => Date;
+    readonly workflow?: PersistModuleLessonWorkflowRunInput;
+  },
 ): Promise<LessonGenerationClaimResult> {
+  const now = options?.now ?? (() => new Date());
+  const workflowMetadata = options?.workflow
+    ? ModuleLessonGenerationMetadataSchema.parse({
+        version: 1,
+        workflow: {
+          provider: 'workflow-sdk',
+          runId: options.workflow.runId,
+          startedAt: options.workflow.startedAt,
+        },
+      })
+    : undefined;
   const attemptClaim = async (): Promise<boolean> => {
     const touched = await dbClient
       .update(modules)
@@ -306,6 +290,9 @@ export async function claimModuleLessonGenerationOrDescribe(
         lessonGenerationCompletedAt: null,
         lessonGenerationFailedAt: null,
         lessonGenerationError: null,
+        ...(workflowMetadata
+          ? { lessonGenerationMetadata: workflowMetadata }
+          : {}),
       })
       .where(
         and(
@@ -325,42 +312,49 @@ export async function claimModuleLessonGenerationOrDescribe(
       return { kind: 'claimed' };
     }
 
-    const status = await readScopedModuleStatus(
+    const state = await readScopedModuleState(
       dbClient,
       planId,
       moduleId,
       userId,
     );
 
-    if (status == null) {
+    if (state == null) {
       return { kind: 'not_found' };
     }
-    if (status === 'ready') {
+    if (state.status === 'ready') {
       return { kind: 'already_ready' };
     }
-    if (status === 'generating') {
+    if (state.status === 'generating') {
+      if (
+        options?.workflow &&
+        state.metadata?.workflow?.runId === options.workflow.runId
+      ) {
+        return { kind: 'claimed' };
+      }
       return { kind: 'in_flight' };
     }
   }
 
-  const status = await readScopedModuleStatus(
-    dbClient,
-    planId,
-    moduleId,
-    userId,
-  );
-  if (status == null) {
+  const state = await readScopedModuleState(dbClient, planId, moduleId, userId);
+  if (state == null) {
     return { kind: 'not_found' };
   }
-  if (status === 'ready') {
+  if (state.status === 'ready') {
     return { kind: 'already_ready' };
   }
-  if (status === 'generating') {
+  if (state.status === 'generating') {
+    if (
+      options?.workflow &&
+      state.metadata?.workflow?.runId === options.workflow.runId
+    ) {
+      return { kind: 'claimed' };
+    }
     return { kind: 'in_flight' };
   }
 
   throw new Error(
-    `Unexpected module lesson_generation_status after claim retries: ${String(status)}`,
+    `Unexpected module lesson_generation_status after claim retries: ${String(state.status)}`,
   );
 }
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -69,8 +69,8 @@ SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest --config vitest.config.ts --pr
 SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit tests/unit/path/to/file.spec.ts  # Single unit test file
 NODE_ENV=test pnpm vitest run --config vitest.config.ts --project integration tests/integration/path/to/file.spec.ts  # Single integration file (Testcontainers)
 pnpm test:integration:changed          # Changed integration tests + Workflow SDK changed phase
-pnpm test:integration                  # Full integration suite + Workflow SDK phase
-pnpm test:workflow                     # Workflow SDK tests only
+pnpm test:integration                  # Full DB/API integration suite
+pnpm test:workflow                     # Workflow SDK wiring + production entrypoints (Testcontainers)
 pnpm test:security                     # RLS policy tests (Testcontainers; requires Docker)
 pnpm test:smoke                        # Playwright smoke: ephemeral DB; full run uses sequential invocations (one Next server at a time)
 pnpm test:smoke -- --project smoke-anon  # Anon-only (lowest RAM; single anon server)
@@ -85,9 +85,9 @@ pnpm exec tsx scripts/tests/smoke/run.ts --smoke-step=db  # DB-only smoke infra 
 
 See [Workflow SDK architecture](../docs/architecture/workflow-sdk.md) for feature flags, local dev (`pnpm dev:workflow`), run correlation, and the full test command matrix.
 
-- Treat `tests/workflow/` as integration-class coverage because it exercises the Workflow SDK runtime boundary, even though it does not use Testcontainers.
-- Keep `vitest.workflow.config.ts` separate from DB/API integration tests so the Workflow SDK harness does not inherit global Testcontainers setup.
-- Use `pnpm test:integration` or `pnpm test:integration:changed` when validating the full integration-class test surface; these commands run the DB/API integration phase first and then the workflow phase.
+- Treat `tests/workflow/` as integration-class coverage because it exercises the Workflow SDK runtime boundary against an isolated Testcontainers database.
+- Keep `vitest.workflow.config.ts` separate from DB/API integration tests; its harness owns production workflow discovery and its own Testcontainers lifecycle.
+- Use `pnpm test:integration:changed` for changed DB/API and workflow coverage, or `pnpm test:all` for both complete suites.
 - Use `pnpm test:workflow` for targeted Workflow SDK iteration.
 - Keep unit tests for workflow helpers, wrappers, and orchestration under `tests/unit/**`; reserve `tests/workflow/**` for runtime wiring and SDK behavior.
 

--- a/tests/integration/db/jobs.queries.spec.ts
+++ b/tests/integration/db/jobs.queries.spec.ts
@@ -3,6 +3,7 @@ import type { InferInsertModel, InferSelectModel } from 'drizzle-orm';
 import { createTestUser } from '../../fixtures/users';
 import { JOB_TYPES } from '@/features/jobs/types';
 import {
+  claimRegenerationJobById,
   cleanupOldJobs,
   getActiveRegenerationJob,
   getFailedJobs,
@@ -71,6 +72,46 @@ describe('Job Queries', () => {
       .returning();
 
     planId = expectPresent(plan, 'Failed to create plan fixture').id;
+  });
+
+  it('atomically claims a regeneration job with workflow ownership metadata', async () => {
+    const pending = await createJob({
+      status: 'pending',
+      payload: { planId },
+    });
+    const payload = {
+      planId,
+      workflow: {
+        provider: 'workflow-sdk' as const,
+        runId: 'wrun_atomic_claim',
+        startedAt: '2026-06-22T18:00:00.000Z',
+      },
+    };
+
+    const claimed = await claimRegenerationJobById(
+      pending.id,
+      { planId, userId },
+      payload,
+      db,
+    );
+
+    expect(claimed).toMatchObject({
+      id: pending.id,
+      status: 'processing',
+      data: payload,
+    });
+    expect(claimed?.processingStartedAt).toBeInstanceOf(Date);
+
+    const competing = await claimRegenerationJobById(
+      pending.id,
+      { planId, userId },
+      {
+        ...payload,
+        workflow: { ...payload.workflow, runId: 'wrun_competing' },
+      },
+      db,
+    );
+    expect(competing).toBeNull();
   });
 
   describe('getFailedJobs', () => {

--- a/tests/integration/db/module-lesson-workflow-metadata.spec.ts
+++ b/tests/integration/db/module-lesson-workflow-metadata.spec.ts
@@ -1,7 +1,4 @@
-import {
-  claimModuleLessonGenerationOrDescribe,
-  persistModuleLessonWorkflowRunMetadata,
-} from '@/lib/db/queries/module-lesson-generation';
+import { claimModuleLessonGenerationOrDescribe } from '@/lib/db/queries/module-lesson-generation';
 import { modules } from '@supabase/schema';
 import { db } from '@supabase/service-role';
 import { createTestModule } from '@tests/fixtures/modules';
@@ -31,34 +28,84 @@ describe('module lesson workflow metadata (integration)', () => {
     const plan = await createTestPlan({ userId, topic: 'Workflow metadata' });
     const mod = await createTestModule({ planId: plan.id });
 
+    const runId = `wrun_${authUserId}`;
+    const startedAt = new Date().toISOString();
     const claim = await claimModuleLessonGenerationOrDescribe(
       db,
       plan.id,
       mod.id,
       userId,
+      {
+        workflow: {
+          userId,
+          planId: plan.id,
+          moduleId: mod.id,
+          runId,
+          startedAt,
+        },
+      },
     );
     expect(claim.kind).toBe('claimed');
 
-    const runId = `wrun_${authUserId}`;
-    await persistModuleLessonWorkflowRunMetadata(db, {
-      userId,
-      planId: plan.id,
-      moduleId: mod.id,
-      runId,
-      startedAt: new Date().toISOString(),
-    });
-
     const [row] = await db
-      .select({ metadata: modules.lessonGenerationMetadata })
+      .select({
+        status: modules.lessonGenerationStatus,
+        startedAt: modules.lessonGenerationStartedAt,
+        metadata: modules.lessonGenerationMetadata,
+      })
       .from(modules)
       .where(eq(modules.id, mod.id));
 
-    expect(row?.metadata).toMatchObject({
-      version: 1,
-      workflow: {
-        provider: 'workflow-sdk',
-        runId,
+    expect(row).toMatchObject({
+      status: 'generating',
+      startedAt: new Date(startedAt),
+      metadata: {
+        version: 1,
+        workflow: {
+          provider: 'workflow-sdk',
+          runId,
+        },
       },
     });
+
+    const replay = await claimModuleLessonGenerationOrDescribe(
+      db,
+      plan.id,
+      mod.id,
+      userId,
+      {
+        workflow: {
+          userId,
+          planId: plan.id,
+          moduleId: mod.id,
+          runId,
+          startedAt,
+        },
+      },
+    );
+    expect(replay.kind).toBe('claimed');
+
+    const competing = await claimModuleLessonGenerationOrDescribe(
+      db,
+      plan.id,
+      mod.id,
+      userId,
+      {
+        workflow: {
+          userId,
+          planId: plan.id,
+          moduleId: mod.id,
+          runId: `${runId}_other`,
+          startedAt: new Date().toISOString(),
+        },
+      },
+    );
+    expect(competing.kind).toBe('in_flight');
+
+    const [unchanged] = await db
+      .select({ metadata: modules.lessonGenerationMetadata })
+      .from(modules)
+      .where(eq(modules.id, mod.id));
+    expect(unchanged?.metadata?.workflow?.runId).toBe(runId);
   });
 });

--- a/tests/integration/db/module-lesson-workflow-metadata.spec.ts
+++ b/tests/integration/db/module-lesson-workflow-metadata.spec.ts
@@ -37,15 +37,13 @@ describe('module lesson workflow metadata (integration)', () => {
       userId,
       {
         workflow: {
-          userId,
-          planId: plan.id,
-          moduleId: mod.id,
           runId,
           startedAt,
         },
       },
     );
     expect(claim.kind).toBe('claimed');
+    expect(claim).toMatchObject({ workflowStartedAt: startedAt });
 
     const [row] = await db
       .select({
@@ -68,6 +66,7 @@ describe('module lesson workflow metadata (integration)', () => {
       },
     });
 
+    const replayStartedAt = new Date(Date.now() + 1_000).toISOString();
     const replay = await claimModuleLessonGenerationOrDescribe(
       db,
       plan.id,
@@ -75,15 +74,13 @@ describe('module lesson workflow metadata (integration)', () => {
       userId,
       {
         workflow: {
-          userId,
-          planId: plan.id,
-          moduleId: mod.id,
           runId,
-          startedAt,
+          startedAt: replayStartedAt,
         },
       },
     );
     expect(replay.kind).toBe('claimed');
+    expect(replay).toMatchObject({ workflowStartedAt: startedAt });
 
     const competing = await claimModuleLessonGenerationOrDescribe(
       db,
@@ -92,9 +89,6 @@ describe('module lesson workflow metadata (integration)', () => {
       userId,
       {
         workflow: {
-          userId,
-          planId: plan.id,
-          moduleId: mod.id,
           runId: `${runId}_other`,
           startedAt: new Date().toISOString(),
         },

--- a/tests/setup/workflow-vitest-global-setup.ts
+++ b/tests/setup/workflow-vitest-global-setup.ts
@@ -1,28 +1,52 @@
+import {
+  setup as setupTestcontainers,
+  teardown as teardownTestcontainers,
+} from './testcontainers';
 import { BaseBuilder, createBaseBuilderConfig } from '@workflow/builders';
 import { initDataDir } from '@workflow/world-local';
+import { readFileSync } from 'node:fs';
 import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 
 const outDir = join(process.cwd(), '.workflow-vitest');
 const dataDir = join(process.cwd(), '.workflow-data');
 
-const workflowDirs = process.env.WORKFLOW_VITEST_DIRS?.split(',')
-  .map((dir) => dir.trim())
-  .filter(Boolean) ?? ['tests/helpers/workflow'];
+const defaultWorkflowDirs = [
+  'src/features/lesson-content/workflows',
+  'src/features/plans/workflows',
+  'tests/helpers/workflow',
+];
+const workflowDirs =
+  process.env.WORKFLOW_VITEST_DIRS?.split(',')
+    .map((dir) => dir.trim())
+    .filter(Boolean) ?? defaultWorkflowDirs;
 
 /**
  * Matches @workflow/vitest's builder, with configurable discovery roots.
- * Default scope is test-only wiring workflows so `steps.mjs` does not pull
- * production step dependencies during smoke runs.
+ * The default scope covers every production workflow plus the wiring helper.
  */
 class ScopedVitestWorkflowBuilder extends BaseBuilder {
   constructor(workingDir: string) {
+    const packageJson = JSON.parse(
+      readFileSync(join(workingDir, 'package.json'), 'utf8'),
+    ) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    const externalPackages = [
+      ...Object.keys(packageJson.dependencies ?? {}),
+      ...Object.keys(packageJson.devDependencies ?? {}),
+    ];
+
     super({
       ...createBaseBuilderConfig({
         workingDir,
         dirs: workflowDirs,
       }),
       buildTarget: 'next',
+      // Bundle project files so aliases resolve in the step worker, but let
+      // Node load package dependencies directly (some contain dynamic require).
+      externalPackages,
       suppressCreateWorkflowsBundleLogs: true,
       suppressCreateWebhookBundleLogs: true,
       suppressCreateManifestLogs: true,
@@ -35,25 +59,33 @@ class ScopedVitestWorkflowBuilder extends BaseBuilder {
 
   async build(): Promise<void> {
     const inputFiles = await this.getInputFiles();
+    const tsconfigPath = await this.findTsConfigPath();
     await mkdir(outDir, { recursive: true });
     await this.createWorkflowsBundle({
       outfile: join(outDir, 'workflows.mjs'),
       bundleFinalOutput: false,
       format: 'esm',
       inputFiles,
+      tsconfigPath,
     });
     await this.createStepsBundle({
       outfile: join(outDir, 'steps.mjs'),
-      externalizeNonSteps: true,
+      externalizeNonSteps: false,
       rewriteTsExtensions: true,
       format: 'esm',
       inputFiles,
+      tsconfigPath,
     });
   }
 }
 
 export async function setup(): Promise<void> {
+  await setupTestcontainers();
   const builder = new ScopedVitestWorkflowBuilder(process.cwd());
   await builder.build();
   await initDataDir(dataDir);
+}
+
+export async function teardown(): Promise<void> {
+  await teardownTestcontainers();
 }

--- a/tests/unit/features/plans/workflows/plan-regeneration.steps.spec.ts
+++ b/tests/unit/features/plans/workflows/plan-regeneration.steps.spec.ts
@@ -1,0 +1,84 @@
+import type { Job } from '@/features/jobs/types';
+import type { PlanRegenerationWorkflowInput } from '@/features/plans/workflows/plan-regeneration.types';
+
+import { claimPlanRegenerationJobStep } from '@/features/plans/workflows/plan-regeneration.steps';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  claimJob: vi.fn(),
+  loadJob: vi.fn(),
+  getWorkflowMetadata: vi.fn(),
+}));
+
+vi.mock('@/features/jobs/queue', () => ({
+  claimRegenerationJob: mocks.claimJob,
+  loadJobById: mocks.loadJob,
+  updateJobPayload: vi.fn(),
+}));
+
+vi.mock('workflow', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('workflow')>();
+  return {
+    ...actual,
+    getWorkflowMetadata: mocks.getWorkflowMetadata,
+  };
+});
+
+const input: PlanRegenerationWorkflowInput = {
+  jobId: 'e6e5528d-1871-45d2-a055-7bc03f2ca8f8',
+  planId: '0c834f38-e9e1-4c7d-bdc0-2e28c505256a',
+  userId: '353d54b9-f3d0-4aa6-8c74-33956019cb71',
+  correlationId: 'regen-same-run-race',
+};
+
+function job(status: Job['status'], runId?: string): Job {
+  const now = new Date('2026-06-22T18:00:00.000Z');
+  return {
+    id: input.jobId,
+    type: 'plan_regeneration',
+    planId: input.planId,
+    userId: input.userId,
+    status,
+    priority: 0,
+    attempts: 0,
+    maxAttempts: 3,
+    data: {
+      planId: input.planId,
+      ...(runId
+        ? {
+            workflow: {
+              provider: 'workflow-sdk' as const,
+              runId,
+              startedAt: now.toISOString(),
+            },
+          }
+        : {}),
+    },
+    result: null,
+    error: null,
+    processingStartedAt: status === 'processing' ? now : null,
+    completedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+describe('claimPlanRegenerationJobStep', () => {
+  beforeEach(() => {
+    mocks.claimJob.mockReset();
+    mocks.loadJob.mockReset();
+    mocks.getWorkflowMetadata.mockReturnValue({ workflowRunId: 'wrun_same' });
+  });
+
+  it('continues when a concurrent same-run claim wins the CAS', async () => {
+    mocks.loadJob
+      .mockResolvedValueOnce(job('pending'))
+      .mockResolvedValueOnce(job('processing', 'wrun_same'));
+    mocks.claimJob.mockResolvedValue(null);
+
+    await expect(claimPlanRegenerationJobStep(input)).resolves.toEqual({
+      kind: 'claimed',
+      runId: 'wrun_same',
+    });
+  });
+});

--- a/tests/workflow/production-entrypoints.workflow.spec.ts
+++ b/tests/workflow/production-entrypoints.workflow.spec.ts
@@ -1,0 +1,149 @@
+import { enqueueJob } from '@/features/jobs/queue';
+import { JOB_TYPES } from '@/features/jobs/types';
+import { moduleLessonGenerationWorkflow } from '@/features/lesson-content/workflows/module-lesson-generation.workflow';
+import { toSerializableReservation } from '@/features/plans/workflows/plan-generation.types';
+import { planGenerationWorkflow } from '@/features/plans/workflows/plan-generation.workflow';
+import { planRegenerationWorkflow } from '@/features/plans/workflows/plan-regeneration.workflow';
+import { reserveAttemptSlot } from '@/lib/db/queries/attempts';
+import {
+  generationAttempts,
+  jobQueue,
+  learningPlans,
+  modules,
+} from '@supabase/schema';
+import { db } from '@supabase/service-role';
+import { createTestModule, createTestTask } from '@tests/fixtures/modules';
+import { createTestPlan } from '@tests/fixtures/plans';
+import { ensureUser } from '@tests/helpers/db/users';
+import { buildTestAuthUserId, buildTestEmail } from '@tests/helpers/testIds';
+import { eq } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+import { start } from 'workflow/api';
+
+const GENERATION_INPUT = {
+  topic: 'Deterministic workflow testing',
+  skillLevel: 'beginner' as const,
+  weeklyHours: 5,
+  learningStyle: 'mixed' as const,
+  startDate: null,
+  deadlineDate: null,
+};
+
+async function createWorkflowUser(scenario: string): Promise<string> {
+  const authUserId = buildTestAuthUserId(`workflow-${scenario}`);
+  return ensureUser({
+    authUserId,
+    email: buildTestEmail(authUserId),
+    subscriptionTier: 'pro',
+  });
+}
+
+describe('production Workflow SDK entrypoints', () => {
+  it('runs plan generation to a persisted successful terminal state', async () => {
+    const userId = await createWorkflowUser('plan-generation');
+    const plan = await createTestPlan({
+      userId,
+      topic: GENERATION_INPUT.topic,
+      generationStatus: 'failed',
+    });
+    const reservation = await reserveAttemptSlot({
+      planId: plan.id,
+      userId,
+      input: GENERATION_INPUT,
+      dbClient: db,
+    });
+    if (!reservation.reserved) {
+      throw new Error(
+        `Expected an attempt reservation, got ${reservation.reason}`,
+      );
+    }
+
+    const run = await start(planGenerationWorkflow, [
+      {
+        planId: plan.id,
+        userId,
+        tier: 'pro',
+        input: GENERATION_INPUT,
+        modelOverride: null,
+        correlationId: `workflow-plan-${plan.id}`,
+        reservation: toSerializableReservation(reservation),
+      },
+    ]);
+
+    const result = await run.returnValue;
+    expect(result.status).toBe('generation_success');
+    expect(await run.status).toBe('completed');
+
+    const [persistedPlan] = await db
+      .select({ status: learningPlans.generationStatus })
+      .from(learningPlans)
+      .where(eq(learningPlans.id, plan.id));
+    const [attempt] = await db
+      .select({ status: generationAttempts.status })
+      .from(generationAttempts)
+      .where(eq(generationAttempts.id, reservation.attemptId));
+    expect(persistedPlan?.status).toBe('ready');
+    expect(attempt?.status).toBe('success');
+  });
+
+  it('runs plan regeneration to a persisted successful terminal state', async () => {
+    const userId = await createWorkflowUser('plan-regeneration');
+    const plan = await createTestPlan({ userId, generationStatus: 'ready' });
+    const jobId = await enqueueJob(
+      JOB_TYPES.PLAN_REGENERATION,
+      plan.id,
+      userId,
+      { planId: plan.id, overrides: { topic: 'Regenerated workflow topic' } },
+    );
+
+    const run = await start(planRegenerationWorkflow, [
+      {
+        jobId,
+        planId: plan.id,
+        userId,
+        correlationId: `workflow-regeneration-${jobId}`,
+      },
+    ]);
+
+    const result = await run.returnValue;
+    expect(result).toMatchObject({
+      kind: 'completed',
+      jobId,
+      planId: plan.id,
+    });
+    expect(await run.status).toBe('completed');
+
+    const [job] = await db
+      .select({ status: jobQueue.status })
+      .from(jobQueue)
+      .where(eq(jobQueue.id, jobId));
+    expect(job?.status).toBe('completed');
+  });
+
+  it('runs module lesson generation to a persisted successful terminal state', async () => {
+    const userId = await createWorkflowUser('module-lessons');
+    const plan = await createTestPlan({ userId, generationStatus: 'ready' });
+    const module = await createTestModule({ planId: plan.id });
+    await createTestTask({ moduleId: module.id });
+
+    const run = await start(moduleLessonGenerationWorkflow, [
+      {
+        userId,
+        planId: plan.id,
+        moduleId: module.id,
+        userTier: 'pro',
+        correlationId: `workflow-module-${module.id}`,
+      },
+    ]);
+
+    const result = await run.returnValue;
+    expect(result.kind).toBe('success');
+    expect(await run.status).toBe('completed');
+
+    const [persistedModule] = await db
+      .select({ status: modules.lessonGenerationStatus })
+      .from(modules)
+      .where(eq(modules.id, module.id));
+    expect(persistedModule?.status).toBe('ready');
+  });
+});

--- a/vitest.workflow.config.ts
+++ b/vitest.workflow.config.ts
@@ -19,7 +19,22 @@ export default defineConfig({
     include: ['tests/workflow/**/*.workflow.spec.ts'],
     passWithNoTests: false,
     globalSetup: ['tests/setup/workflow-vitest-global-setup.ts'],
-    setupFiles: ['tests/setup/workflow-vitest-setup.ts'],
+    setupFiles: [
+      'tests/setup/test-env.ts',
+      'tests/setup.ts',
+      'tests/setup/db.ts',
+      'tests/setup/workflow-vitest-setup.ts',
+    ],
+    env: {
+      AI_PROVIDER: 'mock',
+      MOCK_GENERATION_DELAY_MS: '0',
+      MOCK_GENERATION_FAILURE_RATE: '0',
+      MOCK_GENERATION_SEED: '20260622',
+      MOCK_AI_SCENARIO: 'success',
+      LESSON_GENERATION_ENABLED: 'true',
+      ENABLE_SENTRY: 'false',
+      NEXT_PUBLIC_ENABLE_SENTRY: 'false',
+    },
     alias: {
       '@': srcRoot,
       '@/': path.join(srcRoot, path.sep),


### PR DESCRIPTION
## Summary
- make module lesson and regeneration job claims atomic, replay-safe, and same-run aware
- preserve the winning workflow ownership timestamp across concurrent replay races
- exercise all three production Workflow SDK entrypoints against isolated Testcontainers state with deterministic mock AI
- add a required production workflow CI job and make `test:all` run the workflow suite explicitly
- align workflow test documentation with the production-default, Testcontainers-backed harness

## Validated findings
- Finding 6: module lesson workflow ownership metadata could be persisted after the claim, leaving a replay/race window
- Finding 7: regeneration jobs could enter `processing` before workflow ownership payload was persisted, and production workflow entrypoints were not required by PR CI

## Invariants
- only the winning workflow run owns an in-flight module or regeneration job
- replays from the same run continue; competing runs return `in_flight`
- claim status, start timestamp, and workflow ownership metadata are persisted atomically
- every production workflow is discovered, serialized, started through `workflow/api.start`, awaited through `returnValue`, and verified `completed`
- `All Checks Passed (PR)` fails when production workflow tests fail

## Intentionally unchanged
- workflow feature-flag rollout behavior
- provider selection and production model configuration
- regeneration queue priority, quota, and terminal result contracts
- non-workflow integration and security test semantics

## Verification
- `pnpm test:workflow` — 2 files, 6 tests passed
- targeted regeneration same-run and module timestamp race tests — passed
- `pnpm test` — passed
- `pnpm check:full` — passed
- `pnpm test:all` — check, unit, integration, workflow, and security phases passed
- Thermos correctness/security review — 2 findings fixed
- Thermos maintainability review — 2 findings fixed

## Rollout and risk
The runtime changes are bounded to workflow claim ownership and replay classification. The primary risk is retry behavior under concurrent deliveries; deterministic same-run/competing-run tests and full production Workflow SDK executions cover those paths. CI now runs the production workflow harness as a required independent job before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrent claim/replay behavior for regeneration jobs and module lesson generation—important for workflow correctness but bounded by new integration, unit, and production workflow tests plus required CI.
> 
> **Overview**
> Makes **module lesson** and **plan regeneration** workflow claims **atomic and replay-safe**: status, timestamps, and Workflow SDK ownership metadata are written in one step, same-run replays continue as `claimed`, and competing runs get `in_flight`.
> 
> **Regeneration** passes workflow payload into `claimRegenerationJobById` so `processing` and `job_queue.data.workflow` update together (drops the separate post-claim `updateJobPayload` on claim). **Module lessons** fold workflow metadata into `claimModuleLessonGenerationOrDescribe` (removes `persistModuleLessonWorkflowRunMetadata`) and treat an already-`generating` row with the same `runId` as a successful replay without overwriting the original `startedAt`.
> 
> **Testing & CI:** `pnpm test:integration` no longer runs workflow tests; `test:all` adds an explicit `test:workflow` phase. The workflow Vitest harness uses **Testcontainers**, bundles **production** workflow dirs, and adds end-to-end specs for plan generation, regeneration, and module lesson entrypoints with mock AI. PR CI gains a required **Production Workflow Tests** job (`pnpm test:workflow`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d2c207adf307f4306f387fb317a90bf0e0a9f18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->