### PR TITLE
feat(analytics): add completion usage dashboard

### DIFF
--- a/src/app/(app)/analytics/usage/page.tsx
+++ b/src/app/(app)/analytics/usage/page.tsx
@@ -14,7 +14,6 @@ import { ROUTES } from '@/features/navigation/routes';
 import { formatMinutes } from '@/features/plans/formatters';
 import { listUsageAnalyticsPlanSummaries } from '@/features/plans/read-projection/service';
 import { requestBoundary } from '@/lib/api/request-boundary';
-import { cn } from '@/lib/utils';
 import {
   BarChart3,
   BookOpenCheck,
@@ -69,7 +68,7 @@ function UsageAnalyticsView({ model }: { model: UsageAnalyticsModel }) {
         subtitle='Current completion progress and estimated completed learning time from your plans.'
       />
 
-      {!model.hasPlans ? (
+      {model.planCount === 0 ? (
         <div className='space-y-6'>
           <NoPlansState />
           <HistoricalPlaceholder />
@@ -117,7 +116,7 @@ function AnalyticsContent({ model }: { model: UsageAnalyticsModel }) {
         {ESTIMATED_TIME_HELPER}
       </p>
 
-      {!model.hasCompletedWork ? <NoCompletedWorkState /> : null}
+      {model.completedTasks === 0 ? <NoCompletedWorkState /> : null}
 
       <PlanCompletionSection plans={model.plans} />
 
@@ -244,19 +243,10 @@ function Metric({ label, value }: { label: string; value: string }) {
   );
 }
 
-function ProgressBar({
-  value,
-  className,
-}: {
-  value: number;
-  className?: string;
-}) {
+function ProgressBar({ value }: { value: number }) {
   return (
     <div
-      className={cn(
-        'h-2 w-full overflow-hidden rounded-full bg-muted',
-        className,
-      )}
+      className='h-2 w-full overflow-hidden rounded-full bg-muted'
       aria-hidden='true'
     >
       <div

--- a/src/app/(app)/analytics/usage/page.tsx
+++ b/src/app/(app)/analytics/usage/page.tsx
@@ -1,101 +1,268 @@
 import type { Metadata } from 'next';
 
-import { ComingSoonAlert } from '@/components/shared/ComingSoonAlert';
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
+  buildUsageAnalyticsModel,
+  type UsageAnalyticsModel,
+  type UsageAnalyticsPlanRow,
+} from './usage-analytics-model';
+import { Button } from '@/components/ui/button';
+import { MetricCard } from '@/components/ui/metric-card';
 import { PageHeader } from '@/components/ui/page-header';
-import { BarChart3, Clock, Flame, Target } from 'lucide-react';
+import { RouteEmptyState } from '@/components/ui/route-empty-state';
+import { Surface } from '@/components/ui/surface';
+import { ROUTES } from '@/features/navigation/routes';
+import { formatMinutes } from '@/features/plans/formatters';
+import { listUsageAnalyticsPlanSummaries } from '@/features/plans/read-projection/service';
+import { requestBoundary } from '@/lib/api/request-boundary';
+import { cn } from '@/lib/utils';
+import {
+  BarChart3,
+  BookOpenCheck,
+  Clock,
+  ListChecks,
+  Plus,
+} from 'lucide-react';
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
 
 export const metadata: Metadata = {
   title: 'Usage Analytics | Atlaris',
   description:
-    'Review study time, completion rates, streaks, and weekly learning summaries.',
+    'Review current completion progress and estimated completed learning time across your plans.',
   openGraph: {
     title: 'Usage Analytics | Atlaris',
     description:
-      'Review study time, completion rates, streaks, and weekly learning summaries.',
+      'Review current completion progress and estimated completed learning time across your plans.',
     url: '/analytics/usage',
     images: ['/og-default.jpg'],
   },
 };
 
-const iconClass = 'text-primary size-8 shrink-0';
+const SIGN_IN_RETURN_PATH = `${ROUTES.AUTH.SIGN_IN}?redirect_url=${encodeURIComponent(ROUTES.ANALYTICS.USAGE)}`;
+const ESTIMATED_TIME_HELPER =
+  'Based on estimates for tasks currently marked complete. This is not recorded study time.';
+const HISTORICAL_PLACEHOLDER =
+  'Streaks and weekly summaries start after activity tracking launches.';
 
-const PREVIEW_CARDS = [
-  {
-    icon: <Clock className={iconClass} aria-hidden />,
-    title: 'Study time',
-    description:
-      'Weekly totals and daily averages drawn from your lesson and module activity.',
-  },
-  {
-    icon: <Target className={iconClass} aria-hidden />,
-    title: 'Completion rates',
-    description:
-      'See task and module completion across each plan, with trends over time.',
-  },
-  {
-    icon: <Flame className={iconClass} aria-hidden />,
-    title: 'Learning streaks',
-    description:
-      'Track consecutive study days and spot gaps before they break your rhythm.',
-  },
-  {
-    icon: <BarChart3 className={iconClass} aria-hidden />,
-    title: 'Weekly summary',
-    description:
-      'A single report with time spent, modules finished, and suggested next steps.',
-  },
-];
+export default async function UsageAnalyticsPage() {
+  const result = await requestBoundary.component(async ({ actor, db }) => {
+    const summaries = await listUsageAnalyticsPlanSummaries({
+      userId: actor.id,
+      dbClient: db,
+    });
 
-export default function UsageAnalyticsPage() {
+    return buildUsageAnalyticsModel(summaries);
+  });
+
+  if (!result) {
+    redirect(SIGN_IN_RETURN_PATH);
+  }
+
+  return <UsageAnalyticsView model={result} />;
+}
+
+function UsageAnalyticsView({ model }: { model: UsageAnalyticsModel }) {
   return (
     <>
       <PageHeader
         title='Usage'
-        subtitle='Metrics from your plans, modules, and study sessions'
+        subtitle='Current completion progress and estimated completed learning time from your plans.'
       />
 
-      <ComingSoonAlert
-        title='Usage analytics preview'
-        description='Live charts stay hidden until plan activity is connected, so this page only shows what will unlock.'
-        className='mb-6'
-      />
-
-      <Card className='max-w-3xl'>
-        <CardHeader>
-          <CardTitle as='h3'>Progress signals coming here</CardTitle>
-          <CardDescription>
-            Unlocks when study sessions and module activity start feeding the
-            analytics pipeline.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <ul className='grid gap-4 sm:grid-cols-2'>
-            {PREVIEW_CARDS.map((card) => (
-              <li key={card.title} className='flex gap-3'>
-                <span
-                  className='flex size-10 shrink-0 items-center justify-center rounded-md bg-muted'
-                  aria-hidden='true'
-                >
-                  {card.icon}
-                </span>
-                <div className='min-w-0'>
-                  <h3 className='font-medium text-foreground'>{card.title}</h3>
-                  <p className='mt-1 text-sm text-muted-foreground'>
-                    {card.description}
-                  </p>
-                </div>
-              </li>
-            ))}
-          </ul>
-        </CardContent>
-      </Card>
+      {!model.hasPlans ? (
+        <div className='space-y-6'>
+          <NoPlansState />
+          <HistoricalPlaceholder />
+        </div>
+      ) : (
+        <AnalyticsContent model={model} />
+      )}
     </>
+  );
+}
+
+function AnalyticsContent({ model }: { model: UsageAnalyticsModel }) {
+  return (
+    <div className='space-y-6'>
+      <section
+        aria-label='Usage analytics summary'
+        className='grid gap-4 sm:grid-cols-2 xl:grid-cols-4'
+      >
+        <MetricCard
+          icon={<ListChecks aria-hidden />}
+          label='Tasks complete'
+          value={`${model.completedTasks}/${model.totalTasks}`}
+          sublabel={`${model.taskCompletionPercent}% complete`}
+        />
+        <MetricCard
+          icon={<BookOpenCheck aria-hidden />}
+          label='Modules complete'
+          value={`${model.completedModules}/${model.totalModules}`}
+          sublabel={`${model.moduleCompletionPercent}% complete`}
+        />
+        <MetricCard
+          icon={<Clock aria-hidden />}
+          label='Estimated completed learning time'
+          value={formatMinutes(model.completedMinutes)}
+          sublabel='From completed task estimates'
+        />
+        <MetricCard
+          icon={<BarChart3 aria-hidden />}
+          label='Total estimated plan time'
+          value={formatMinutes(model.totalMinutes)}
+          sublabel={`${model.planCount} ${model.planCount === 1 ? 'plan' : 'plans'}`}
+        />
+      </section>
+      <p className='text-sm leading-6 text-muted-foreground'>
+        {ESTIMATED_TIME_HELPER}
+      </p>
+
+      {!model.hasCompletedWork ? <NoCompletedWorkState /> : null}
+
+      <PlanCompletionSection plans={model.plans} />
+
+      <HistoricalPlaceholder />
+    </div>
+  );
+}
+
+function HistoricalPlaceholder() {
+  return (
+    <Surface variant='muted'>
+      <div className='space-y-2'>
+        <h2 className='text-lg font-semibold text-foreground'>
+          Historical analytics
+        </h2>
+        <p className='text-sm leading-6 text-muted-foreground'>
+          {HISTORICAL_PLACEHOLDER}
+        </p>
+      </div>
+    </Surface>
+  );
+}
+
+function NoPlansState() {
+  return (
+    <RouteEmptyState
+      icon={BarChart3}
+      title='No usage data yet'
+      description='Create a learning plan to start seeing current completion progress and estimated completed learning time.'
+      action={
+        <Button asChild>
+          <Link href={ROUTES.PLANS.NEW}>
+            <Plus aria-hidden />
+            Create plan
+          </Link>
+        </Button>
+      }
+    />
+  );
+}
+
+function NoCompletedWorkState() {
+  return (
+    <Surface variant='inset'>
+      <div className='space-y-2'>
+        <h2 className='text-base font-semibold text-foreground'>
+          No completed work yet
+        </h2>
+        <p className='text-sm leading-6 text-muted-foreground'>
+          Estimated completed learning time appears after tasks are marked
+          complete.
+        </p>
+      </div>
+    </Surface>
+  );
+}
+
+function PlanCompletionSection({ plans }: { plans: UsageAnalyticsPlanRow[] }) {
+  return (
+    <Surface>
+      <div className='mb-5 space-y-2'>
+        <h2 className='text-lg font-semibold text-foreground'>
+          Plan completion
+        </h2>
+        <p className='text-sm leading-6 text-muted-foreground'>
+          Current task and module completion from your learning plans.
+        </p>
+      </div>
+
+      <div className='divide-y divide-border'>
+        {plans.map((plan) => (
+          <PlanCompletionRow key={plan.id} plan={plan} />
+        ))}
+      </div>
+    </Surface>
+  );
+}
+
+function PlanCompletionRow({ plan }: { plan: UsageAnalyticsPlanRow }) {
+  return (
+    <article className='grid gap-4 py-5 first:pt-0 last:pb-0 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,24rem)] lg:items-center'>
+      <div className='min-w-0 space-y-3'>
+        <div className='flex flex-wrap items-start justify-between gap-3'>
+          <h3 className='min-w-0 text-base font-semibold text-foreground'>
+            {plan.topic}
+          </h3>
+          <span className='shrink-0 text-sm font-medium text-foreground tabular-nums'>
+            {plan.taskCompletionPercent}% complete
+          </span>
+        </div>
+        <ProgressBar value={plan.taskCompletionPercent} />
+      </div>
+
+      <dl className='grid grid-cols-2 gap-3 text-sm sm:grid-cols-4 lg:grid-cols-2'>
+        <Metric
+          label='Tasks'
+          value={`${plan.completedTasks}/${plan.totalTasks}`}
+        />
+        <Metric
+          label='Modules'
+          value={`${plan.completedModules}/${plan.totalModules}`}
+        />
+        <Metric
+          label='Estimated complete'
+          value={formatMinutes(plan.completedMinutes)}
+        />
+        <Metric
+          label='Plan estimate'
+          value={formatMinutes(plan.totalMinutes)}
+        />
+      </dl>
+    </article>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className='text-xs font-medium text-muted-foreground uppercase'>
+        {label}
+      </dt>
+      <dd className='mt-1 font-medium text-foreground tabular-nums'>{value}</dd>
+    </div>
+  );
+}
+
+function ProgressBar({
+  value,
+  className,
+}: {
+  value: number;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        'h-2 w-full overflow-hidden rounded-full bg-muted',
+        className,
+      )}
+      aria-hidden='true'
+    >
+      <div
+        className='h-full rounded-full bg-primary'
+        style={{ width: `${Math.min(100, Math.max(0, value))}%` }}
+      />
+    </div>
   );
 }

--- a/src/app/(app)/analytics/usage/usage-analytics-model.ts
+++ b/src/app/(app)/analytics/usage/usage-analytics-model.ts
@@ -26,7 +26,8 @@ export type UsageAnalyticsModel = {
 };
 
 function completionPercent(completed: number, total: number): number {
-  return total > 0 ? Math.round((completed / total) * 100) : 0;
+  if (total <= 0) return 0;
+  return completed >= total ? 100 : Math.floor((completed / total) * 100);
 }
 
 export function buildUsageAnalyticsModel(

--- a/src/app/(app)/analytics/usage/usage-analytics-model.ts
+++ b/src/app/(app)/analytics/usage/usage-analytics-model.ts
@@ -1,0 +1,97 @@
+import type { LightweightPlanSummary } from '@/shared/types/db.types';
+
+export type UsageAnalyticsPlanRow = {
+  id: string;
+  topic: string;
+  completedTasks: number;
+  totalTasks: number;
+  taskCompletionPercent: number;
+  completedModules: number;
+  totalModules: number;
+  moduleCompletionPercent: number;
+  completedMinutes: number;
+  totalMinutes: number;
+};
+
+export type UsageAnalyticsModel = {
+  plans: UsageAnalyticsPlanRow[];
+  planCount: number;
+  completedTasks: number;
+  totalTasks: number;
+  taskCompletionPercent: number;
+  completedModules: number;
+  totalModules: number;
+  moduleCompletionPercent: number;
+  completedMinutes: number;
+  totalMinutes: number;
+  hasPlans: boolean;
+  hasCompletedWork: boolean;
+};
+
+function completionPercent(completed: number, total: number): number {
+  return total > 0 ? Math.round((completed / total) * 100) : 0;
+}
+
+export function buildUsageAnalyticsModel(
+  summaries: LightweightPlanSummary[],
+): UsageAnalyticsModel {
+  const plans = summaries.map((summary) => ({
+    id: summary.id,
+    topic: summary.topic,
+    completedTasks: summary.completedTasks,
+    totalTasks: summary.totalTasks,
+    taskCompletionPercent: completionPercent(
+      summary.completedTasks,
+      summary.totalTasks,
+    ),
+    completedModules: summary.completedModules,
+    totalModules: summary.moduleCount,
+    moduleCompletionPercent: completionPercent(
+      summary.completedModules,
+      summary.moduleCount,
+    ),
+    completedMinutes: summary.completedMinutes,
+    totalMinutes: summary.totalMinutes,
+  }));
+
+  const totals = plans.reduce(
+    (acc, plan) => {
+      acc.completedTasks += plan.completedTasks;
+      acc.totalTasks += plan.totalTasks;
+      acc.completedModules += plan.completedModules;
+      acc.totalModules += plan.totalModules;
+      acc.completedMinutes += plan.completedMinutes;
+      acc.totalMinutes += plan.totalMinutes;
+      return acc;
+    },
+    {
+      completedTasks: 0,
+      totalTasks: 0,
+      completedModules: 0,
+      totalModules: 0,
+      completedMinutes: 0,
+      totalMinutes: 0,
+    },
+  );
+
+  return {
+    plans,
+    planCount: plans.length,
+    completedTasks: totals.completedTasks,
+    totalTasks: totals.totalTasks,
+    taskCompletionPercent: completionPercent(
+      totals.completedTasks,
+      totals.totalTasks,
+    ),
+    completedModules: totals.completedModules,
+    totalModules: totals.totalModules,
+    moduleCompletionPercent: completionPercent(
+      totals.completedModules,
+      totals.totalModules,
+    ),
+    completedMinutes: totals.completedMinutes,
+    totalMinutes: totals.totalMinutes,
+    hasPlans: plans.length > 0,
+    hasCompletedWork: totals.completedTasks > 0,
+  };
+}

--- a/src/app/(app)/analytics/usage/usage-analytics-model.ts
+++ b/src/app/(app)/analytics/usage/usage-analytics-model.ts
@@ -8,7 +8,6 @@ export type UsageAnalyticsPlanRow = {
   taskCompletionPercent: number;
   completedModules: number;
   totalModules: number;
-  moduleCompletionPercent: number;
   completedMinutes: number;
   totalMinutes: number;
 };
@@ -24,8 +23,6 @@ export type UsageAnalyticsModel = {
   moduleCompletionPercent: number;
   completedMinutes: number;
   totalMinutes: number;
-  hasPlans: boolean;
-  hasCompletedWork: boolean;
 };
 
 function completionPercent(completed: number, total: number): number {
@@ -46,10 +43,6 @@ export function buildUsageAnalyticsModel(
     ),
     completedModules: summary.completedModules,
     totalModules: summary.moduleCount,
-    moduleCompletionPercent: completionPercent(
-      summary.completedModules,
-      summary.moduleCount,
-    ),
     completedMinutes: summary.completedMinutes,
     totalMinutes: summary.totalMinutes,
   }));
@@ -91,7 +84,5 @@ export function buildUsageAnalyticsModel(
     ),
     completedMinutes: totals.completedMinutes,
     totalMinutes: totals.totalMinutes,
-    hasPlans: plans.length > 0,
-    hasCompletedWork: totals.completedTasks > 0,
   };
 }

--- a/src/features/plans/read-projection/service.ts
+++ b/src/features/plans/read-projection/service.ts
@@ -126,12 +126,7 @@ export async function listUsageAnalyticsPlanSummaries(params: {
   userId: string;
   dbClient?: PlanDbClient;
 }): Promise<LightweightPlanSummary[]> {
-  const rows = await getLightweightPlanSummaryRowsForUser(
-    params.userId,
-    params.dbClient,
-  );
-
-  return buildLightweightPlanSummaries(rows);
+  return listLightweightPlansForApi(params);
 }
 
 export async function getPlanListTotalCount(params: {

--- a/src/features/plans/read-projection/service.ts
+++ b/src/features/plans/read-projection/service.ts
@@ -122,6 +122,18 @@ export async function listLightweightPlansForApi(params: {
   return buildLightweightPlanSummaries(rows);
 }
 
+export async function listUsageAnalyticsPlanSummaries(params: {
+  userId: string;
+  dbClient?: PlanDbClient;
+}): Promise<LightweightPlanSummary[]> {
+  const rows = await getLightweightPlanSummaryRowsForUser(
+    params.userId,
+    params.dbClient,
+  );
+
+  return buildLightweightPlanSummaries(rows);
+}
+
 export async function getPlanListTotalCount(params: {
   userId: string;
   dbClient?: PlanDbClient;

--- a/tests/unit/app/analytics/usage-analytics-model.spec.ts
+++ b/tests/unit/app/analytics/usage-analytics-model.spec.ts
@@ -1,0 +1,181 @@
+import type { LightweightPlanSummary } from '@/shared/types/db.types';
+
+import {
+  buildUsageAnalyticsModel,
+  type UsageAnalyticsModel,
+} from '@/app/(app)/analytics/usage/usage-analytics-model';
+import { describe, expect, it } from 'vitest';
+
+function planSummary(
+  overrides: Partial<LightweightPlanSummary> &
+    Pick<LightweightPlanSummary, 'id'>,
+): LightweightPlanSummary {
+  const { id, ...rest } = overrides;
+
+  return {
+    id,
+    topic: 'Data structures',
+    skillLevel: 'beginner',
+    learningStyle: 'mixed',
+    visibility: 'private',
+    origin: 'ai',
+    generationStatus: 'ready',
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    completion: 0,
+    completedTasks: 0,
+    totalTasks: 0,
+    totalMinutes: 0,
+    completedMinutes: 0,
+    completedModules: 0,
+    moduleCount: 0,
+    ...rest,
+  };
+}
+
+function pickTotals(model: UsageAnalyticsModel) {
+  return {
+    planCount: model.planCount,
+    completedTasks: model.completedTasks,
+    totalTasks: model.totalTasks,
+    taskCompletionPercent: model.taskCompletionPercent,
+    completedModules: model.completedModules,
+    totalModules: model.totalModules,
+    moduleCompletionPercent: model.moduleCompletionPercent,
+    completedMinutes: model.completedMinutes,
+    totalMinutes: model.totalMinutes,
+    hasPlans: model.hasPlans,
+    hasCompletedWork: model.hasCompletedWork,
+  };
+}
+
+describe('buildUsageAnalyticsModel', () => {
+  it('returns zeroed analytics when no plans exist', () => {
+    const model = buildUsageAnalyticsModel([]);
+
+    expect(pickTotals(model)).toEqual({
+      planCount: 0,
+      completedTasks: 0,
+      totalTasks: 0,
+      taskCompletionPercent: 0,
+      completedModules: 0,
+      totalModules: 0,
+      moduleCompletionPercent: 0,
+      completedMinutes: 0,
+      totalMinutes: 0,
+      hasPlans: false,
+      hasCompletedWork: false,
+    });
+    expect(model.plans).toEqual([]);
+  });
+
+  it('keeps available plan scope when no tasks are completed', () => {
+    const model = buildUsageAnalyticsModel([
+      planSummary({
+        id: 'plan-1',
+        totalTasks: 5,
+        totalMinutes: 120,
+        moduleCount: 2,
+      }),
+    ]);
+
+    expect(pickTotals(model)).toMatchObject({
+      planCount: 1,
+      completedTasks: 0,
+      totalTasks: 5,
+      taskCompletionPercent: 0,
+      completedMinutes: 0,
+      totalMinutes: 120,
+      hasPlans: true,
+      hasCompletedWork: false,
+    });
+  });
+
+  it('aggregates partial progress across multiple plans', () => {
+    const model = buildUsageAnalyticsModel([
+      planSummary({
+        id: 'plan-1',
+        topic: 'React',
+        completedTasks: 2,
+        totalTasks: 5,
+        completedModules: 1,
+        moduleCount: 3,
+        completedMinutes: 40,
+        totalMinutes: 120,
+      }),
+      planSummary({
+        id: 'plan-2',
+        topic: 'SQL',
+        completedTasks: 3,
+        totalTasks: 5,
+        completedModules: 1,
+        moduleCount: 2,
+        completedMinutes: 60,
+        totalMinutes: 80,
+      }),
+    ]);
+
+    expect(pickTotals(model)).toMatchObject({
+      planCount: 2,
+      completedTasks: 5,
+      totalTasks: 10,
+      taskCompletionPercent: 50,
+      completedModules: 2,
+      totalModules: 5,
+      moduleCompletionPercent: 40,
+      completedMinutes: 100,
+      totalMinutes: 200,
+      hasCompletedWork: true,
+    });
+    expect(model.plans).toMatchObject([
+      {
+        topic: 'React',
+        taskCompletionPercent: 40,
+        moduleCompletionPercent: 33,
+      },
+      { topic: 'SQL', taskCompletionPercent: 60, moduleCompletionPercent: 50 },
+    ]);
+  });
+
+  it('counts completed plans and modules from current completion totals', () => {
+    const model = buildUsageAnalyticsModel([
+      planSummary({
+        id: 'plan-1',
+        completedTasks: 4,
+        totalTasks: 4,
+        completedModules: 2,
+        moduleCount: 2,
+        completedMinutes: 90,
+        totalMinutes: 90,
+      }),
+    ]);
+
+    expect(model.taskCompletionPercent).toBe(100);
+    expect(model.moduleCompletionPercent).toBe(100);
+    expect(model.plans[0]).toMatchObject({
+      completedTasks: 4,
+      totalTasks: 4,
+      taskCompletionPercent: 100,
+      completedModules: 2,
+      totalModules: 2,
+      moduleCompletionPercent: 100,
+    });
+  });
+
+  it('uses only currently completed task estimates for completed learning time', () => {
+    const model = buildUsageAnalyticsModel([
+      planSummary({
+        id: 'plan-1',
+        completedTasks: 1,
+        totalTasks: 4,
+        completedMinutes: 25,
+        totalMinutes: 140,
+      }),
+    ]);
+
+    expect(model.completedMinutes).toBe(25);
+    expect(model.totalMinutes).toBe(140);
+    expect(model.plans[0].completedMinutes).toBe(25);
+    expect(model.plans[0].totalMinutes).toBe(140);
+  });
+});

--- a/tests/unit/app/analytics/usage-analytics-model.spec.ts
+++ b/tests/unit/app/analytics/usage-analytics-model.spec.ts
@@ -44,8 +44,6 @@ function pickTotals(model: UsageAnalyticsModel) {
     moduleCompletionPercent: model.moduleCompletionPercent,
     completedMinutes: model.completedMinutes,
     totalMinutes: model.totalMinutes,
-    hasPlans: model.hasPlans,
-    hasCompletedWork: model.hasCompletedWork,
   };
 }
 
@@ -63,8 +61,6 @@ describe('buildUsageAnalyticsModel', () => {
       moduleCompletionPercent: 0,
       completedMinutes: 0,
       totalMinutes: 0,
-      hasPlans: false,
-      hasCompletedWork: false,
     });
     expect(model.plans).toEqual([]);
   });
@@ -86,8 +82,6 @@ describe('buildUsageAnalyticsModel', () => {
       taskCompletionPercent: 0,
       completedMinutes: 0,
       totalMinutes: 120,
-      hasPlans: true,
-      hasCompletedWork: false,
     });
   });
 
@@ -125,15 +119,10 @@ describe('buildUsageAnalyticsModel', () => {
       moduleCompletionPercent: 40,
       completedMinutes: 100,
       totalMinutes: 200,
-      hasCompletedWork: true,
     });
     expect(model.plans).toMatchObject([
-      {
-        topic: 'React',
-        taskCompletionPercent: 40,
-        moduleCompletionPercent: 33,
-      },
-      { topic: 'SQL', taskCompletionPercent: 60, moduleCompletionPercent: 50 },
+      { topic: 'React', taskCompletionPercent: 40 },
+      { topic: 'SQL', taskCompletionPercent: 60 },
     ]);
   });
 
@@ -158,7 +147,6 @@ describe('buildUsageAnalyticsModel', () => {
       taskCompletionPercent: 100,
       completedModules: 2,
       totalModules: 2,
-      moduleCompletionPercent: 100,
     });
   });
 

--- a/tests/unit/app/analytics/usage-analytics-model.spec.ts
+++ b/tests/unit/app/analytics/usage-analytics-model.spec.ts
@@ -150,6 +150,22 @@ describe('buildUsageAnalyticsModel', () => {
     });
   });
 
+  it('does not round incomplete progress up to complete', () => {
+    const model = buildUsageAnalyticsModel([
+      planSummary({
+        id: 'plan-1',
+        completedTasks: 199,
+        totalTasks: 200,
+        completedModules: 1,
+        moduleCount: 2,
+      }),
+    ]);
+
+    expect(model.taskCompletionPercent).toBe(99);
+    expect(model.moduleCompletionPercent).toBe(50);
+    expect(model.plans[0].taskCompletionPercent).toBe(99);
+  });
+
   it('uses only currently completed task estimates for completed learning time', () => {
     const model = buildUsageAnalyticsModel([
       planSummary({


### PR DESCRIPTION
## Summary
- replace the /analytics/usage placeholder with current-state completion analytics
- reuse existing lightweight plan completion projections through a usage page entrypoint
- label estimated completed learning time without claiming actual study time or history
- address review cleanup by trimming unused model/page plumbing

## Validation
- SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit tests/unit/app/analytics/usage-analytics-model.spec.ts
- npx -y react-doctor@latest . --verbose --scope changed
- pnpm test
- pnpm check:full

## Screenshots
Captured locally under gitignored screenshots/jcs-26-usage-analytics:
- desktop 1440x1000
- tablet 834x1112
- mobile 390x844

Closes #369

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only UI over existing user-scoped plan projections; no new write paths or auth logic beyond the standard server component boundary.
> 
> **Overview**
> Replaces the **Usage** analytics placeholder with a live dashboard driven by existing lightweight plan completion projections.
> 
> The page loads the signed-in user’s plan summaries via `listUsageAnalyticsPlanSummaries`, builds a `UsageAnalyticsModel` with `buildUsageAnalyticsModel`, and renders summary **metric cards** (tasks, modules, estimated completed vs total plan time), a **per-plan completion** list with progress bars, and copy that **estimated time is not recorded study time**. Empty states cover no plans and no completed tasks; a muted **historical analytics** section still defers streaks and weekly summaries until activity tracking exists. Unauthenticated visitors are redirected to sign-in with a return URL.
> 
> Adds a thin `listUsageAnalyticsPlanSummaries` entrypoint in the read-projection service and unit tests for aggregation and completion-percent behavior (including floor rounding).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d378dc1a82d72e8fb552e15de7aa9477f0b109f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->