### PR TITLE
chore: resolve deferred Fallow cleanup debt

### DIFF
--- a/src/app/(app)/settings/billing/components/BillingCards.tsx
+++ b/src/app/(app)/settings/billing/components/BillingCards.tsx
@@ -19,6 +19,30 @@ import { ROUTES } from '@/features/navigation/routes';
 import { requestBoundary } from '@/lib/api/request-boundary';
 import { redirect } from 'next/navigation';
 
+type UsageMeterRowProps = {
+  label: string;
+  ariaLabel: string;
+  used: number;
+  limit: number | null | undefined;
+};
+
+function UsageMeterRow({ label, ariaLabel, used, limit }: UsageMeterRowProps) {
+  return (
+    <div>
+      <div className='mb-1 flex items-center justify-between text-sm'>
+        <span>{label}</span>
+        <span className='text-muted-foreground tabular-nums'>
+          {used}/{formatCompactUsageLimit(limit)}
+        </span>
+      </div>
+      <Progress
+        value={getUsagePercent(used, limit)}
+        aria-label={`${ariaLabel}: ${used} of ${formatUsageLimitLabel(limit)}`}
+      />
+    </div>
+  );
+}
+
 /**
  * Async component that fetches subscription and usage data.
  * Wrapped in Suspense boundary by the parent page.
@@ -65,23 +89,6 @@ export async function BillingCards({ locale }: { locale?: string }) {
       )
     : '—';
 
-  const plansValue = getUsagePercent(
-    snapshot.usage.activePlans.current,
-    snapshot.usage.activePlans.limit,
-  );
-  const regenValue = getUsagePercent(
-    snapshot.usage.regenerations.used,
-    snapshot.usage.regenerations.limit,
-  );
-  const exportValue = getUsagePercent(
-    snapshot.usage.exports.used,
-    snapshot.usage.exports.limit,
-  );
-  const lessonGenerationValue = getUsagePercent(
-    snapshot.usage.lessonGenerations.used,
-    snapshot.usage.lessonGenerations.limit,
-  );
-
   return (
     <>
       <Card>
@@ -125,63 +132,30 @@ export async function BillingCards({ locale }: { locale?: string }) {
           <CardTitle as='h3'>Usage</CardTitle>
         </CardHeader>
         <CardContent className='space-y-5'>
-          <div>
-            <div className='mb-1 flex items-center justify-between text-sm'>
-              <span>Active plans</span>
-              <span className='text-muted-foreground tabular-nums'>
-                {snapshot.usage.activePlans.current}/
-                {formatCompactUsageLimit(snapshot.usage.activePlans.limit)}
-              </span>
-            </div>
-            <Progress
-              value={plansValue}
-              aria-label={`Active plans: ${snapshot.usage.activePlans.current} of ${formatUsageLimitLabel(snapshot.usage.activePlans.limit)}`}
-            />
-          </div>
-
-          <div>
-            <div className='mb-1 flex items-center justify-between text-sm'>
-              <span>Regenerations (monthly)</span>
-              <span className='text-muted-foreground tabular-nums'>
-                {snapshot.usage.regenerations.used}/
-                {formatCompactUsageLimit(snapshot.usage.regenerations.limit)}
-              </span>
-            </div>
-            <Progress
-              value={regenValue}
-              aria-label={`Monthly regenerations: ${snapshot.usage.regenerations.used} of ${formatUsageLimitLabel(snapshot.usage.regenerations.limit)}`}
-            />
-          </div>
-
-          <div>
-            <div className='mb-1 flex items-center justify-between text-sm'>
-              <span>Exports (monthly)</span>
-              <span className='text-muted-foreground tabular-nums'>
-                {snapshot.usage.exports.used}/
-                {formatCompactUsageLimit(snapshot.usage.exports.limit)}
-              </span>
-            </div>
-            <Progress
-              value={exportValue}
-              aria-label={`Monthly exports: ${snapshot.usage.exports.used} of ${formatUsageLimitLabel(snapshot.usage.exports.limit)}`}
-            />
-          </div>
-
-          <div>
-            <div className='mb-1 flex items-center justify-between text-sm'>
-              <span>Lesson generations (monthly)</span>
-              <span className='text-muted-foreground tabular-nums'>
-                {snapshot.usage.lessonGenerations.used}/
-                {formatCompactUsageLimit(
-                  snapshot.usage.lessonGenerations.limit,
-                )}
-              </span>
-            </div>
-            <Progress
-              value={lessonGenerationValue}
-              aria-label={`Monthly lesson generations: ${snapshot.usage.lessonGenerations.used} of ${formatUsageLimitLabel(snapshot.usage.lessonGenerations.limit)}`}
-            />
-          </div>
+          <UsageMeterRow
+            label='Active plans'
+            ariaLabel='Active plans'
+            used={snapshot.usage.activePlans.current}
+            limit={snapshot.usage.activePlans.limit}
+          />
+          <UsageMeterRow
+            label='Regenerations (monthly)'
+            ariaLabel='Monthly regenerations'
+            used={snapshot.usage.regenerations.used}
+            limit={snapshot.usage.regenerations.limit}
+          />
+          <UsageMeterRow
+            label='Exports (monthly)'
+            ariaLabel='Monthly exports'
+            used={snapshot.usage.exports.used}
+            limit={snapshot.usage.exports.limit}
+          />
+          <UsageMeterRow
+            label='Lesson generations (monthly)'
+            ariaLabel='Monthly lesson generations'
+            used={snapshot.usage.lessonGenerations.used}
+            limit={snapshot.usage.lessonGenerations.limit}
+          />
         </CardContent>
       </Card>
     </>

--- a/src/app/api/internal/maintenance/plans/cleanup/route.ts
+++ b/src/app/api/internal/maintenance/plans/cleanup/route.ts
@@ -1,13 +1,7 @@
-import type { PlainHandler } from '@/lib/api/auth';
-
 import { runPlanCleanupMaintenance } from '@/features/plans/cleanup';
-import { assertMaintenanceWorkerAccess } from '@/lib/api/internal/internal-worker-access';
-import { checkIpRateLimit } from '@/lib/api/ip-rate-limit';
+import { createMaintenancePostRoute } from '@/lib/api/internal/maintenance-route';
 import { json } from '@/lib/api/response';
-import { withErrorBoundary } from '@/lib/api/route-wrappers';
 import { maintenanceEnv } from '@/lib/config/env';
-import { getLoggingRequestContext } from '@/lib/logging/request-context';
-import * as Sentry from '@sentry/nextjs';
 
 const PLAN_CLEANUP_MONITOR_SLUG = 'plan-cleanup-maintenance';
 const PLAN_CLEANUP_MONITOR_CONFIG = {
@@ -20,37 +14,24 @@ const PLAN_CLEANUP_MONITOR_CONFIG = {
   isolateTrace: true,
 } as const;
 
-const runPlanCleanup: PlainHandler = async (request) => {
-  const { logger } = getLoggingRequestContext(request);
-  const pathname = new URL(request.url).pathname;
+export const POST = createMaintenancePostRoute({
+  enabled: () => maintenanceEnv.planCleanupEnabled,
+  unavailableMessage: 'Plan cleanup is currently unavailable.',
+  unauthorizedLogMessage: 'Unauthorized plan cleanup trigger attempt',
+  monitor: {
+    slug: PLAN_CLEANUP_MONITOR_SLUG,
+    config: PLAN_CLEANUP_MONITOR_CONFIG,
+  },
+  run: async ({ logger }) => {
+    logger.info('Starting plan cleanup');
 
-  checkIpRateLimit(request, 'internal');
+    const result = await runPlanCleanupMaintenance();
 
-  assertMaintenanceWorkerAccess({
-    request,
-    pathname,
-    logger,
-    enabled: maintenanceEnv.planCleanupEnabled,
-    unavailableMessage: 'Plan cleanup is currently unavailable.',
-    unauthorizedLogMessage: 'Unauthorized plan cleanup trigger attempt',
-  });
+    logger.info(result, 'Completed plan cleanup');
 
-  return Sentry.withMonitor(
-    PLAN_CLEANUP_MONITOR_SLUG,
-    async () => {
-      logger.info('Starting plan cleanup');
-
-      const result = await runPlanCleanupMaintenance();
-
-      logger.info(result, 'Completed plan cleanup');
-
-      return json({
-        ...result,
-        ok: true,
-      });
-    },
-    PLAN_CLEANUP_MONITOR_CONFIG,
-  );
-};
-
-export const POST: PlainHandler = withErrorBoundary(runPlanCleanup);
+    return json({
+      ...result,
+      ok: true,
+    });
+  },
+});

--- a/src/app/api/internal/maintenance/retention/cleanup/route.ts
+++ b/src/app/api/internal/maintenance/retention/cleanup/route.ts
@@ -1,33 +1,19 @@
-import type { PlainHandler } from '@/lib/api/auth';
-
-import { assertMaintenanceWorkerAccess } from '@/lib/api/internal/internal-worker-access';
-import { checkIpRateLimit } from '@/lib/api/ip-rate-limit';
+import { createMaintenancePostRoute } from '@/lib/api/internal/maintenance-route';
 import { json } from '@/lib/api/response';
-import { withErrorBoundary } from '@/lib/api/route-wrappers';
 import { maintenanceEnv } from '@/lib/config/env';
 import { cleanupRetainedDbRows } from '@/lib/db/queries/admin/retention';
-import { getLoggingRequestContext } from '@/lib/logging/request-context';
 
-export const POST: PlainHandler = withErrorBoundary(async (request) => {
-  const { logger } = getLoggingRequestContext(request);
-  const pathname = new URL(request.url).pathname;
+export const POST = createMaintenancePostRoute({
+  enabled: () => maintenanceEnv.retentionCleanupEnabled,
+  unavailableMessage: 'Retention cleanup is currently unavailable.',
+  unauthorizedLogMessage: 'Unauthorized retention cleanup trigger attempt',
+  run: async ({ logger }) => {
+    logger.info('Starting retention cleanup');
 
-  checkIpRateLimit(request, 'internal');
+    const deleted = await cleanupRetainedDbRows();
 
-  assertMaintenanceWorkerAccess({
-    request,
-    pathname,
-    logger,
-    enabled: maintenanceEnv.retentionCleanupEnabled,
-    unavailableMessage: 'Retention cleanup is currently unavailable.',
-    unauthorizedLogMessage: 'Unauthorized retention cleanup trigger attempt',
-  });
+    logger.info({ deleted }, 'Completed retention cleanup');
 
-  logger.info('Starting retention cleanup');
-
-  const deleted = await cleanupRetainedDbRows();
-
-  logger.info({ deleted }, 'Completed retention cleanup');
-
-  return json({ ok: true, ...deleted });
+    return json({ ok: true, ...deleted });
+  },
 });

--- a/src/features/ai/parser.ts
+++ b/src/features/ai/parser.ts
@@ -160,16 +160,12 @@ function toParsedModule(module: unknown, moduleIndex: number): ParsedModule {
   return { title, description, estimatedMinutes, tasks };
 }
 
-export async function parseGenerationStream(
-  stream: AsyncIterable<string> | ReadableStream<string>,
+async function readRawGenerationResponse(
+  source: AsyncIterable<string>,
   callbacks: ParserCallbacks = {},
-): Promise<ParsedGeneration> {
+): Promise<string> {
   let buffer = '';
   let moduleDetected = false;
-  const source =
-    stream instanceof ReadableStream
-      ? readableStreamToAsyncIterable(stream)
-      : stream;
 
   for await (const chunk of source) {
     callbacks.signal?.throwIfAborted();
@@ -190,8 +186,13 @@ export async function parseGenerationStream(
     }
   }
 
-  callbacks.signal?.throwIfAborted();
+  return buffer;
+}
 
+function parseRawGenerationResponse(
+  buffer: string,
+  signal?: AbortSignal,
+): Record<string, unknown> {
   if (!buffer.trim()) {
     throw new ParserError(
       'invalid_json',
@@ -202,7 +203,7 @@ export async function parseGenerationStream(
   let parsed: unknown;
   try {
     parsed = JSON.parse(buffer);
-    callbacks.signal?.throwIfAborted();
+    signal?.throwIfAborted();
   } catch (error) {
     // Re-throw abort so callers can distinguish user cancellation from parse failures.
     if (error instanceof Error && error.name === 'AbortError') throw error;
@@ -220,7 +221,14 @@ export async function parseGenerationStream(
     );
   }
 
-  const modulesRaw = (parsed as Record<string, unknown>).modules;
+  return parsed as Record<string, unknown>;
+}
+
+function toParsedModules(
+  parsed: Record<string, unknown>,
+  signal?: AbortSignal,
+): ParsedModule[] {
+  const modulesRaw = parsed.modules;
   if (!Array.isArray(modulesRaw)) {
     throw new ParserError(
       'validation',
@@ -239,9 +247,27 @@ export async function parseGenerationStream(
 
   const modules: ParsedModule[] = [];
   for (let index = 0; index < modulesRaw.length; index++) {
-    callbacks.signal?.throwIfAborted();
+    signal?.throwIfAborted();
     modules.push(toParsedModule(modulesRaw[index], index));
   }
+
+  return modules;
+}
+
+export async function parseGenerationStream(
+  stream: AsyncIterable<string> | ReadableStream<string>,
+  callbacks: ParserCallbacks = {},
+): Promise<ParsedGeneration> {
+  const source =
+    stream instanceof ReadableStream
+      ? readableStreamToAsyncIterable(stream)
+      : stream;
+  const buffer = await readRawGenerationResponse(source, callbacks);
+
+  callbacks.signal?.throwIfAborted();
+
+  const parsed = parseRawGenerationResponse(buffer, callbacks.signal);
+  const modules = toParsedModules(parsed, callbacks.signal);
 
   return {
     modules,

--- a/src/features/ai/parser.ts
+++ b/src/features/ai/parser.ts
@@ -202,8 +202,8 @@ function parseRawGenerationResponse(
 
   let parsed: unknown;
   try {
-    parsed = JSON.parse(buffer);
     signal?.throwIfAborted();
+    parsed = JSON.parse(buffer);
   } catch (error) {
     // Re-throw abort so callers can distinguish user cancellation from parse failures.
     if (error instanceof Error && error.name === 'AbortError') throw error;

--- a/src/features/ai/usage.ts
+++ b/src/features/ai/usage.ts
@@ -107,14 +107,15 @@ export function normalizeToCanonicalUsage(
   // log it explicitly so the silent path stops being invisible. Any other
   // error from computeCostCents (invalid token counts, registry bug) must
   // propagate.
-  const estimatedCostCents = computeEstimatedCostCents({
-    model: resolvedModel,
-    inputTokens: resolvedInputTokens,
-    outputTokens: resolvedOutputTokens,
-    provider: resolvedProvider,
-  });
-
   const isPartial = missingFields.length > 0;
+  const estimatedCostCents = isPartial
+    ? 0
+    : computeEstimatedCostCents({
+        model: resolvedModel,
+        inputTokens: resolvedInputTokens,
+        outputTokens: resolvedOutputTokens,
+        provider: resolvedProvider,
+      });
   const providerCostMicrousd = resolveProviderCostMicrousd(usage, isPartial);
 
   const canonical: CanonicalAIUsage = {

--- a/src/features/ai/usage.ts
+++ b/src/features/ai/usage.ts
@@ -21,6 +21,65 @@ import {
 } from '@/shared/types/ai-usage.types';
 import * as Sentry from '@sentry/nextjs';
 
+function collectMissingFields(
+  metadata: ProviderMetadata | undefined,
+): CanonicalUsageMissingField[] {
+  const missingFields: CanonicalUsageMissingField[] = [];
+  const usage = metadata?.usage;
+
+  if (!metadata?.provider) missingFields.push('provider');
+  if (!metadata?.model) missingFields.push('model');
+  if (usage?.promptTokens == null) missingFields.push('inputTokens');
+  if (usage?.completionTokens == null) missingFields.push('outputTokens');
+
+  return missingFields;
+}
+
+function computeEstimatedCostCents(args: {
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  provider: string;
+}): number {
+  const { model, inputTokens, outputTokens, provider } = args;
+
+  try {
+    return computeCostCents(model, inputTokens, outputTokens);
+  } catch (error) {
+    if (error instanceof UnknownModelError) {
+      logger.warn(
+        {
+          source: 'canonical-usage',
+          event: 'unknown_model_cost_skipped',
+          modelId: model,
+          provider,
+        },
+        `Unknown model "${model}" — recording 0 estimated cost`,
+      );
+      return 0;
+    }
+
+    throw error;
+  }
+}
+
+function resolveProviderCostMicrousd(
+  usage: ProviderMetadata['usage'] | undefined,
+  isPartial: boolean,
+): number | null {
+  if (isPartial) {
+    return null;
+  }
+
+  const usd = usage?.providerReportedCostUsd;
+  return usd != null &&
+    typeof usd === 'number' &&
+    Number.isFinite(usd) &&
+    usd >= 0
+    ? usdCostToMicrousdInteger(usd)
+    : null;
+}
+
 /**
  * Strictly normalize provider metadata into a CanonicalAIUsage.
  *
@@ -32,16 +91,10 @@ import * as Sentry from '@sentry/nextjs';
 export function normalizeToCanonicalUsage(
   metadata: ProviderMetadata | undefined,
 ): CanonicalAIUsage {
-  const missingFields: CanonicalUsageMissingField[] = [];
-
+  const missingFields = collectMissingFields(metadata);
   const provider = metadata?.provider;
   const model = metadata?.model;
   const usage = metadata?.usage;
-
-  if (!provider) missingFields.push('provider');
-  if (!model) missingFields.push('model');
-  if (usage?.promptTokens == null) missingFields.push('inputTokens');
-  if (usage?.completionTokens == null) missingFields.push('outputTokens');
 
   const resolvedProvider = provider ?? 'unknown';
   const resolvedModel = model ?? 'unknown';
@@ -54,43 +107,15 @@ export function normalizeToCanonicalUsage(
   // log it explicitly so the silent path stops being invisible. Any other
   // error from computeCostCents (invalid token counts, registry bug) must
   // propagate.
-  let estimatedCostCents = 0;
-  try {
-    estimatedCostCents = computeCostCents(
-      resolvedModel,
-      resolvedInputTokens,
-      resolvedOutputTokens,
-    );
-  } catch (error) {
-    if (error instanceof UnknownModelError) {
-      logger.warn(
-        {
-          source: 'canonical-usage',
-          event: 'unknown_model_cost_skipped',
-          modelId: resolvedModel,
-          provider: resolvedProvider,
-        },
-        `Unknown model "${resolvedModel}" — recording 0 estimated cost`,
-      );
-    } else {
-      throw error;
-    }
-  }
+  const estimatedCostCents = computeEstimatedCostCents({
+    model: resolvedModel,
+    inputTokens: resolvedInputTokens,
+    outputTokens: resolvedOutputTokens,
+    provider: resolvedProvider,
+  });
 
   const isPartial = missingFields.length > 0;
-
-  let providerCostMicrousd: number | null = null;
-  if (!isPartial) {
-    const usd = usage?.providerReportedCostUsd;
-    if (
-      usd != null &&
-      typeof usd === 'number' &&
-      Number.isFinite(usd) &&
-      usd >= 0
-    ) {
-      providerCostMicrousd = usdCostToMicrousdInteger(usd);
-    }
-  }
+  const providerCostMicrousd = resolveProviderCostMicrousd(usage, isPartial);
 
   const canonical: CanonicalAIUsage = {
     inputTokens: resolvedInputTokens,

--- a/src/features/billing/stripe-commerce/subscription-db-sync.ts
+++ b/src/features/billing/stripe-commerce/subscription-db-sync.ts
@@ -21,6 +21,8 @@ type SyncSubscriptionToDbDeps = {
   timeoutMs?: number;
 };
 
+type SubscriptionTier = 'free' | 'starter' | 'pro';
+
 export type StripeSubscriptionForSync = Pick<
   Stripe.Subscription,
   'id' | 'cancel_at_period_end' | 'customer' | 'status'
@@ -86,6 +88,68 @@ async function withAbortSignal<T>(
   });
 }
 
+async function resolveTierFromPrice(args: {
+  stripe: Stripe;
+  priceId: string | undefined;
+  existingTier: SubscriptionTier;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}): Promise<SubscriptionTier> {
+  const { stripe, priceId, existingTier, signal, timeoutMs } = args;
+  if (!priceId) {
+    return existingTier;
+  }
+
+  const requestTimeoutMs = timeoutMs ?? 10_000;
+  try {
+    const price = await withAbortSignal(
+      () =>
+        stripe.prices.retrieve(
+          priceId,
+          {
+            expand: ['product'],
+          },
+          {
+            timeout: requestTimeoutMs,
+          },
+        ),
+      signal,
+    );
+
+    const product = price.product as Stripe.Product;
+    const tierMetadata = product.metadata?.tier;
+
+    return tierMetadata === 'starter' || tierMetadata === 'pro'
+      ? tierMetadata
+      : existingTier;
+  } catch (error) {
+    if (isAbortError(error)) {
+      logger.warn(
+        {
+          priceId,
+          event: 'subscription_sync_price_fetch_aborted',
+          timeoutMs: requestTimeoutMs,
+        },
+        'Stripe price lookup aborted during subscription sync',
+      );
+    } else {
+      logger.error(
+        {
+          priceId,
+          event: 'subscription_sync_price_fetch_failed',
+          error,
+        },
+        'Error retrieving Stripe price/product during subscription sync',
+      );
+    }
+
+    throw new Error(
+      `Unable to determine subscription tier for Stripe price ${priceId}`,
+      { cause: error },
+    );
+  }
+}
+
 /**
  * Stripe subscription → users row sync. Internal to write-side reconciliation
  * (`reconciliation.ts`); not a public billing API.
@@ -129,58 +193,13 @@ export async function syncSubscriptionToDb(
       ? user.subscriptionTier
       : 'free';
 
-  let tier: 'free' | 'starter' | 'pro' = existingTier;
-
-  if (priceId) {
-    const requestTimeoutMs = deps.timeoutMs ?? 10_000;
-    try {
-      const price = await withAbortSignal(
-        () =>
-          stripe.prices.retrieve(
-            priceId,
-            {
-              expand: ['product'],
-            },
-            {
-              timeout: requestTimeoutMs,
-            },
-          ),
-        deps.signal,
-      );
-
-      const product = price.product as Stripe.Product;
-      const tierMetadata = product.metadata?.tier;
-
-      if (tierMetadata === 'starter' || tierMetadata === 'pro') {
-        tier = tierMetadata;
-      }
-    } catch (error) {
-      if (isAbortError(error)) {
-        logger.warn(
-          {
-            priceId,
-            event: 'subscription_sync_price_fetch_aborted',
-            timeoutMs: requestTimeoutMs,
-          },
-          'Stripe price lookup aborted during subscription sync',
-        );
-      } else {
-        logger.error(
-          {
-            priceId,
-            event: 'subscription_sync_price_fetch_failed',
-            error,
-          },
-          'Error retrieving Stripe price/product during subscription sync',
-        );
-      }
-
-      throw new Error(
-        `Unable to determine subscription tier for Stripe price ${priceId}`,
-        { cause: error },
-      );
-    }
-  }
+  const tier = await resolveTierFromPrice({
+    stripe,
+    priceId,
+    existingTier,
+    signal: deps.signal,
+    timeoutMs: deps.timeoutMs,
+  });
 
   const status = mapStripeSubscriptionStatus(subscription.status);
 

--- a/src/features/billing/stripe-commerce/subscription-db-sync.ts
+++ b/src/features/billing/stripe-commerce/subscription-db-sync.ts
@@ -1,4 +1,5 @@
 import type { DbClient } from '@/lib/db/types';
+import type { SubscriptionTier } from '@/shared/types/billing.types';
 import type Stripe from 'stripe';
 
 import { getStripe } from '@/features/billing/client';
@@ -20,8 +21,6 @@ type SyncSubscriptionToDbDeps = {
   signal?: AbortSignal;
   timeoutMs?: number;
 };
-
-type SubscriptionTier = 'free' | 'starter' | 'pro';
 
 export type StripeSubscriptionForSync = Pick<
   Stripe.Subscription,

--- a/src/lib/api/internal/maintenance-route.ts
+++ b/src/lib/api/internal/maintenance-route.ts
@@ -1,0 +1,61 @@
+import type { PlainHandler } from '@/lib/api/auth';
+import type { Logger } from '@/lib/logging/logger';
+
+import { assertMaintenanceWorkerAccess } from '@/lib/api/internal/internal-worker-access';
+import { checkIpRateLimit } from '@/lib/api/ip-rate-limit';
+import { withErrorBoundary } from '@/lib/api/route-wrappers';
+import { getLoggingRequestContext } from '@/lib/logging/request-context';
+import * as Sentry from '@sentry/nextjs';
+
+type MaintenanceRouteContext = {
+  request: Request;
+  logger: Logger;
+  pathname: string;
+};
+
+type MaintenanceMonitor = {
+  slug: string;
+  config: Parameters<typeof Sentry.withMonitor>[2];
+};
+
+type CreateMaintenancePostRouteArgs = {
+  enabled: () => boolean;
+  unavailableMessage: string;
+  unauthorizedLogMessage: string;
+  monitor?: MaintenanceMonitor;
+  run: (context: MaintenanceRouteContext) => Promise<Response>;
+};
+
+/**
+ * Shared preamble for internal maintenance POST routes. Route bodies stay
+ * local; optional Sentry monitors cover scheduled routes without forcing every
+ * maintenance handler into the same monitor shape.
+ */
+export function createMaintenancePostRoute(
+  args: CreateMaintenancePostRouteArgs,
+): PlainHandler {
+  return withErrorBoundary(async (request) => {
+    const { logger } = getLoggingRequestContext(request);
+    const pathname = new URL(request.url).pathname;
+
+    checkIpRateLimit(request, 'internal');
+
+    assertMaintenanceWorkerAccess({
+      request,
+      pathname,
+      logger,
+      enabled: args.enabled(),
+      unavailableMessage: args.unavailableMessage,
+      unauthorizedLogMessage: args.unauthorizedLogMessage,
+    });
+
+    const context = { request, logger, pathname };
+    return args.monitor
+      ? Sentry.withMonitor(
+          args.monitor.slug,
+          () => args.run(context),
+          args.monitor.config,
+        )
+      : args.run(context);
+  });
+}

--- a/tests/helpers/db/retention-fixtures.ts
+++ b/tests/helpers/db/retention-fixtures.ts
@@ -6,6 +6,7 @@ import {
 } from '@supabase/schema';
 import { db } from '@supabase/service-role';
 import { ensureUser } from '@tests/helpers/db/users';
+import { and, eq, inArray } from 'drizzle-orm';
 
 export const JOB_QUEUE_RETENTION_DAYS = 30;
 export const STRIPE_WEBHOOK_EVENT_RETENTION_DAYS = 45;
@@ -35,6 +36,20 @@ export type SeedRetentionCleanupRowsResult = {
   };
   jobRowIds: string[];
 };
+
+export async function selectRetentionJobRows(
+  fixture: Pick<SeedRetentionCleanupRowsResult, 'userId' | 'jobRowIds'>,
+) {
+  return db
+    .select({ id: jobQueue.id, status: jobQueue.status })
+    .from(jobQueue)
+    .where(
+      and(
+        eq(jobQueue.userId, fixture.userId),
+        inArray(jobQueue.id, fixture.jobRowIds),
+      ),
+    );
+}
 
 export async function seedRetentionCleanupRows(
   options: SeedRetentionCleanupRowsOptions,

--- a/tests/helpers/maintenance-request.ts
+++ b/tests/helpers/maintenance-request.ts
@@ -1,0 +1,21 @@
+export function createMaintenancePostRequest(
+  url: string,
+  init: RequestInit & { token?: string; useBearer?: boolean } = {},
+): Request {
+  const { token, useBearer = true, ...requestInit } = init;
+  const headers = new Headers(requestInit.headers);
+
+  if (token) {
+    if (useBearer) {
+      headers.set('Authorization', `Bearer ${token}`);
+    } else {
+      headers.set('x-maintenance-worker-token', token);
+    }
+  }
+
+  return new Request(url, {
+    method: 'POST',
+    ...requestInit,
+    headers,
+  });
+}

--- a/tests/integration/api/plan-cleanup-process.spec.ts
+++ b/tests/integration/api/plan-cleanup-process.spec.ts
@@ -8,31 +8,34 @@ import { generationAttempts, learningPlans } from '@supabase/schema';
 import { db } from '@supabase/service-role';
 import { createTestPlan } from '@tests/fixtures/plans';
 import { createTestUser } from '@tests/fixtures/users';
+import { createMaintenancePostRequest } from '@tests/helpers/maintenance-request';
 import { eq } from 'drizzle-orm';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const CLEANUP_URL = 'http://localhost/api/internal/maintenance/plans/cleanup';
 const WORKER_TOKEN = 'maintenance-secret';
 
+type PlanCleanupResponseBody = {
+  ok: boolean;
+  stuckPlansCleaned: number;
+  orphanedAttemptsCleaned: number;
+};
+
 function createCleanupRequest(
   init: RequestInit & { token?: string; useBearer?: boolean } = {},
 ): Request {
-  const { token, useBearer = true, ...requestInit } = init;
-  const headers = new Headers(requestInit.headers);
+  return createMaintenancePostRequest(CLEANUP_URL, init);
+}
 
-  if (token) {
-    if (useBearer) {
-      headers.set('Authorization', `Bearer ${token}`);
-    } else {
-      headers.set('x-maintenance-worker-token', token);
-    }
-  }
-
-  return new Request(CLEANUP_URL, {
-    method: 'POST',
-    ...requestInit,
-    headers,
-  });
+async function expectPlanCleanupOk(
+  response: Response,
+): Promise<PlanCleanupResponseBody> {
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as PlanCleanupResponseBody;
+  expect(body.ok).toBe(true);
+  expect(body.stuckPlansCleaned).toEqual(expect.any(Number));
+  expect(body.orphanedAttemptsCleaned).toEqual(expect.any(Number));
+  return body;
 }
 
 describe('POST /api/internal/maintenance/plans/cleanup', () => {
@@ -77,15 +80,7 @@ describe('POST /api/internal/maintenance/plans/cleanup', () => {
       createCleanupRequest({ token: WORKER_TOKEN }),
     );
 
-    expect(response.status).toBe(200);
-    const body = (await response.json()) as {
-      ok: boolean;
-      stuckPlansCleaned: number;
-      orphanedAttemptsCleaned: number;
-    };
-    expect(body.ok).toBe(true);
-    expect(body.stuckPlansCleaned).toEqual(expect.any(Number));
-    expect(body.orphanedAttemptsCleaned).toEqual(expect.any(Number));
+    await expectPlanCleanupOk(response);
   });
 
   it('returns 200 with ok:true when authenticated via x-maintenance-worker-token', async () => {
@@ -170,13 +165,7 @@ describe('POST /api/internal/maintenance/plans/cleanup', () => {
 
     const response = await POST_PLAN_CLEANUP(createCleanupRequest());
 
-    expect(response.status).toBe(200);
-    const body = (await response.json()) as {
-      ok: boolean;
-      stuckPlansCleaned: number;
-      orphanedAttemptsCleaned: number;
-    };
-    expect(body.ok).toBe(true);
+    const body = await expectPlanCleanupOk(response);
     expect(body.stuckPlansCleaned).toBeGreaterThanOrEqual(1);
     expect(body.orphanedAttemptsCleaned).toBeGreaterThanOrEqual(1);
 

--- a/tests/integration/api/retention-cleanup-process.spec.ts
+++ b/tests/integration/api/retention-cleanup-process.spec.ts
@@ -1,14 +1,16 @@
 import { POST as POST_RETENTION_CLEANUP } from '@/app/api/internal/maintenance/retention/cleanup/route';
-import {
-  jobQueue,
-  oauthStateTokens,
-  stripeWebhookEvents,
-} from '@supabase/schema';
+import { oauthStateTokens, stripeWebhookEvents } from '@supabase/schema';
 import { db } from '@supabase/service-role';
-import { seedRetentionCleanupRows } from '@tests/helpers/db/retention-fixtures';
-import { and, eq, inArray } from 'drizzle-orm';
+import {
+  seedRetentionCleanupRows,
+  selectRetentionJobRows,
+} from '@tests/helpers/db/retention-fixtures';
+import { createMaintenancePostRequest } from '@tests/helpers/maintenance-request';
+import { inArray } from 'drizzle-orm';
 import { afterEach, describe, expect, it } from 'vitest';
 
+const CLEANUP_URL =
+  'http://localhost/api/internal/maintenance/retention/cleanup';
 const ORIGINAL_ENV = {
   MAINTENANCE_WORKER_TOKEN: process.env.MAINTENANCE_WORKER_TOKEN,
   RETENTION_CLEANUP_ENABLED: process.env.RETENTION_CLEANUP_ENABLED,
@@ -36,10 +38,7 @@ describe('POST /api/internal/maintenance/retention/cleanup', () => {
     process.env.RETENTION_CLEANUP_ENABLED = 'false';
 
     const response = await POST_RETENTION_CLEANUP(
-      new Request(
-        'http://localhost/api/internal/maintenance/retention/cleanup',
-        { method: 'POST' },
-      ),
+      createMaintenancePostRequest(CLEANUP_URL),
     );
 
     expect(response.status).toBe(503);
@@ -50,10 +49,7 @@ describe('POST /api/internal/maintenance/retention/cleanup', () => {
     process.env.RETENTION_CLEANUP_ENABLED = 'true';
 
     const response = await POST_RETENTION_CLEANUP(
-      new Request(
-        'http://localhost/api/internal/maintenance/retention/cleanup',
-        { method: 'POST' },
-      ),
+      createMaintenancePostRequest(CLEANUP_URL),
     );
 
     expect(response.status).toBe(401);
@@ -70,10 +66,7 @@ describe('POST /api/internal/maintenance/retention/cleanup', () => {
     });
 
     const response = await POST_RETENTION_CLEANUP(
-      new Request(
-        'http://localhost/api/internal/maintenance/retention/cleanup',
-        { method: 'POST' },
-      ),
+      createMaintenancePostRequest(CLEANUP_URL),
     );
 
     expect(response.status).toBe(200);
@@ -112,15 +105,7 @@ describe('POST /api/internal/maintenance/retention/cleanup', () => {
       { eventId: fixture.stripe.recentEventId },
     ]);
 
-    const remainingJobs = await db
-      .select({ id: jobQueue.id, status: jobQueue.status })
-      .from(jobQueue)
-      .where(
-        and(
-          eq(jobQueue.userId, fixture.userId),
-          inArray(jobQueue.id, fixture.jobRowIds),
-        ),
-      );
+    const remainingJobs = await selectRetentionJobRows(fixture);
     expect(remainingJobs).toEqual(
       expect.arrayContaining([expect.objectContaining({ status: 'pending' })]),
     );

--- a/tests/integration/db/retention-cleanup-function.spec.ts
+++ b/tests/integration/db/retention-cleanup-function.spec.ts
@@ -1,7 +1,9 @@
-import { jobQueue } from '@supabase/schema';
 import { db } from '@supabase/service-role';
-import { seedRetentionCleanupRows } from '@tests/helpers/db/retention-fixtures';
-import { sql, and, eq, inArray } from 'drizzle-orm';
+import {
+  seedRetentionCleanupRows,
+  selectRetentionJobRows,
+} from '@tests/helpers/db/retention-fixtures';
+import { sql } from 'drizzle-orm';
 import { describe, expect, it } from 'vitest';
 
 describe('private.cleanup_retained_db_rows', () => {
@@ -58,15 +60,7 @@ describe('private.cleanup_retained_db_rows', () => {
       },
     ]);
 
-    const remainingJobs = await db
-      .select({ id: jobQueue.id, status: jobQueue.status })
-      .from(jobQueue)
-      .where(
-        and(
-          eq(jobQueue.userId, fixture.userId),
-          inArray(jobQueue.id, fixture.jobRowIds),
-        ),
-      );
+    const remainingJobs = await selectRetentionJobRows(fixture);
     expect(remainingJobs).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ status: 'completed' }),

--- a/tests/unit/app/settings/billing/BillingCards.spec.tsx
+++ b/tests/unit/app/settings/billing/BillingCards.spec.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getBillingAccountSnapshotMock: vi.fn(),
+  manageSubscriptionButtonMock: vi.fn(),
+  redirectMock: vi.fn(),
+  requestBoundaryComponentMock: vi.fn(),
+}));
+
+vi.mock('@/features/billing/account-snapshot', () => ({
+  getBillingAccountSnapshot: mocks.getBillingAccountSnapshotMock,
+}));
+
+vi.mock('@/lib/api/request-boundary', () => ({
+  requestBoundary: {
+    component: mocks.requestBoundaryComponentMock,
+  },
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: mocks.redirectMock,
+}));
+
+vi.mock(
+  '@/app/(app)/settings/billing/components/ManageSubscriptionButton',
+  () => ({
+    default: (props: { canOpenBillingPortal: boolean }) => {
+      mocks.manageSubscriptionButtonMock(props);
+      return <button type='button'>Manage Subscription</button>;
+    },
+  }),
+);
+
+async function renderBillingCards(): Promise<void> {
+  const { BillingCards } =
+    await import('@/app/(app)/settings/billing/components/BillingCards');
+
+  render(await BillingCards({ locale: 'en-US' }));
+}
+
+describe('BillingCards', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.requestBoundaryComponentMock.mockImplementation(async (resolver) =>
+      resolver({
+        actor: { id: 'user_billing_cards' },
+        db: {} as never,
+      }),
+    );
+    mocks.getBillingAccountSnapshotMock.mockResolvedValue({
+      tier: 'pro',
+      subscriptionStatus: 'active',
+      subscriptionPeriodEnd: new Date('2026-07-01T00:00:00.000Z'),
+      cancelAtPeriodEnd: false,
+      stripeCustomerId: 'cus_test',
+      stripeSubscriptionId: 'sub_test',
+      canOpenBillingPortal: true,
+      usage: {
+        tier: 'pro',
+        activePlans: { current: 2, limit: 5 },
+        regenerations: { used: 3, limit: 10 },
+        exports: { used: 1, limit: 8 },
+        lessonGenerations: { used: 4, limit: 20 },
+      },
+    });
+  });
+
+  it('renders each usage meter with explicit labels and limits', async () => {
+    await renderBillingCards();
+
+    expect(mocks.getBillingAccountSnapshotMock).toHaveBeenCalledWith({
+      userId: 'user_billing_cards',
+      dbClient: {},
+    });
+    expect(mocks.manageSubscriptionButtonMock).toHaveBeenCalledWith(
+      expect.objectContaining({ canOpenBillingPortal: true }),
+    );
+    expect(screen.getByText('PRO')).toBeVisible();
+    expect(screen.getByText('Active plans')).toBeVisible();
+    expect(screen.getByText('Regenerations (monthly)')).toBeVisible();
+    expect(screen.getByText('Exports (monthly)')).toBeVisible();
+    expect(screen.getByText('Lesson generations (monthly)')).toBeVisible();
+    expect(screen.getByText('2/5')).toBeVisible();
+    expect(screen.getByText('3/10')).toBeVisible();
+    expect(screen.getByText('1/8')).toBeVisible();
+    expect(screen.getByText('4/20')).toBeVisible();
+    expect(screen.getByLabelText('Active plans: 2 of 5')).toBeVisible();
+    expect(
+      screen.getByLabelText('Monthly regenerations: 3 of 10'),
+    ).toBeVisible();
+    expect(screen.getByLabelText('Monthly exports: 1 of 8')).toBeVisible();
+    expect(
+      screen.getByLabelText('Monthly lesson generations: 4 of 20'),
+    ).toBeVisible();
+  });
+});

--- a/tests/unit/features/billing/stripe-commerce/subscription-db-sync.spec.ts
+++ b/tests/unit/features/billing/stripe-commerce/subscription-db-sync.spec.ts
@@ -1,0 +1,116 @@
+import type { StripeSubscriptionForSync } from '@/features/billing/stripe-commerce/subscription-db-sync';
+
+import { syncSubscriptionToDb } from '@/features/billing/stripe-commerce/subscription-db-sync';
+import { users } from '@supabase/schema';
+import { makeDbClient } from '@tests/fixtures/db-mocks';
+import { createId } from '@tests/fixtures/ids';
+import { makeStripeMock } from '@tests/fixtures/stripe-mocks';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+function makeSubscription(
+  overrides: Partial<StripeSubscriptionForSync> = {},
+): StripeSubscriptionForSync {
+  return {
+    id: createId('sub'),
+    customer: createId('cus'),
+    status: 'active',
+    cancel_at_period_end: false,
+    current_period_end: 1_735_689_600,
+    items: { data: [] },
+    ...overrides,
+  };
+}
+
+function buildDb(selectRows: Array<{ id: string; subscriptionTier: string }>) {
+  const limit = vi.fn().mockResolvedValue(selectRows);
+  const whereSelect = vi.fn().mockReturnValue({ limit });
+  const from = vi.fn().mockReturnValue({ where: whereSelect });
+  const select = vi.fn().mockReturnValue({ from });
+
+  const whereUpdate = vi.fn().mockResolvedValue(undefined);
+  const set = vi.fn().mockReturnValue({ where: whereUpdate });
+  const update = vi.fn().mockReturnValue({ set });
+
+  return {
+    db: makeDbClient({ select, update }),
+    spies: { select, from, whereSelect, limit, update, set, whereUpdate },
+  };
+}
+
+describe('syncSubscriptionToDb', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('syncs the tier from the injected Stripe price metadata', async () => {
+    const userId = createId('user');
+    const priceId = createId('price');
+    const { db, spies } = buildDb([{ id: userId, subscriptionTier: 'free' }]);
+    const retrieve = vi.fn().mockResolvedValue({
+      product: { metadata: { tier: 'pro' } },
+    });
+    const stripe = makeStripeMock({ prices: { retrieve } });
+
+    await syncSubscriptionToDb(
+      makeSubscription({
+        id: 'sub_active',
+        customer: 'cus_active',
+        items: { data: [{ price: priceId }] },
+        current_period_end: 1_735_689_600,
+      }),
+      { dbClient: db, stripe, timeoutMs: 2_500 },
+    );
+
+    expect(retrieve).toHaveBeenCalledWith(
+      priceId,
+      { expand: ['product'] },
+      { timeout: 2_500 },
+    );
+    expect(spies.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subscriptionTier: 'pro',
+        stripeSubscriptionId: 'sub_active',
+        subscriptionStatus: 'active',
+        subscriptionPeriodEnd: new Date('2025-01-01T00:00:00.000Z'),
+        cancelAtPeriodEnd: false,
+      }),
+    );
+    expect(spies.update).toHaveBeenCalledWith(users);
+  });
+
+  it('keeps the existing paid tier when the subscription has no price item', async () => {
+    const { db, spies } = buildDb([
+      { id: createId('user'), subscriptionTier: 'starter' },
+    ]);
+    const stripe = makeStripeMock({});
+
+    await syncSubscriptionToDb(makeSubscription(), { dbClient: db, stripe });
+
+    expect(stripe.prices.retrieve).not.toHaveBeenCalled();
+    expect(spies.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subscriptionTier: 'starter',
+      }),
+    );
+  });
+
+  it('throws without updating when Stripe cannot resolve the price tier', async () => {
+    const { db, spies } = buildDb([
+      { id: createId('user'), subscriptionTier: 'free' },
+    ]);
+    const retrieve = vi.fn().mockRejectedValue(new Error('stripe unavailable'));
+    const stripe = makeStripeMock({ prices: { retrieve } });
+
+    await expect(
+      syncSubscriptionToDb(
+        makeSubscription({ items: { data: [{ price: 'price_missing' }] } }),
+        { dbClient: db, stripe },
+      ),
+    ).rejects.toThrow(
+      'Unable to determine subscription tier for Stripe price price_missing',
+    );
+
+    expect(spies.update).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Resolves Linear JCS-23 deferred Fallow cleanup items 1-6 across billing sync, AI usage/parser code, billing settings UI, and maintenance cleanup routes/tests.
- Adds focused unit coverage for `syncSubscriptionToDb` with injected Stripe/db boundaries and `BillingCards` usage-meter rendering.
- Extracts small shared helpers for tier resolution, usage cost derivation, generation parsing, maintenance route wiring, and maintenance request/test fixtures.

## Validation
- `SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit tests/unit/ai/usage.spec.ts tests/unit/ai/parser.spec.ts tests/unit/ai/parser/validation.spec.ts tests/unit/features/billing/stripe-commerce/subscription-db-sync.spec.ts tests/unit/app/settings/billing/BillingCards.spec.tsx`
- `NODE_ENV=test pnpm vitest run --config vitest.config.ts --project integration tests/integration/api/plan-cleanup-process.spec.ts tests/integration/api/retention-cleanup-process.spec.ts tests/integration/db/retention-cleanup-function.spec.ts`
- `npx -y react-doctor@latest . --verbose --scope changed --base origin/develop`
- `npx --yes fallow health --format json --quiet --explain --complexity --changed-since origin/develop` - 0 findings, 0 functions above threshold
- `npx --yes fallow dupes --format json --quiet --changed-since origin/develop` - 0 clone groups
- `pnpm test`
- `pnpm check:full`
- Push hook reran `pnpm check:full`

Linear: JCS-23
Refs #356

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly structural refactors and test helpers; subscription sync logic is extracted, not rewritten, with new unit tests locking behavior. Maintenance routes share one factory but preserve the same auth and enablement checks.
> 
> **Overview**
> Refactors deferred cleanup work across billing, AI, maintenance routes, and tests without changing outward behavior.
> 
> **Billing settings** — `BillingCards` replaces four duplicated usage-meter blocks with a shared `UsageMeterRow` component (labels, compact limits, progress `aria-label` unchanged).
> 
> **Stripe subscription sync** — Tier resolution from Stripe price/product metadata moves into `resolveTierFromPrice`; `syncSubscriptionToDb` calls it. New unit tests cover metadata tier sync, keeping the existing tier when there is no price item, and failing without a DB update when Stripe lookup fails.
> 
> **AI** — `parseGenerationStream` splits into `readRawGenerationResponse`, `parseRawGenerationResponse`, and `toParsedModules`. `normalizeToCanonicalUsage` delegates to `collectMissingFields`, `computeEstimatedCostCents`, and `resolveProviderCostMicrousd` (partial usage still skips cost computation).
> 
> **Internal maintenance** — New `createMaintenancePostRoute` centralizes rate limiting, worker auth, error boundary, and optional Sentry monitors; plan and retention cleanup routes adopt it. Tests use `createMaintenancePostRequest`, `selectRetentionJobRows`, and shared assertion helpers.
> 
> **Tests** — Adds `BillingCards` unit coverage for usage meters and `subscription-db-sync` unit coverage for tier resolution paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d2e3c67c91ba34b41cf224d9f567f44e055e885. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->