### PR TITLE
feat(analytics): record learning activity history

### DIFF
--- a/docs/architecture/usage-analytics-metric-contract.md
+++ b/docs/architecture/usage-analytics-metric-contract.md
@@ -25,18 +25,21 @@ Use this wording for the MVP time metric:
 | `plan_completion` | Existing completion read projections over plan tasks | Current-state | `completedTasks / totalTasks`; plans with zero tasks have `0` completion. |
 | `estimated_completed_learning_time` | `tasks.estimated_minutes` for currently completed tasks | Current-state, estimated | Sum task estimates for tasks currently marked complete. This is not actual recorded study time. |
 | `actual_study_time` | Future append-only learning activity history | Historical, actual | Unavailable until explicit study-duration events or another accepted actual-time source exists. |
-| `streaks` | Future append-only learning activity history | Historical | Unavailable until progress-change activity events exist and date bucketing is defined. |
-| `weekly_summaries` | Future append-only learning activity history | Historical | Unavailable until post-launch activity events exist. |
-| `trends` | Future append-only learning activity history | Historical | Unavailable until post-launch activity events exist. |
+| `streaks` | `learning_activity_events` | Historical | Unavailable until JCS-28 defines date bucketing and reads recorded post-launch progress-change activity. |
+| `weekly_summaries` | `learning_activity_events` | Historical | Unavailable until JCS-28 reads recorded post-launch activity events. |
+| `trends` | `learning_activity_events` | Historical | Unavailable until JCS-28 reads recorded post-launch activity events. |
 
 ## Future Activity Semantics
 
-JCS-27 must create the durable activity source before JCS-28 exposes historical
-analytics.
+JCS-27 creates `learning_activity_events` as the durable activity source before
+JCS-28 exposes historical analytics.
 
 - A study day is any calendar day with at least one recorded task progress
   status change.
 - Activity history is forward-only from the activity-history launch date.
+- `learning_activity_events` records task progress status changes at the
+  database boundary. Rows are deleted if their user, plan, module, or task is
+  deleted.
 - Do not reconstruct complete pre-launch history from mutable current-state
   rows.
 - Streaks should support both global and per-plan views when implemented.
@@ -72,7 +75,7 @@ analytics.
 
 - JCS-26 may ship completion analytics and estimated completed learning time
   from existing current-state projections.
-- JCS-27 must add append-only learning activity history before any historical
-  analytics ship.
+- JCS-27 adds append-only learning activity history in
+  `learning_activity_events`; no historical analytics ship in that slice.
 - JCS-28 may build streaks, weekly summaries, and trends only from recorded
   activity history.

--- a/src/lib/db/queries/tasks.ts
+++ b/src/lib/db/queries/tasks.ts
@@ -79,9 +79,7 @@ async function setTaskProgress(
       tx,
       userId,
       eq(tasks.id, taskId),
-    )
-      .limit(1)
-      .for('update');
+    ).limit(1);
 
     if (!taskRow) {
       throw new Error('Task not found or access denied');
@@ -173,7 +171,7 @@ export async function setTaskProgressBatch(
       tx,
       userId,
       and(...scopeConditions)!,
-    ).for('update');
+    );
 
     const ownedIds = new Set(ownedTasks.map((row) => row.task.id));
     const missingIds = taskIds.filter((id) => !ownedIds.has(id));

--- a/src/lib/db/queries/types/tasks.types.ts
+++ b/src/lib/db/queries/types/tasks.types.ts
@@ -1,8 +1,15 @@
 import type { getDb } from '@supabase/runtime';
-import type { taskProgress, tasks } from '@supabase/schema';
+import type {
+  learningActivityEvents,
+  taskProgress,
+  tasks,
+} from '@supabase/schema';
 import type { InferSelectModel } from 'drizzle-orm';
 
 export type DbTask = InferSelectModel<typeof tasks>;
 export type DbTaskProgress = InferSelectModel<typeof taskProgress>;
+export type DbLearningActivityEvent = InferSelectModel<
+  typeof learningActivityEvents
+>;
 
 export type TasksDbClient = ReturnType<typeof getDb>;

--- a/supabase/migrations/0036_add_learning_activity_events.sql
+++ b/supabase/migrations/0036_add_learning_activity_events.sql
@@ -1,0 +1,92 @@
+CREATE TABLE "learning_activity_events" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"plan_id" uuid NOT NULL,
+	"module_id" uuid NOT NULL,
+	"task_id" uuid NOT NULL,
+	"previous_status" "progress_status",
+	"status" "progress_status" NOT NULL,
+	"task_estimated_minutes" integer NOT NULL,
+	"occurred_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "learning_activity_events_task_estimated_minutes_nonneg" CHECK ("learning_activity_events"."task_estimated_minutes" >= 0)
+);
+--> statement-breakpoint
+ALTER TABLE "learning_activity_events" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "learning_activity_events" ADD CONSTRAINT "learning_activity_events_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "learning_activity_events" ADD CONSTRAINT "learning_activity_events_plan_id_learning_plans_id_fk" FOREIGN KEY ("plan_id") REFERENCES "public"."learning_plans"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "learning_activity_events" ADD CONSTRAINT "learning_activity_events_module_id_modules_id_fk" FOREIGN KEY ("module_id") REFERENCES "public"."modules"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "learning_activity_events" ADD CONSTRAINT "learning_activity_events_task_id_tasks_id_fk" FOREIGN KEY ("task_id") REFERENCES "public"."tasks"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_learning_activity_events_user_occurred" ON "learning_activity_events" USING btree ("user_id","occurred_at");--> statement-breakpoint
+CREATE INDEX "idx_learning_activity_events_user_plan_occurred" ON "learning_activity_events" USING btree ("user_id","plan_id","occurred_at");--> statement-breakpoint
+CREATE INDEX "idx_learning_activity_events_task_occurred" ON "learning_activity_events" USING btree ("task_id","occurred_at");--> statement-breakpoint
+CREATE POLICY "learning_activity_events_select_own" ON "learning_activity_events" AS PERMISSIVE FOR SELECT TO "authenticated" USING (
+    "learning_activity_events"."user_id" IN (
+      SELECT id FROM "users" WHERE "users"."auth_user_id" = current_setting('request.jwt.claims', true)::json->>'sub'
+    )
+  );--> statement-breakpoint
+GRANT SELECT ON TABLE "learning_activity_events" TO authenticated;--> statement-breakpoint
+REVOKE INSERT, UPDATE, DELETE ON TABLE "learning_activity_events" FROM authenticated;--> statement-breakpoint
+CREATE SCHEMA IF NOT EXISTS "private";--> statement-breakpoint
+CREATE OR REPLACE FUNCTION "private"."record_learning_activity_event"()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = "public", pg_temp
+AS $$
+DECLARE
+  task_context record;
+BEGIN
+  IF TG_OP = 'UPDATE' AND OLD.status IS NOT DISTINCT FROM NEW.status THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT
+    "tasks"."module_id" AS "module_id",
+    "modules"."plan_id" AS "plan_id",
+    "learning_plans"."user_id" AS "owner_user_id",
+    "tasks"."estimated_minutes" AS "task_estimated_minutes"
+  INTO task_context
+  FROM "tasks"
+  JOIN "modules" ON "modules"."id" = "tasks"."module_id"
+  JOIN "learning_plans" ON "learning_plans"."id" = "modules"."plan_id"
+  WHERE "tasks"."id" = NEW.task_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Missing task context for task_progress row %', NEW.id;
+  END IF;
+
+  IF task_context."owner_user_id" IS DISTINCT FROM NEW.user_id THEN
+    RAISE EXCEPTION 'task_progress user_id does not own task %', NEW.task_id;
+  END IF;
+
+  INSERT INTO "learning_activity_events" (
+    "user_id",
+    "plan_id",
+    "module_id",
+    "task_id",
+    "previous_status",
+    "status",
+    "task_estimated_minutes",
+    "occurred_at"
+  )
+  VALUES (
+    NEW.user_id,
+    task_context."plan_id",
+    task_context."module_id",
+    NEW.task_id,
+    CASE WHEN TG_OP = 'UPDATE' THEN OLD.status ELSE NULL END,
+    NEW.status,
+    task_context."task_estimated_minutes",
+    NEW.updated_at
+  );
+
+  RETURN NEW;
+END;
+$$;--> statement-breakpoint
+REVOKE ALL ON SCHEMA "private" FROM PUBLIC;--> statement-breakpoint
+REVOKE ALL ON FUNCTION "private"."record_learning_activity_event"() FROM PUBLIC, anon, authenticated;--> statement-breakpoint
+CREATE TRIGGER "record_learning_activity_event"
+AFTER INSERT OR UPDATE OF "status" ON "task_progress"
+FOR EACH ROW
+EXECUTE FUNCTION "private"."record_learning_activity_event"();

--- a/supabase/migrations/0036_add_learning_activity_events.sql
+++ b/supabase/migrations/0036_add_learning_activity_events.sql
@@ -27,6 +27,7 @@ CREATE POLICY "learning_activity_events_select_own" ON "learning_activity_events
   );--> statement-breakpoint
 GRANT SELECT ON TABLE "learning_activity_events" TO authenticated;--> statement-breakpoint
 REVOKE INSERT, UPDATE, DELETE ON TABLE "learning_activity_events" FROM authenticated;--> statement-breakpoint
+REVOKE DELETE ON TABLE "task_progress" FROM authenticated;--> statement-breakpoint
 CREATE SCHEMA IF NOT EXISTS "private";--> statement-breakpoint
 CREATE OR REPLACE FUNCTION "private"."record_learning_activity_event"()
 RETURNS trigger
@@ -78,7 +79,7 @@ BEGIN
     CASE WHEN TG_OP = 'UPDATE' THEN OLD.status ELSE NULL END,
     NEW.status,
     task_context."task_estimated_minutes",
-    NEW.updated_at
+    statement_timestamp()
   );
 
   RETURN NEW;

--- a/supabase/migrations/meta/0036_snapshot.json
+++ b/supabase/migrations/meta/0036_snapshot.json
@@ -1,0 +1,2427 @@
+{
+  "id": "e4b2c3ab-d2b4-4f5d-b451-6a983e7e2f0b",
+  "prevId": "6654f1f9-adf0-4ae7-b587-32f89b117fa5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.oauth_state_tokens": {
+      "name": "oauth_state_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "state_token_hash": {
+          "name": "state_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_state_tokens_hash_idx": {
+          "name": "oauth_state_tokens_hash_idx",
+          "columns": [
+            {
+              "expression": "state_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_state_tokens_expires_at_idx": {
+          "name": "oauth_state_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "oauth_state_tokens_insert": {
+          "name": "oauth_state_tokens_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"oauth_state_tokens\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'"
+        },
+        "oauth_state_tokens_select": {
+          "name": "oauth_state_tokens_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"oauth_state_tokens\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'"
+        },
+        "oauth_state_tokens_delete": {
+          "name": "oauth_state_tokens_delete",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"oauth_state_tokens\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.job_queue": {
+      "name": "job_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "job_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_job_queue_pending_claim": {
+          "name": "idx_job_queue_pending_claim",
+          "columns": [
+            {
+              "expression": "job_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"job_queue\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_job_queue_user_id": {
+          "name": "idx_job_queue_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_job_queue_plan_id": {
+          "name": "idx_job_queue_plan_id",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_job_queue_created_at": {
+          "name": "idx_job_queue_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "job_queue_plan_id_learning_plans_id_fk": {
+          "name": "job_queue_plan_id_learning_plans_id_fk",
+          "tableFrom": "job_queue",
+          "tableTo": "learning_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "job_queue_user_id_users_id_fk": {
+          "name": "job_queue_user_id_users_id_fk",
+          "tableFrom": "job_queue",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "job_queue_select_own": {
+          "name": "job_queue_select_own",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"job_queue\".\"user_id\" IN (\n        SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n      )"
+        }
+      },
+      "checkConstraints": {
+        "attempts_check": {
+          "name": "attempts_check",
+          "value": "\"job_queue\".\"attempts\" >= 0"
+        },
+        "max_attempts_check": {
+          "name": "max_attempts_check",
+          "value": "\"job_queue\".\"max_attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.generation_attempts": {
+      "name": "generation_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classification": {
+          "name": "classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modules_count": {
+          "name": "modules_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tasks_count": {
+          "name": "tasks_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "truncated_topic": {
+          "name": "truncated_topic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "truncated_notes": {
+          "name": "truncated_notes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "normalized_effort": {
+          "name": "normalized_effort",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "prompt_hash": {
+          "name": "prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_generation_attempts_plan_id": {
+          "name": "idx_generation_attempts_plan_id",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_generation_attempts_created_at_plan_id": {
+          "name": "idx_generation_attempts_created_at_plan_id",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "generation_attempts_plan_id_learning_plans_id_fk": {
+          "name": "generation_attempts_plan_id_learning_plans_id_fk",
+          "tableFrom": "generation_attempts",
+          "tableTo": "learning_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "generation_attempts_select": {
+          "name": "generation_attempts_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n    EXISTS (\n      SELECT 1 FROM \"learning_plans\"\n      WHERE \"learning_plans\".\"id\" = \"generation_attempts\".\"plan_id\"\n      AND \"learning_plans\".\"user_id\" IN (\n        SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n      )\n    )\n  "
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.learning_plans": {
+      "name": "learning_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_level": {
+          "name": "skill_level",
+          "type": "skill_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weekly_hours": {
+          "name": "weekly_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "learning_style": {
+          "name": "learning_style",
+          "type": "learning_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline_date": {
+          "name": "deadline_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "origin": {
+          "name": "origin",
+          "type": "plan_origin",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ai'"
+        },
+        "generation_status": {
+          "name": "generation_status",
+          "type": "generation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'generating'"
+        },
+        "is_quota_eligible": {
+          "name": "is_quota_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_learning_plans_user_created_at_desc": {
+          "name": "idx_learning_plans_user_created_at_desc",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_learning_plans_user_generation_status": {
+          "name": "idx_learning_plans_user_generation_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_learning_plans_user_origin": {
+          "name": "idx_learning_plans_user_origin",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "origin",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_learning_plans_user_quota_generation_status": {
+          "name": "idx_learning_plans_user_quota_generation_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_quota_eligible",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "learning_plans_user_id_users_id_fk": {
+          "name": "learning_plans_user_id_users_id_fk",
+          "tableFrom": "learning_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "learning_plans_select": {
+          "name": "learning_plans_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n    \"learning_plans\".\"user_id\" IN (\n      SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n    )\n  "
+        }
+      },
+      "checkConstraints": {
+        "weekly_hours_check": {
+          "name": "weekly_hours_check",
+          "value": "\"learning_plans\".\"weekly_hours\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.plan_schedules": {
+      "name": "plan_schedules",
+      "schema": "",
+      "columns": {
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_json": {
+          "name": "schedule_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputs_hash": {
+          "name": "inputs_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weekly_hours": {
+          "name": "weekly_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plan_schedules_plan_id_learning_plans_id_fk": {
+          "name": "plan_schedules_plan_id_learning_plans_id_fk",
+          "tableFrom": "plan_schedules",
+          "tableTo": "learning_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "plan_schedules_select": {
+          "name": "plan_schedules_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n    EXISTS (\n      SELECT 1 FROM \"learning_plans\"\n      WHERE \"learning_plans\".\"id\" = \"plan_schedules\".\"plan_id\"\n      AND \"learning_plans\".\"user_id\" IN (\n        SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n      )\n    )\n  "
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.stripe_webhook_events": {
+      "name": "stripe_webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "livemode": {
+          "name": "livemode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_stripe_webhook_events_created_at": {
+          "name": "idx_stripe_webhook_events_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stripe_webhook_events_event_id_unique": {
+          "name": "stripe_webhook_events_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.learning_activity_events": {
+      "name": "learning_activity_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_status": {
+          "name": "previous_status",
+          "type": "progress_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "progress_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_estimated_minutes": {
+          "name": "task_estimated_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_learning_activity_events_user_occurred": {
+          "name": "idx_learning_activity_events_user_occurred",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_learning_activity_events_user_plan_occurred": {
+          "name": "idx_learning_activity_events_user_plan_occurred",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_learning_activity_events_task_occurred": {
+          "name": "idx_learning_activity_events_task_occurred",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "learning_activity_events_user_id_users_id_fk": {
+          "name": "learning_activity_events_user_id_users_id_fk",
+          "tableFrom": "learning_activity_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "learning_activity_events_plan_id_learning_plans_id_fk": {
+          "name": "learning_activity_events_plan_id_learning_plans_id_fk",
+          "tableFrom": "learning_activity_events",
+          "tableTo": "learning_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "learning_activity_events_module_id_modules_id_fk": {
+          "name": "learning_activity_events_module_id_modules_id_fk",
+          "tableFrom": "learning_activity_events",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "learning_activity_events_task_id_tasks_id_fk": {
+          "name": "learning_activity_events_task_id_tasks_id_fk",
+          "tableFrom": "learning_activity_events",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "learning_activity_events_select_own": {
+          "name": "learning_activity_events_select_own",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n    \"learning_activity_events\".\"user_id\" IN (\n      SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n    )\n  "
+        }
+      },
+      "checkConstraints": {
+        "learning_activity_events_task_estimated_minutes_nonneg": {
+          "name": "learning_activity_events_task_estimated_minutes_nonneg",
+          "value": "\"learning_activity_events\".\"task_estimated_minutes\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_minutes": {
+          "name": "estimated_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_generation_status": {
+          "name": "lesson_generation_status",
+          "type": "lesson_generation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_generated'"
+        },
+        "lesson_generation_started_at": {
+          "name": "lesson_generation_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lesson_generation_completed_at": {
+          "name": "lesson_generation_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lesson_generation_failed_at": {
+          "name": "lesson_generation_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lesson_generation_error": {
+          "name": "lesson_generation_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lesson_generation_metadata": {
+          "name": "lesson_generation_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "modules_plan_id_learning_plans_id_fk": {
+          "name": "modules_plan_id_learning_plans_id_fk",
+          "tableFrom": "modules",
+          "tableTo": "learning_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "modules_plan_id_order_unique": {
+          "name": "modules_plan_id_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "plan_id",
+            "order"
+          ]
+        }
+      },
+      "policies": {
+        "modules_select_own_plan": {
+          "name": "modules_select_own_plan",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n    EXISTS (\n      SELECT 1 FROM \"learning_plans\"\n      WHERE \"learning_plans\".\"id\" = \"modules\".\"plan_id\"\n      AND \"learning_plans\".\"user_id\" IN (\n        SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n      )\n    )\n  "
+        }
+      },
+      "checkConstraints": {
+        "order_check": {
+          "name": "order_check",
+          "value": "\"modules\".\"order\" >= 1"
+        },
+        "estimated_minutes_check": {
+          "name": "estimated_minutes_check",
+          "value": "\"modules\".\"estimated_minutes\" >= 0"
+        },
+        "module_lesson_generation_error_length": {
+          "name": "module_lesson_generation_error_length",
+          "value": "(\"modules\".\"lesson_generation_error\" IS NULL OR char_length(\"modules\".\"lesson_generation_error\") <= 4000)"
+        },
+        "module_title_length": {
+          "name": "module_title_length",
+          "value": "char_length(\"modules\".\"title\") <= 500"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.resources": {
+      "name": "resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "resource_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_cents": {
+          "name": "cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_resources_type": {
+          "name": "idx_resources_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "resources_url_unique": {
+          "name": "resources_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {
+        "resources_select_auth": {
+          "name": "resources_select_auth",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "duration_minutes_check": {
+          "name": "duration_minutes_check",
+          "value": "\"resources\".\"duration_minutes\" >= 0"
+        },
+        "cost_cents_check": {
+          "name": "cost_cents_check",
+          "value": "\"resources\".\"cost_cents\" >= 0"
+        },
+        "resource_title_length": {
+          "name": "resource_title_length",
+          "value": "char_length(\"resources\".\"title\") <= 500"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.task_progress": {
+      "name": "task_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "progress_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_task_progress_user_id": {
+          "name": "idx_task_progress_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_task_progress_task_id": {
+          "name": "idx_task_progress_task_id",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_task_progress_user_task": {
+          "name": "idx_task_progress_user_task",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_progress_task_id_tasks_id_fk": {
+          "name": "task_progress_task_id_tasks_id_fk",
+          "tableFrom": "task_progress",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_progress_user_id_users_id_fk": {
+          "name": "task_progress_user_id_users_id_fk",
+          "tableFrom": "task_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_progress_task_id_user_id_unique": {
+          "name": "task_progress_task_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "task_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {
+        "task_progress_select_own": {
+          "name": "task_progress_select_own",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n    \"task_progress\".\"user_id\" IN (\n      SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n    )\n  "
+        },
+        "task_progress_insert_own": {
+          "name": "task_progress_insert_own",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n          (\n    \"task_progress\".\"user_id\" IN (\n      SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n    )\n  )\n          AND (\n    EXISTS (\n      SELECT 1 FROM \"tasks\"\n      JOIN \"modules\" ON \"modules\".\"id\" = \"tasks\".\"module_id\"\n      JOIN \"learning_plans\" ON \"learning_plans\".\"id\" = \"modules\".\"plan_id\"\n      WHERE \"tasks\".\"id\" = \"task_progress\".\"task_id\"\n      AND (\n    \"learning_plans\".\"user_id\" IN (\n      SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n    )\n  )\n    )\n  )\n        "
+        },
+        "task_progress_update_own": {
+          "name": "task_progress_update_own",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n    \"task_progress\".\"user_id\" IN (\n      SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n    )\n  ",
+          "withCheck": "\n        (\n    \"task_progress\".\"user_id\" IN (\n      SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n    )\n  )\n        AND (\n    EXISTS (\n      SELECT 1 FROM \"tasks\"\n      JOIN \"modules\" ON \"modules\".\"id\" = \"tasks\".\"module_id\"\n      JOIN \"learning_plans\" ON \"learning_plans\".\"id\" = \"modules\".\"plan_id\"\n      WHERE \"tasks\".\"id\" = \"task_progress\".\"task_id\"\n      AND (\n    \"learning_plans\".\"user_id\" IN (\n      SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n    )\n  )\n    )\n  )\n      "
+        },
+        "task_progress_delete_own": {
+          "name": "task_progress_delete_own",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n    \"task_progress\".\"user_id\" IN (\n      SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n    )\n  "
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.task_resources": {
+      "name": "task_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_task_resources_resource_id": {
+          "name": "idx_task_resources_resource_id",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_resources_task_id_tasks_id_fk": {
+          "name": "task_resources_task_id_tasks_id_fk",
+          "tableFrom": "task_resources",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_resources_resource_id_resources_id_fk": {
+          "name": "task_resources_resource_id_resources_id_fk",
+          "tableFrom": "task_resources",
+          "tableTo": "resources",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_resources_task_id_resource_id_unique": {
+          "name": "task_resources_task_id_resource_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "task_id",
+            "resource_id"
+          ]
+        }
+      },
+      "policies": {
+        "task_resources_select_own_plan": {
+          "name": "task_resources_select_own_plan",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n    EXISTS (\n      SELECT 1 FROM \"tasks\"\n      JOIN \"modules\" ON \"modules\".\"id\" = \"tasks\".\"module_id\"\n      JOIN \"learning_plans\" ON \"learning_plans\".\"id\" = \"modules\".\"plan_id\"\n      WHERE \"tasks\".\"id\" = \"task_resources\".\"task_id\"\n      AND (\n    \"learning_plans\".\"user_id\" IN (\n      SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n    )\n  )\n    )\n  "
+        }
+      },
+      "checkConstraints": {
+        "order_check": {
+          "name": "order_check",
+          "value": "\"task_resources\".\"order\" >= 1"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_minutes": {
+          "name": "estimated_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_micro_explanation": {
+          "name": "has_micro_explanation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lesson_content": {
+          "name": "lesson_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lesson_content_updated_at": {
+          "name": "lesson_content_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_module_id_modules_id_fk": {
+          "name": "tasks_module_id_modules_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tasks_module_id_order_unique": {
+          "name": "tasks_module_id_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "module_id",
+            "order"
+          ]
+        }
+      },
+      "policies": {
+        "tasks_select_own_plan": {
+          "name": "tasks_select_own_plan",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n      EXISTS (\n        SELECT 1 FROM \"modules\"\n        WHERE \"modules\".\"id\" = \"tasks\".\"module_id\"\n        AND (\n    EXISTS (\n      SELECT 1 FROM \"learning_plans\"\n      WHERE \"learning_plans\".\"id\" = \"modules\".\"plan_id\"\n      AND \"learning_plans\".\"user_id\" IN (\n        SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n      )\n    )\n  )\n      )\n    "
+        }
+      },
+      "checkConstraints": {
+        "order_check": {
+          "name": "order_check",
+          "value": "\"tasks\".\"order\" >= 1"
+        },
+        "estimated_minutes_check": {
+          "name": "estimated_minutes_check",
+          "value": "\"tasks\".\"estimated_minutes\" >= 0"
+        },
+        "task_lesson_content_json_length": {
+          "name": "task_lesson_content_json_length",
+          "value": "(\"tasks\".\"lesson_content\" IS NULL OR length(\"tasks\".\"lesson_content\"::text) <= 262144)"
+        },
+        "task_title_length": {
+          "name": "task_title_length",
+          "value": "char_length(\"tasks\".\"title\") <= 500"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.ai_usage_events": {
+      "name": "ai_usage_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_cents": {
+          "name": "cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "provider_cost_microusd": {
+          "name": "provider_cost_microusd",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_pricing_snapshot": {
+          "name": "model_pricing_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ai_usage_created_at": {
+          "name": "idx_ai_usage_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_events_user_created_at": {
+          "name": "idx_ai_usage_events_user_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_usage_events_user_id_users_id_fk": {
+          "name": "ai_usage_events_user_id_users_id_fk",
+          "tableFrom": "ai_usage_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "ai_usage_events_select_own": {
+          "name": "ai_usage_events_select_own",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n    \"ai_usage_events\".\"user_id\" IN (\n      SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n    )\n  "
+        }
+      },
+      "checkConstraints": {
+        "ai_usage_events_input_tokens_nonneg": {
+          "name": "ai_usage_events_input_tokens_nonneg",
+          "value": "\"ai_usage_events\".\"input_tokens\" >= 0"
+        },
+        "ai_usage_events_output_tokens_nonneg": {
+          "name": "ai_usage_events_output_tokens_nonneg",
+          "value": "\"ai_usage_events\".\"output_tokens\" >= 0"
+        },
+        "ai_usage_events_cost_cents_nonneg": {
+          "name": "ai_usage_events_cost_cents_nonneg",
+          "value": "\"ai_usage_events\".\"cost_cents\" >= 0"
+        },
+        "ai_usage_events_provider_cost_microusd_nonneg": {
+          "name": "ai_usage_events_provider_cost_microusd_nonneg",
+          "value": "\"ai_usage_events\".\"provider_cost_microusd\" IS NULL OR \"ai_usage_events\".\"provider_cost_microusd\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.usage_metrics": {
+      "name": "usage_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plans_generated": {
+          "name": "plans_generated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "regenerations_used": {
+          "name": "regenerations_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "exports_used": {
+          "name": "exports_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lesson_modules_generated": {
+          "name": "lesson_modules_generated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "usage_metrics_user_id_users_id_fk": {
+          "name": "usage_metrics_user_id_users_id_fk",
+          "tableFrom": "usage_metrics",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "usage_metrics_user_id_month_unique": {
+          "name": "usage_metrics_user_id_month_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "month"
+          ]
+        }
+      },
+      "policies": {
+        "usage_metrics_select_own": {
+          "name": "usage_metrics_select_own",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n    \"usage_metrics\".\"user_id\" IN (\n      SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n    )\n  "
+        }
+      },
+      "checkConstraints": {
+        "plans_generated_nonneg": {
+          "name": "plans_generated_nonneg",
+          "value": "\"usage_metrics\".\"plans_generated\" >= 0"
+        },
+        "regenerations_used_nonneg": {
+          "name": "regenerations_used_nonneg",
+          "value": "\"usage_metrics\".\"regenerations_used\" >= 0"
+        },
+        "exports_used_nonneg": {
+          "name": "exports_used_nonneg",
+          "value": "\"usage_metrics\".\"exports_used\" >= 0"
+        },
+        "lesson_modules_generated_nonneg": {
+          "name": "lesson_modules_generated_nonneg",
+          "value": "\"usage_metrics\".\"lesson_modules_generated\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_tier": {
+          "name": "subscription_tier",
+          "type": "subscription_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_period_end": {
+          "name": "subscription_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "monthly_export_count": {
+          "name": "monthly_export_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preferred_ai_model": {
+          "name": "preferred_ai_model",
+          "type": "preferred_ai_model",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_auth_user_id_unique": {
+          "name": "users_auth_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth_user_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_stripe_customer_id_unique": {
+          "name": "users_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "users_stripe_subscription_id_unique": {
+          "name": "users_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {
+        "users_select_own": {
+          "name": "users_select_own",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'"
+        },
+        "users_insert_own": {
+          "name": "users_insert_own",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'"
+        },
+        "users_update_own": {
+          "name": "users_update_own",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'",
+          "withCheck": "\"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "public.generation_status": {
+      "name": "generation_status",
+      "schema": "public",
+      "values": [
+        "generating",
+        "pending_retry",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.job_type": {
+      "name": "job_type",
+      "schema": "public",
+      "values": [
+        "plan_regeneration"
+      ]
+    },
+    "public.learning_style": {
+      "name": "learning_style",
+      "schema": "public",
+      "values": [
+        "reading",
+        "video",
+        "practice",
+        "mixed"
+      ]
+    },
+    "public.lesson_generation_status": {
+      "name": "lesson_generation_status",
+      "schema": "public",
+      "values": [
+        "not_generated",
+        "generating",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.plan_origin": {
+      "name": "plan_origin",
+      "schema": "public",
+      "values": [
+        "ai",
+        "template",
+        "manual"
+      ]
+    },
+    "public.preferred_ai_model": {
+      "name": "preferred_ai_model",
+      "schema": "public",
+      "values": [
+        "google/gemini-2.0-flash-exp:free",
+        "openai/gpt-oss-20b:free",
+        "alibaba/tongyi-deepresearch-30b-a3b:free",
+        "anthropic/claude-haiku-4.5",
+        "google/gemini-2.5-flash-lite",
+        "google/gemini-3-flash-preview",
+        "google/gemini-3-pro-preview",
+        "anthropic/claude-sonnet-4.5",
+        "openai/gpt-4o-mini-2024-07-18",
+        "openai/gpt-4o-mini-search-preview",
+        "openai/gpt-4o",
+        "openai/gpt-5.1",
+        "openai/gpt-5.2"
+      ]
+    },
+    "public.progress_status": {
+      "name": "progress_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "in_progress",
+        "completed"
+      ]
+    },
+    "public.resource_type": {
+      "name": "resource_type",
+      "schema": "public",
+      "values": [
+        "video",
+        "article",
+        "course",
+        "doc",
+        "other"
+      ]
+    },
+    "public.skill_level": {
+      "name": "skill_level",
+      "schema": "public",
+      "values": [
+        "beginner",
+        "intermediate",
+        "advanced"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "canceled",
+        "past_due",
+        "trialing"
+      ]
+    },
+    "public.subscription_tier": {
+      "name": "subscription_tier",
+      "schema": "public",
+      "values": [
+        "free",
+        "starter",
+        "pro"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1779489548000,
       "tag": "20260522223908_schedule_retention_cleanup",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1782430837257,
+      "tag": "0036_add_learning_activity_events",
+      "breakpoints": true
     }
   ]
 }

--- a/supabase/privileges/authenticated-table-privileges.ts
+++ b/supabase/privileges/authenticated-table-privileges.ts
@@ -9,6 +9,7 @@
 export const AUTHENTICATED_SERVER_OWNED_WRITE_TABLES = [
   'ai_usage_events',
   'generation_attempts',
+  'learning_activity_events',
   'learning_plans',
   'modules',
   'plan_schedules',

--- a/supabase/schema/relations.ts
+++ b/supabase/schema/relations.ts
@@ -5,6 +5,7 @@ import {
   planSchedules,
 } from './tables/plans';
 import {
+  learningActivityEvents,
   modules,
   resources,
   taskProgress,
@@ -21,6 +22,7 @@ export const usersRelations = relations(users, ({ many }) => ({
   aiUsageEvents: many(aiUsageEvents),
   jobQueue: many(jobQueue),
   taskProgress: many(taskProgress),
+  learningActivityEvents: many(learningActivityEvents),
 }));
 
 export const learningPlansRelations = relations(
@@ -34,6 +36,7 @@ export const learningPlansRelations = relations(
     planSchedules: one(planSchedules),
     generationAttempts: many(generationAttempts),
     jobQueue: many(jobQueue),
+    learningActivityEvents: many(learningActivityEvents),
   }),
 );
 
@@ -60,6 +63,7 @@ export const modulesRelations = relations(modules, ({ one, many }) => ({
     references: [learningPlans.id],
   }),
   tasks: many(tasks),
+  learningActivityEvents: many(learningActivityEvents),
 }));
 
 export const tasksRelations = relations(tasks, ({ one, many }) => ({
@@ -69,6 +73,7 @@ export const tasksRelations = relations(tasks, ({ one, many }) => ({
   }),
   taskResources: many(taskResources),
   taskProgress: many(taskProgress),
+  learningActivityEvents: many(learningActivityEvents),
 }));
 
 export const resourcesRelations = relations(resources, ({ many }) => ({
@@ -96,6 +101,28 @@ export const taskProgressRelations = relations(taskProgress, ({ one }) => ({
     references: [users.id],
   }),
 }));
+
+export const learningActivityEventsRelations = relations(
+  learningActivityEvents,
+  ({ one }) => ({
+    user: one(users, {
+      fields: [learningActivityEvents.userId],
+      references: [users.id],
+    }),
+    plan: one(learningPlans, {
+      fields: [learningActivityEvents.planId],
+      references: [learningPlans.id],
+    }),
+    module: one(modules, {
+      fields: [learningActivityEvents.moduleId],
+      references: [modules.id],
+    }),
+    task: one(tasks, {
+      fields: [learningActivityEvents.taskId],
+      references: [tasks.id],
+    }),
+  }),
+);
 
 export const usageMetricsRelations = relations(usageMetrics, ({ one }) => ({
   user: one(users, {

--- a/supabase/schema/tables/tasks.ts
+++ b/supabase/schema/tables/tasks.ts
@@ -320,3 +320,55 @@ export const taskProgress = pgTable(
     ];
   },
 ).enableRLS();
+
+export const learningActivityEvents = pgTable(
+  'learning_activity_events',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    planId: uuid('plan_id')
+      .notNull()
+      .references(() => learningPlans.id, { onDelete: 'cascade' }),
+    moduleId: uuid('module_id')
+      .notNull()
+      .references(() => modules.id, { onDelete: 'cascade' }),
+    taskId: uuid('task_id')
+      .notNull()
+      .references(() => tasks.id, { onDelete: 'cascade' }),
+    previousStatus: progressStatus('previous_status'),
+    status: progressStatus('status').notNull(),
+    taskEstimatedMinutes: integer('task_estimated_minutes').notNull(),
+    occurredAt: timestamp('occurred_at', { withTimezone: true }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    check(
+      'learning_activity_events_task_estimated_minutes_nonneg',
+      sql`${table.taskEstimatedMinutes} >= 0`,
+    ),
+    index('idx_learning_activity_events_user_occurred').on(
+      table.userId,
+      table.occurredAt,
+    ),
+    index('idx_learning_activity_events_user_plan_occurred').on(
+      table.userId,
+      table.planId,
+      table.occurredAt,
+    ),
+    index('idx_learning_activity_events_task_occurred').on(
+      table.taskId,
+      table.occurredAt,
+    ),
+
+    // Users can read their own learning activity history.
+    pgPolicy('learning_activity_events_select_own', {
+      for: 'select',
+      to: 'authenticated',
+      using: recordOwnedByCurrentUser(table.userId),
+    }),
+  ],
+).enableRLS();

--- a/tests/helpers/db/bootstrap.ts
+++ b/tests/helpers/db/bootstrap.ts
@@ -58,7 +58,8 @@ export async function grantRlsPermissions(
       REVOKE INSERT, UPDATE, DELETE ON "job_queue" FROM authenticated;
       REVOKE INSERT, UPDATE, DELETE ON "job_queue" FROM anon;
       REVOKE INSERT, UPDATE, DELETE ON ${serverOwnedTablesSql} FROM authenticated;
-      GRANT INSERT, UPDATE, DELETE ON "task_progress" TO authenticated;
+      GRANT INSERT, UPDATE ON "task_progress" TO authenticated;
+      REVOKE DELETE ON "task_progress" FROM authenticated;
     `);
 
     const updateColumnGrants = await sql<{ column_name: string }[]>`

--- a/tests/helpers/db/rls-bootstrap.ts
+++ b/tests/helpers/db/rls-bootstrap.ts
@@ -62,7 +62,8 @@ export async function ensureRlsRolesAndPermissions() {
     REVOKE INSERT, UPDATE, DELETE ON ${sql.raw(
       AUTHENTICATED_SERVER_OWNED_WRITE_TABLES_SQL,
     )} FROM authenticated;
-    GRANT INSERT, UPDATE, DELETE ON "task_progress" TO authenticated;
+    GRANT INSERT, UPDATE ON "task_progress" TO authenticated;
+    REVOKE DELETE ON "task_progress" FROM authenticated;
   `);
 
   // Grant read-only permissions to anon role

--- a/tests/helpers/db/truncate.ts
+++ b/tests/helpers/db/truncate.ts
@@ -2,6 +2,7 @@ import {
   aiUsageEvents,
   generationAttempts,
   jobQueue,
+  learningActivityEvents,
   learningPlans,
   modules,
   oauthStateTokens,
@@ -65,6 +66,7 @@ function assertSafeToTruncate() {
  */
 const TRUNCATE_TABLES = [
   taskResources,
+  learningActivityEvents,
   taskProgress,
   aiUsageEvents,
   generationAttempts,

--- a/tests/integration/db/tasks.queries.spec.ts
+++ b/tests/integration/db/tasks.queries.spec.ts
@@ -102,7 +102,11 @@ describe('Task Queries', () => {
       .orderBy(asc(learningActivityEvents.occurredAt));
 
     expect(events).toHaveLength(2);
-    expect(events[0]).toMatchObject({
+    const [firstEvent, secondEvent] = events;
+    if (!firstEvent || !secondEvent) {
+      throw new Error('Expected two learning activity events');
+    }
+    expect(firstEvent).toMatchObject({
       userId,
       planId: plan.id,
       moduleId: mod.id,
@@ -110,9 +114,10 @@ describe('Task Queries', () => {
       previousStatus: null,
       status: 'completed',
       taskEstimatedMinutes: 45,
-      occurredAt: new Date('2026-06-25T10:00:00.000Z'),
     });
-    expect(events[1]).toMatchObject({
+    expectDate(firstEvent.occurredAt, 'first occurredAt');
+    expectRecentTimestamp(firstEvent.occurredAt);
+    expect(secondEvent).toMatchObject({
       userId,
       planId: plan.id,
       moduleId: mod.id,
@@ -120,8 +125,9 @@ describe('Task Queries', () => {
       previousStatus: 'completed',
       status: 'in_progress',
       taskEstimatedMinutes: 45,
-      occurredAt: new Date('2026-06-25T10:10:00.000Z'),
     });
+    expectDate(secondEvent.occurredAt, 'second occurredAt');
+    expectRecentTimestamp(secondEvent.occurredAt);
   });
 
   it.each([

--- a/tests/integration/db/tasks.queries.spec.ts
+++ b/tests/integration/db/tasks.queries.spec.ts
@@ -1,11 +1,17 @@
 import { setTaskProgressBatch } from '@/lib/db/queries/tasks';
-import { taskProgress } from '@supabase/schema';
+import {
+  learningActivityEvents,
+  learningPlans,
+  taskProgress,
+  tasks,
+  users,
+} from '@supabase/schema';
 import { db } from '@supabase/service-role';
 import { createTestModule, createTestTask } from '@tests/fixtures/modules';
 import { createTestPlan } from '@tests/fixtures/plans';
 import { ensureUser } from '@tests/helpers/db/users';
 import { buildTestAuthUserId, buildTestEmail } from '@tests/helpers/testIds';
-import { eq } from 'drizzle-orm';
+import { asc, eq } from 'drizzle-orm';
 import { describe, expect, it } from 'vitest';
 
 const RECENT_TIMESTAMP_THRESHOLD_MS = 10_000;
@@ -48,9 +54,123 @@ describe('Task Queries', () => {
       .select()
       .from(taskProgress)
       .where(eq(taskProgress.taskId, taskB.id));
+    const activityRows = await db
+      .select()
+      .from(learningActivityEvents)
+      .where(eq(learningActivityEvents.taskId, taskB.id));
 
     expect(rows).toHaveLength(0);
+    expect(activityRows).toHaveLength(0);
   });
+
+  it('records append-only learning activity events for progress status changes', async () => {
+    const authUserId = buildTestAuthUserId('db-tasks-activity');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+    });
+    const plan = await createTestPlan({ userId, topic: 'activity history' });
+    const mod = await createTestModule({ planId: plan.id });
+    const task = await createTestTask({
+      moduleId: mod.id,
+      estimatedMinutes: 45,
+    });
+
+    await setTaskProgressBatch(
+      userId,
+      [{ taskId: task.id, status: 'completed' }],
+      db,
+      { now: new Date('2026-06-25T10:00:00.000Z') },
+    );
+    await setTaskProgressBatch(
+      userId,
+      [{ taskId: task.id, status: 'completed' }],
+      db,
+      { now: new Date('2026-06-25T10:05:00.000Z') },
+    );
+    await setTaskProgressBatch(
+      userId,
+      [{ taskId: task.id, status: 'in_progress' }],
+      db,
+      { now: new Date('2026-06-25T10:10:00.000Z') },
+    );
+
+    const events = await db
+      .select()
+      .from(learningActivityEvents)
+      .where(eq(learningActivityEvents.taskId, task.id))
+      .orderBy(asc(learningActivityEvents.occurredAt));
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({
+      userId,
+      planId: plan.id,
+      moduleId: mod.id,
+      taskId: task.id,
+      previousStatus: null,
+      status: 'completed',
+      taskEstimatedMinutes: 45,
+      occurredAt: new Date('2026-06-25T10:00:00.000Z'),
+    });
+    expect(events[1]).toMatchObject({
+      userId,
+      planId: plan.id,
+      moduleId: mod.id,
+      taskId: task.id,
+      previousStatus: 'completed',
+      status: 'in_progress',
+      taskEstimatedMinutes: 45,
+      occurredAt: new Date('2026-06-25T10:10:00.000Z'),
+    });
+  });
+
+  it.each([
+    [
+      'plan',
+      (id: string) => db.delete(learningPlans).where(eq(learningPlans.id, id)),
+    ],
+    ['task', (id: string) => db.delete(tasks).where(eq(tasks.id, id))],
+    ['user', (id: string) => db.delete(users).where(eq(users.id, id))],
+  ] as const)(
+    'cascades learning activity events when deleting the %s',
+    async (target, deleteTarget) => {
+      const authUserId = buildTestAuthUserId(`db-tasks-cascade-${target}`);
+      const userId = await ensureUser({
+        authUserId,
+        email: buildTestEmail(authUserId),
+      });
+      const plan = await createTestPlan({ userId, topic: 'activity cascade' });
+      const mod = await createTestModule({ planId: plan.id });
+      const task = await createTestTask({ moduleId: mod.id });
+      const targetIds = {
+        plan: plan.id,
+        task: task.id,
+        user: userId,
+      };
+
+      await setTaskProgressBatch(
+        userId,
+        [{ taskId: task.id, status: 'completed' }],
+        db,
+      );
+
+      expect(
+        await db
+          .select()
+          .from(learningActivityEvents)
+          .where(eq(learningActivityEvents.taskId, task.id)),
+      ).toHaveLength(1);
+
+      await deleteTarget(targetIds[target]);
+
+      expect(
+        await db
+          .select()
+          .from(learningActivityEvents)
+          .where(eq(learningActivityEvents.taskId, task.id)),
+      ).toHaveLength(0);
+    },
+  );
 
   it('uses DB-backed timestamps for the no-scope single-update fallback', async () => {
     const authUserId = buildTestAuthUserId('db-tasks-single-time');

--- a/tests/security/learning-activity-events.rls.spec.ts
+++ b/tests/security/learning-activity-events.rls.spec.ts
@@ -1,0 +1,193 @@
+import { expectRlsViolation } from './rls-test-helpers';
+import { setTaskProgressBatch } from '@/lib/db/queries/tasks';
+import { learningActivityEvents, taskProgress } from '@supabase/schema';
+import { db } from '@supabase/service-role';
+import { createTestModule, createTestTask } from '@tests/fixtures/modules';
+import { createTestPlan } from '@tests/fixtures/plans';
+import { truncateAll } from '@tests/helpers/db/truncate';
+import { ensureUser } from '@tests/helpers/db/users';
+import {
+  cleanupTrackedRlsClients,
+  createRlsDbForUser,
+} from '@tests/helpers/rls';
+import { buildTestAuthUserId, buildTestEmail } from '@tests/helpers/testIds';
+import { and, eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+async function createActivityFixture(suffix: string) {
+  const authUserId = buildTestAuthUserId(`activity-${suffix}`);
+  const userId = await ensureUser({
+    authUserId,
+    email: buildTestEmail(authUserId),
+  });
+  const plan = await createTestPlan({ userId, topic: 'Activity Plan' });
+  const module = await createTestModule({ planId: plan.id });
+  const task = await createTestTask({ moduleId: module.id });
+
+  return { authUserId, userId, plan, module, task };
+}
+
+describe('learning_activity_events RLS and write boundary', () => {
+  beforeEach(async () => {
+    await cleanupTrackedRlsClients();
+    await truncateAll();
+  });
+
+  afterEach(async () => {
+    await cleanupTrackedRlsClients();
+  });
+
+  it('request-auth batch progress writes can record learning activity', async () => {
+    const { authUserId, userId, plan, task } =
+      await createActivityFixture('batch-write');
+    const authDb = await createRlsDbForUser(authUserId);
+
+    const progressRows = await setTaskProgressBatch(
+      userId,
+      [{ taskId: task.id, status: 'completed' }],
+      authDb,
+      { planId: plan.id },
+    );
+
+    expect(progressRows).toHaveLength(1);
+    expect(progressRows[0]?.status).toBe('completed');
+
+    const eventRows = await authDb
+      .select()
+      .from(learningActivityEvents)
+      .where(eq(learningActivityEvents.taskId, task.id));
+
+    expect(eventRows).toHaveLength(1);
+    expect(eventRows[0]?.status).toBe('completed');
+    expect(eventRows[0]?.taskEstimatedMinutes).toBe(30);
+  });
+
+  it('owners can read activity history but cannot directly write it', async () => {
+    const { authUserId, userId, plan, module, task } =
+      await createActivityFixture('owner-read');
+    const otherAuthUserId = buildTestAuthUserId('activity-other');
+    await ensureUser({
+      authUserId: otherAuthUserId,
+      email: buildTestEmail(otherAuthUserId),
+    });
+
+    await db.insert(taskProgress).values({
+      taskId: task.id,
+      userId,
+      status: 'completed',
+    });
+
+    const ownerDb = await createRlsDbForUser(authUserId);
+    const otherDb = await createRlsDbForUser(otherAuthUserId);
+    const ownerRows = await ownerDb.select().from(learningActivityEvents);
+    const otherRows = await otherDb.select().from(learningActivityEvents);
+
+    expect(ownerRows).toHaveLength(1);
+    expect(ownerRows[0]?.status).toBe('completed');
+    expect(otherRows).toHaveLength(0);
+    const eventId = ownerRows[0]?.id;
+    expect(eventId).toBeDefined();
+    if (!eventId) throw new Error('Expected learning activity event id');
+
+    await expectRlsViolation(() =>
+      ownerDb.insert(learningActivityEvents).values({
+        userId,
+        planId: plan.id,
+        moduleId: module.id,
+        taskId: task.id,
+        status: 'completed',
+        taskEstimatedMinutes: 30,
+        occurredAt: new Date(),
+      }),
+    );
+    await expectRlsViolation(() =>
+      ownerDb
+        .update(learningActivityEvents)
+        .set({ status: 'in_progress' })
+        .where(eq(learningActivityEvents.id, eventId)),
+    );
+    await expectRlsViolation(() =>
+      ownerDb
+        .delete(learningActivityEvents)
+        .where(eq(learningActivityEvents.id, eventId)),
+    );
+  });
+
+  it('uses the database clock for activity history timestamps', async () => {
+    const { authUserId, userId, task } =
+      await createActivityFixture('forged-clock');
+    const authDb = await createRlsDbForUser(authUserId);
+    const forgedInsertTime = new Date('2001-01-01T00:00:00.000Z');
+    const forgedUpdateTime = new Date('2002-01-01T00:00:00.000Z');
+
+    await authDb.insert(taskProgress).values({
+      taskId: task.id,
+      userId,
+      status: 'completed',
+      completedAt: forgedInsertTime,
+      updatedAt: forgedInsertTime,
+    });
+    await authDb
+      .update(taskProgress)
+      .set({
+        status: 'in_progress',
+        completedAt: null,
+        updatedAt: forgedUpdateTime,
+      })
+      .where(eq(taskProgress.taskId, task.id));
+
+    const completedEvents = await authDb
+      .select()
+      .from(learningActivityEvents)
+      .where(
+        and(
+          eq(learningActivityEvents.taskId, task.id),
+          eq(learningActivityEvents.status, 'completed'),
+        ),
+      );
+    const inProgressEvents = await authDb
+      .select()
+      .from(learningActivityEvents)
+      .where(
+        and(
+          eq(learningActivityEvents.taskId, task.id),
+          eq(learningActivityEvents.status, 'in_progress'),
+        ),
+      );
+
+    expect(completedEvents).toHaveLength(1);
+    expect(inProgressEvents).toHaveLength(1);
+    expect(completedEvents[0]?.occurredAt.getTime()).toBeGreaterThan(
+      forgedInsertTime.getTime(),
+    );
+    expect(inProgressEvents[0]).toMatchObject({
+      previousStatus: 'completed',
+      status: 'in_progress',
+    });
+    expect(inProgressEvents[0]?.occurredAt.getTime()).toBeGreaterThan(
+      forgedUpdateTime.getTime(),
+    );
+  });
+
+  it('does not allow browser-authenticated users to delete progress rows', async () => {
+    const { authUserId, userId, task } =
+      await createActivityFixture('deny-delete');
+    await db.insert(taskProgress).values({
+      taskId: task.id,
+      userId,
+      status: 'completed',
+    });
+
+    const authDb = await createRlsDbForUser(authUserId);
+
+    await expectRlsViolation(() =>
+      authDb.delete(taskProgress).where(eq(taskProgress.taskId, task.id)),
+    );
+
+    const rows = await db
+      .select()
+      .from(taskProgress)
+      .where(eq(taskProgress.taskId, task.id));
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/tests/security/rls-test-helpers.ts
+++ b/tests/security/rls-test-helpers.ts
@@ -18,6 +18,7 @@ export const expectedPolicyTables = [
   'tasks',
   'resources',
   'task_progress',
+  'learning_activity_events',
   'usage_metrics',
   'ai_usage_events',
 ] as const;

--- a/tests/security/rls.policies.spec.ts
+++ b/tests/security/rls.policies.spec.ts
@@ -28,12 +28,10 @@ import {
   policyRowSchema,
   serverOwnedWriteTables,
 } from './rls-test-helpers';
-import { setTaskProgressBatch } from '@/lib/db/queries/tasks';
 import {
   jobQueue,
   aiUsageEvents,
   generationAttempts,
-  learningActivityEvents,
   learningPlans,
   modules,
   planSchedules,
@@ -1448,157 +1446,6 @@ describe('RLS Policy Verification', () => {
 
       expect(updated).toHaveLength(1);
       expect(updated[0]?.status).toBe('in_progress');
-    });
-
-    it('request-auth batch progress writes can record learning activity', async () => {
-      const [user] = await db
-        .insert(users)
-        .values({
-          authUserId: 'user_progress_batch',
-          email: 'progress-batch@test.com',
-        })
-        .returning();
-
-      const [plan] = await db
-        .insert(learningPlans)
-        .values({
-          userId: user.id,
-          topic: 'Batch Progress Plan',
-          skillLevel: 'beginner',
-          weeklyHours: 5,
-          learningStyle: 'practice',
-          visibility: 'private',
-        })
-        .returning();
-
-      const [module] = await db
-        .insert(modules)
-        .values({
-          planId: plan.id,
-          order: 1,
-          title: 'Module 1',
-          estimatedMinutes: 120,
-        })
-        .returning();
-
-      const [task] = await db
-        .insert(tasks)
-        .values({
-          moduleId: module.id,
-          order: 1,
-          title: 'Task 1',
-          estimatedMinutes: 30,
-        })
-        .returning();
-
-      const authDb = await createRlsDbForUser('user_progress_batch');
-      const progressRows = await setTaskProgressBatch(
-        user.id,
-        [{ taskId: task.id, status: 'completed' }],
-        authDb,
-        { planId: plan.id },
-      );
-
-      expect(progressRows).toHaveLength(1);
-      expect(progressRows[0]?.status).toBe('completed');
-
-      const eventRows = await authDb
-        .select()
-        .from(learningActivityEvents)
-        .where(eq(learningActivityEvents.taskId, task.id));
-
-      expect(eventRows).toHaveLength(1);
-      expect(eventRows[0]?.status).toBe('completed');
-      expect(eventRows[0]?.taskEstimatedMinutes).toBe(30);
-    });
-
-    it('learning activity history is owner-readable and DB-written only', async () => {
-      const [owner] = await db
-        .insert(users)
-        .values({
-          authUserId: 'user_activity_owner',
-          email: 'activity-owner@test.com',
-        })
-        .returning();
-      await db.insert(users).values({
-        authUserId: 'user_activity_other',
-        email: 'activity-other@test.com',
-      });
-
-      const [plan] = await db
-        .insert(learningPlans)
-        .values({
-          userId: owner.id,
-          topic: 'Activity Plan',
-          skillLevel: 'beginner',
-          weeklyHours: 5,
-          learningStyle: 'practice',
-          visibility: 'private',
-        })
-        .returning();
-
-      const [module] = await db
-        .insert(modules)
-        .values({
-          planId: plan.id,
-          order: 1,
-          title: 'Module 1',
-          estimatedMinutes: 120,
-        })
-        .returning();
-
-      const [task] = await db
-        .insert(tasks)
-        .values({
-          moduleId: module.id,
-          order: 1,
-          title: 'Task 1',
-          estimatedMinutes: 30,
-        })
-        .returning();
-
-      await db.insert(taskProgress).values({
-        taskId: task.id,
-        userId: owner.id,
-        status: 'completed',
-      });
-
-      const ownerDb = await createRlsDbForUser('user_activity_owner');
-      const otherDb = await createRlsDbForUser('user_activity_other');
-      const ownerRows = await ownerDb.select().from(learningActivityEvents);
-      const otherRows = await otherDb.select().from(learningActivityEvents);
-
-      expect(ownerRows).toHaveLength(1);
-      expect(ownerRows[0]?.status).toBe('completed');
-      expect(otherRows).toHaveLength(0);
-      const eventId = ownerRows[0]?.id;
-      expect(eventId).toBeDefined();
-      if (!eventId) {
-        throw new Error('Expected learning activity event id');
-      }
-
-      await expectRlsViolation(() =>
-        ownerDb.insert(learningActivityEvents).values({
-          userId: owner.id,
-          planId: plan.id,
-          moduleId: module.id,
-          taskId: task.id,
-          status: 'completed',
-          taskEstimatedMinutes: 30,
-          occurredAt: new Date(),
-        }),
-      );
-      await expectRlsViolation(() =>
-        ownerDb
-          .update(learningActivityEvents)
-          .set({ status: 'in_progress' })
-          .where(eq(learningActivityEvents.id, eventId)),
-      );
-      await expectRlsViolation(() =>
-        ownerDb
-          .delete(learningActivityEvents)
-          .where(eq(learningActivityEvents.id, eventId)),
-      );
     });
   });
 

--- a/tests/security/rls.policies.spec.ts
+++ b/tests/security/rls.policies.spec.ts
@@ -28,10 +28,12 @@ import {
   policyRowSchema,
   serverOwnedWriteTables,
 } from './rls-test-helpers';
+import { setTaskProgressBatch } from '@/lib/db/queries/tasks';
 import {
   jobQueue,
   aiUsageEvents,
   generationAttempts,
+  learningActivityEvents,
   learningPlans,
   modules,
   planSchedules,
@@ -1446,6 +1448,157 @@ describe('RLS Policy Verification', () => {
 
       expect(updated).toHaveLength(1);
       expect(updated[0]?.status).toBe('in_progress');
+    });
+
+    it('request-auth batch progress writes can record learning activity', async () => {
+      const [user] = await db
+        .insert(users)
+        .values({
+          authUserId: 'user_progress_batch',
+          email: 'progress-batch@test.com',
+        })
+        .returning();
+
+      const [plan] = await db
+        .insert(learningPlans)
+        .values({
+          userId: user.id,
+          topic: 'Batch Progress Plan',
+          skillLevel: 'beginner',
+          weeklyHours: 5,
+          learningStyle: 'practice',
+          visibility: 'private',
+        })
+        .returning();
+
+      const [module] = await db
+        .insert(modules)
+        .values({
+          planId: plan.id,
+          order: 1,
+          title: 'Module 1',
+          estimatedMinutes: 120,
+        })
+        .returning();
+
+      const [task] = await db
+        .insert(tasks)
+        .values({
+          moduleId: module.id,
+          order: 1,
+          title: 'Task 1',
+          estimatedMinutes: 30,
+        })
+        .returning();
+
+      const authDb = await createRlsDbForUser('user_progress_batch');
+      const progressRows = await setTaskProgressBatch(
+        user.id,
+        [{ taskId: task.id, status: 'completed' }],
+        authDb,
+        { planId: plan.id },
+      );
+
+      expect(progressRows).toHaveLength(1);
+      expect(progressRows[0]?.status).toBe('completed');
+
+      const eventRows = await authDb
+        .select()
+        .from(learningActivityEvents)
+        .where(eq(learningActivityEvents.taskId, task.id));
+
+      expect(eventRows).toHaveLength(1);
+      expect(eventRows[0]?.status).toBe('completed');
+      expect(eventRows[0]?.taskEstimatedMinutes).toBe(30);
+    });
+
+    it('learning activity history is owner-readable and DB-written only', async () => {
+      const [owner] = await db
+        .insert(users)
+        .values({
+          authUserId: 'user_activity_owner',
+          email: 'activity-owner@test.com',
+        })
+        .returning();
+      await db.insert(users).values({
+        authUserId: 'user_activity_other',
+        email: 'activity-other@test.com',
+      });
+
+      const [plan] = await db
+        .insert(learningPlans)
+        .values({
+          userId: owner.id,
+          topic: 'Activity Plan',
+          skillLevel: 'beginner',
+          weeklyHours: 5,
+          learningStyle: 'practice',
+          visibility: 'private',
+        })
+        .returning();
+
+      const [module] = await db
+        .insert(modules)
+        .values({
+          planId: plan.id,
+          order: 1,
+          title: 'Module 1',
+          estimatedMinutes: 120,
+        })
+        .returning();
+
+      const [task] = await db
+        .insert(tasks)
+        .values({
+          moduleId: module.id,
+          order: 1,
+          title: 'Task 1',
+          estimatedMinutes: 30,
+        })
+        .returning();
+
+      await db.insert(taskProgress).values({
+        taskId: task.id,
+        userId: owner.id,
+        status: 'completed',
+      });
+
+      const ownerDb = await createRlsDbForUser('user_activity_owner');
+      const otherDb = await createRlsDbForUser('user_activity_other');
+      const ownerRows = await ownerDb.select().from(learningActivityEvents);
+      const otherRows = await otherDb.select().from(learningActivityEvents);
+
+      expect(ownerRows).toHaveLength(1);
+      expect(ownerRows[0]?.status).toBe('completed');
+      expect(otherRows).toHaveLength(0);
+      const eventId = ownerRows[0]?.id;
+      expect(eventId).toBeDefined();
+      if (!eventId) {
+        throw new Error('Expected learning activity event id');
+      }
+
+      await expectRlsViolation(() =>
+        ownerDb.insert(learningActivityEvents).values({
+          userId: owner.id,
+          planId: plan.id,
+          moduleId: module.id,
+          taskId: task.id,
+          status: 'completed',
+          taskEstimatedMinutes: 30,
+          occurredAt: new Date(),
+        }),
+      );
+      await expectRlsViolation(() =>
+        ownerDb
+          .update(learningActivityEvents)
+          .set({ status: 'in_progress' })
+          .where(eq(learningActivityEvents.id, eventId)),
+      );
+      await expectRlsViolation(() =>
+        ownerDb
+          .delete(learningActivityEvents)
+          .where(eq(learningActivityEvents.id, eventId)),
+      );
     });
   });
 

--- a/tests/unit/helpers/db/server-owned-write-privilege-bootstrap-sync.spec.ts
+++ b/tests/unit/helpers/db/server-owned-write-privilege-bootstrap-sync.spec.ts
@@ -27,6 +27,14 @@ describe('server-owned write privilege bootstrap sync', () => {
       ),
       'utf8',
     );
+    const learningActivityMigration = readFileSync(
+      resolve(
+        REPO_ROOT,
+        'supabase/migrations/0036_add_learning_activity_events.sql',
+      ),
+      'utf8',
+    );
+    const serverOwnedMigrationSql = `${migration}\n${learningActivityMigration}`;
     const bootstrap = readFileSync(
       resolve(TEST_DIR, '../../../helpers/db/bootstrap.ts'),
       'utf8',
@@ -41,7 +49,7 @@ describe('server-owned write privilege bootstrap sync', () => {
     expect(migration).toMatch(migrationRevokeBlock);
 
     for (const table of AUTHENTICATED_SERVER_OWNED_WRITE_TABLES) {
-      expect(migration).toContain(`"${table}"`);
+      expect(serverOwnedMigrationSql).toContain(`"${table}"`);
     }
 
     expect(bootstrap).toContain('AUTHENTICATED_SERVER_OWNED_WRITE_TABLES');


### PR DESCRIPTION
## Summary
- Add append-only `learning_activity_events` history for task progress status changes.
- Keep writes DB-owned through a trigger and authenticated read-only RLS policy.
- Harden activity timestamps to use the database clock and block direct browser-authenticated `task_progress` deletes.
- Split focused learning activity RLS coverage out of the broad policy spec.

## Validation
- `NODE_ENV=test pnpm vitest run --config vitest.config.ts --project integration tests/integration/db/tasks.queries.spec.ts`
- `NODE_ENV=test pnpm vitest run --config vitest.config.ts --project security tests/security/learning-activity-events.rls.spec.ts tests/security/rls.policies.spec.ts`
- `SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit tests/unit/helpers/db/server-owned-write-privilege-bootstrap-sync.spec.ts`
- `pnpm test`
- `pnpm check:full`

Closes #370

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `task_progress` write path, privileges, and a security-definer trigger; behavior changes include no client deletes on progress and every status change firing DB-side logic.
> 
> **Overview**
> Adds **`learning_activity_events`** as the durable store for future streaks and trends, wired through a **`SECURITY DEFINER` trigger** on `task_progress` that records status transitions (skipping no-op updates), stamps **`occurred_at` with `statement_timestamp()`**, and validates task ownership before insert. Clients get **SELECT-only RLS** on activity rows; **INSERT/UPDATE/DELETE** on that table are revoked for `authenticated`, and **`task_progress` DELETE** is revoked as well so history is not bypassed by deleting progress.
> 
> Application task progress writes **drop row-level `FOR UPDATE` locks** on ownership reads. Drizzle schema, relations, server-owned privilege lists, test bootstrap/truncate, and the usage analytics metric contract are updated to name **`learning_activity_events`** and JCS-27/28 boundaries. New integration and security specs cover event recording, cascades, forged client timestamps, and direct activity writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5625db2e3997ee525c48a72588686d484b53cf27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->