### PR TITLE
feat(analytics): add historical usage analytics

### DIFF
--- a/docs/architecture/usage-analytics-metric-contract.md
+++ b/docs/architecture/usage-analytics-metric-contract.md
@@ -1,20 +1,22 @@
 # Usage Analytics Metric Contract
 
-This contract defines what the first user-facing usage analytics release may
-promise, and what must wait for append-only learning activity history.
+This contract defines what user-facing usage analytics may promise from current
+completion state and append-only learning activity history.
 
 ## First Release Boundary
 
 The first `/analytics/usage` release may show completion analytics and clearly
-labeled estimated completed learning time. It must not promise actual study
-time, streaks, weekly summaries, or trends until Atlaris records durable
-activity history.
+labeled estimated completed learning time. After JCS-27, historical analytics
+may show streaks, weekly summaries, and trends only from recorded
+`learning_activity_events`.
 
 Use this wording for the MVP time metric:
 
 - Label: `Estimated completed learning time`
 - Helper copy: `Based on estimates for tasks currently marked complete. This is not recorded study time.`
-- Historical placeholder copy: `Streaks and weekly summaries start after activity tracking launches.`
+- No-history copy: explain that streaks and weekly summaries start after task
+  progress changes are recorded, and that earlier study activity is not
+  backfilled.
 
 ## Metric Glossary
 
@@ -25,14 +27,14 @@ Use this wording for the MVP time metric:
 | `plan_completion` | Existing completion read projections over plan tasks | Current-state | `completedTasks / totalTasks`; plans with zero tasks have `0` completion. |
 | `estimated_completed_learning_time` | `tasks.estimated_minutes` for currently completed tasks | Current-state, estimated | Sum task estimates for tasks currently marked complete. This is not actual recorded study time. |
 | `actual_study_time` | Future append-only learning activity history | Historical, actual | Unavailable until explicit study-duration events or another accepted actual-time source exists. |
-| `streaks` | `learning_activity_events` | Historical | Unavailable until JCS-28 defines date bucketing and reads recorded post-launch progress-change activity. |
-| `weekly_summaries` | `learning_activity_events` | Historical | Unavailable until JCS-28 reads recorded post-launch activity events. |
-| `trends` | `learning_activity_events` | Historical | Unavailable until JCS-28 reads recorded post-launch activity events. |
+| `streaks` | `learning_activity_events` | Historical | Count local study days from recorded post-launch progress-change activity. Current streak may continue through yesterday when today has no activity yet. |
+| `weekly_summaries` | `learning_activity_events` | Historical | Summarize recorded progress-change activity in Monday-start learning weeks. |
+| `trends` | `learning_activity_events` | Historical | Show recent weekly progress-change and completed-event history from recorded events only. |
 
 ## Future Activity Semantics
 
-JCS-27 creates `learning_activity_events` as the durable activity source before
-JCS-28 exposes historical analytics.
+JCS-27 creates `learning_activity_events` as the durable activity source. JCS-28
+exposes historical analytics from that source.
 
 - A study day is any calendar day with at least one recorded task progress
   status change.
@@ -42,10 +44,10 @@ JCS-28 exposes historical analytics.
   deleted.
 - Do not reconstruct complete pre-launch history from mutable current-state
   rows.
-- Streaks should support both global and per-plan views when implemented.
-- Date bucketing must not ship until the history implementation chooses a
-  canonical timezone source. The current schema has schedule timezone data, but
-  no general user timezone.
+- Streaks support both global and per-plan views.
+- Date bucketing uses `users.analytics_timezone`. New and existing users default
+  to `UTC`; `/analytics/usage` may update the setting from the browser's IANA
+  timezone after authenticated render.
 
 ## Guardrails
 
@@ -70,6 +72,8 @@ JCS-28 exposes historical analytics.
   `src/features/plans/read-projection/summary-projection.ts`
 - Current task progress schema:
   `supabase/schema/tables/tasks.ts`
+- Analytics timezone source:
+  `supabase/schema/tables/users.ts`
 
 ## Downstream Issue Boundaries
 
@@ -77,5 +81,5 @@ JCS-28 exposes historical analytics.
   from existing current-state projections.
 - JCS-27 adds append-only learning activity history in
   `learning_activity_events`; no historical analytics ship in that slice.
-- JCS-28 may build streaks, weekly summaries, and trends only from recorded
-  activity history.
+- JCS-28 builds streaks, weekly summaries, and trends only from recorded
+  activity history and the stored analytics timezone.

--- a/src/app/(app)/analytics/usage/actions.ts
+++ b/src/app/(app)/analytics/usage/actions.ts
@@ -11,15 +11,18 @@ export async function syncAnalyticsTimezoneAction(
   const parsed = updateUserProfileSchema.safeParse({ analyticsTimezone });
   if (!parsed.success) return false;
 
+  const nextAnalyticsTimezone = parsed.data.analyticsTimezone;
+  if (!nextAnalyticsTimezone) return false;
+
   const result = await requestBoundary.action(async ({ actor, db }) => {
-    if (actor.analyticsTimezone === parsed.data.analyticsTimezone) {
+    if (actor.analyticsTimezone === nextAnalyticsTimezone) {
       return false;
     }
 
     await db
       .update(users)
       .set({
-        analyticsTimezone: parsed.data.analyticsTimezone,
+        analyticsTimezone: nextAnalyticsTimezone,
         updatedAt: sql<Date>`now()`,
       })
       .where(eq(users.authUserId, actor.authUserId));

--- a/src/app/(app)/analytics/usage/actions.ts
+++ b/src/app/(app)/analytics/usage/actions.ts
@@ -1,0 +1,31 @@
+'use server';
+
+import { updateUserProfileSchema } from '@/app/api/v1/user/profile/validation';
+import { requestBoundary } from '@/lib/api/request-boundary';
+import { users } from '@supabase/schema';
+import { eq, sql } from 'drizzle-orm';
+
+export async function syncAnalyticsTimezoneAction(
+  analyticsTimezone: string,
+): Promise<boolean> {
+  const parsed = updateUserProfileSchema.safeParse({ analyticsTimezone });
+  if (!parsed.success) return false;
+
+  const result = await requestBoundary.action(async ({ actor, db }) => {
+    if (actor.analyticsTimezone === parsed.data.analyticsTimezone) {
+      return false;
+    }
+
+    await db
+      .update(users)
+      .set({
+        analyticsTimezone: parsed.data.analyticsTimezone,
+        updatedAt: sql<Date>`now()`,
+      })
+      .where(eq(users.authUserId, actor.authUserId));
+
+    return true;
+  });
+
+  return result ?? false;
+}

--- a/src/app/(app)/analytics/usage/page.tsx
+++ b/src/app/(app)/analytics/usage/page.tsx
@@ -4,7 +4,9 @@ import {
   buildUsageAnalyticsModel,
   type UsageAnalyticsModel,
   type UsageAnalyticsPlanRow,
+  type UsageAnalyticsWeekRow,
 } from './usage-analytics-model';
+import { UsageAnalyticsTimezoneSync } from './usage-analytics-timezone-sync';
 import { Button } from '@/components/ui/button';
 import { MetricCard } from '@/components/ui/metric-card';
 import { PageHeader } from '@/components/ui/page-header';
@@ -14,12 +16,16 @@ import { ROUTES } from '@/features/navigation/routes';
 import { formatMinutes } from '@/features/plans/formatters';
 import { listUsageAnalyticsPlanSummaries } from '@/features/plans/read-projection/service';
 import { requestBoundary } from '@/lib/api/request-boundary';
+import { getLearningActivityEventsForUser } from '@/lib/db/queries/tasks';
 import {
   BarChart3,
   BookOpenCheck,
+  CalendarDays,
   Clock,
+  Flame,
   ListChecks,
   Plus,
+  TrendingUp,
 } from 'lucide-react';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
@@ -40,17 +46,21 @@ export const metadata: Metadata = {
 const SIGN_IN_RETURN_PATH = `${ROUTES.AUTH.SIGN_IN}?redirect_url=${encodeURIComponent(ROUTES.ANALYTICS.USAGE)}`;
 const ESTIMATED_TIME_HELPER =
   'Based on estimates for tasks currently marked complete. This is not recorded study time.';
-const HISTORICAL_PLACEHOLDER =
-  'Streaks and weekly summaries start after activity tracking launches.';
 
 export default async function UsageAnalyticsPage() {
   const result = await requestBoundary.component(async ({ actor, db }) => {
-    const summaries = await listUsageAnalyticsPlanSummaries({
-      userId: actor.id,
-      dbClient: db,
-    });
+    const [summaries, activityEvents] = await Promise.all([
+      listUsageAnalyticsPlanSummaries({
+        userId: actor.id,
+        dbClient: db,
+      }),
+      getLearningActivityEventsForUser(actor.id, db),
+    ]);
 
-    return buildUsageAnalyticsModel(summaries);
+    return buildUsageAnalyticsModel(summaries, {
+      activityEvents,
+      analyticsTimezone: actor.analyticsTimezone,
+    });
   });
 
   if (!result) {
@@ -63,6 +73,7 @@ export default async function UsageAnalyticsPage() {
 function UsageAnalyticsView({ model }: { model: UsageAnalyticsModel }) {
   return (
     <>
+      <UsageAnalyticsTimezoneSync analyticsTimezone={model.analyticsTimezone} />
       <PageHeader
         title='Usage'
         subtitle='Current completion progress and estimated completed learning time from your plans.'
@@ -71,7 +82,7 @@ function UsageAnalyticsView({ model }: { model: UsageAnalyticsModel }) {
       {model.planCount === 0 ? (
         <div className='space-y-6'>
           <NoPlansState />
-          <HistoricalPlaceholder />
+          <HistoricalAnalyticsSection model={model} />
         </div>
       ) : (
         <AnalyticsContent model={model} />
@@ -118,22 +129,105 @@ function AnalyticsContent({ model }: { model: UsageAnalyticsModel }) {
 
       {model.completedTasks === 0 ? <NoCompletedWorkState /> : null}
 
+      <HistoricalAnalyticsSection model={model} />
+
       <PlanCompletionSection plans={model.plans} />
 
-      <HistoricalPlaceholder />
+      {model.history.hasActivity ? (
+        <PlanActivitySection plans={model.plans} />
+      ) : null}
     </div>
   );
 }
 
-function HistoricalPlaceholder() {
+function HistoricalAnalyticsSection({ model }: { model: UsageAnalyticsModel }) {
+  const currentWeek = model.history.currentWeek;
+
   return (
-    <Surface variant='muted'>
+    <section aria-label='Historical activity' className='space-y-4'>
       <div className='space-y-2'>
         <h2 className='text-lg font-semibold text-foreground'>
-          Historical analytics
+          Historical activity
         </h2>
         <p className='text-sm leading-6 text-muted-foreground'>
-          {HISTORICAL_PLACEHOLDER}
+          Based on recorded task progress changes since activity tracking
+          launched. Calendar days use {model.analyticsTimezone}.
+        </p>
+      </div>
+
+      {!model.history.hasActivity ? (
+        <NoHistoricalActivityState />
+      ) : (
+        <>
+          <section
+            aria-label='Historical activity summary'
+            className='grid gap-4 sm:grid-cols-2 xl:grid-cols-4'
+          >
+            <MetricCard
+              icon={<Flame aria-hidden />}
+              label='Current streak'
+              value={formatDayCount(model.history.currentStreakDays)}
+              sublabel={`Longest: ${formatDayCount(model.history.longestStreakDays)}`}
+            />
+            <MetricCard
+              icon={<CalendarDays aria-hidden />}
+              label='Active days this week'
+              value={`${currentWeek.activeDays}/7`}
+              sublabel={`${currentWeek.progressChangeCount} progress changes`}
+            />
+            <MetricCard
+              icon={<ListChecks aria-hidden />}
+              label='Completed events this week'
+              value={currentWeek.completedEvents.toString()}
+              sublabel='From recorded status changes'
+            />
+            <MetricCard
+              icon={<TrendingUp aria-hidden />}
+              label='Estimated completion added'
+              value={formatMinutes(currentWeek.estimatedCompletionAddedMinutes)}
+              sublabel='From completed event estimates'
+            />
+          </section>
+
+          {currentWeek.progressChangeCount === 0 ? (
+            <NoCurrentWeekActivityState />
+          ) : null}
+
+          <WeeklyTrendSection
+            weeks={model.history.weeklyTrends}
+            maxProgressChanges={model.history.maxWeeklyProgressChanges}
+          />
+        </>
+      )}
+    </section>
+  );
+}
+
+function NoHistoricalActivityState() {
+  return (
+    <Surface variant='inset'>
+      <div className='space-y-2'>
+        <h3 className='text-base font-semibold text-foreground'>
+          No recorded activity yet
+        </h3>
+        <p className='text-sm leading-6 text-muted-foreground'>
+          Streaks and weekly summaries start after task progress changes are
+          recorded. Earlier study activity is not backfilled.
+        </p>
+      </div>
+    </Surface>
+  );
+}
+
+function NoCurrentWeekActivityState() {
+  return (
+    <Surface variant='inset'>
+      <div className='space-y-2'>
+        <h3 className='text-base font-semibold text-foreground'>
+          No activity recorded this week
+        </h3>
+        <p className='text-sm leading-6 text-muted-foreground'>
+          Weekly summaries update when task progress changes are recorded.
         </p>
       </div>
     </Surface>
@@ -192,6 +286,116 @@ function PlanCompletionSection({ plans }: { plans: UsageAnalyticsPlanRow[] }) {
         ))}
       </div>
     </Surface>
+  );
+}
+
+function WeeklyTrendSection({
+  weeks,
+  maxProgressChanges,
+}: {
+  weeks: UsageAnalyticsWeekRow[];
+  maxProgressChanges: number;
+}) {
+  return (
+    <Surface>
+      <div className='mb-5 space-y-2'>
+        <h2 className='text-lg font-semibold text-foreground'>Weekly trend</h2>
+        <p className='text-sm leading-6 text-muted-foreground'>
+          Progress changes and completion events from recorded activity history.
+        </p>
+      </div>
+
+      <div className='space-y-4'>
+        {weeks.map((week) => (
+          <WeeklyTrendRow
+            key={week.weekStartDate}
+            week={week}
+            maxProgressChanges={maxProgressChanges}
+          />
+        ))}
+      </div>
+    </Surface>
+  );
+}
+
+function WeeklyTrendRow({
+  week,
+  maxProgressChanges,
+}: {
+  week: UsageAnalyticsWeekRow;
+  maxProgressChanges: number;
+}) {
+  const width = `${Math.round(
+    (week.progressChangeCount / maxProgressChanges) * 100,
+  )}%`;
+
+  return (
+    <div className='grid gap-3 sm:grid-cols-[8rem_minmax(0,1fr)_12rem] sm:items-center'>
+      <div>
+        <p className='text-sm font-medium text-foreground'>{week.label}</p>
+        {week.isCurrentWeek ? (
+          <p className='text-xs text-muted-foreground'>Current week</p>
+        ) : null}
+      </div>
+      <div className='h-2 overflow-hidden rounded-full bg-muted'>
+        <div className='h-full rounded-full bg-primary' style={{ width }} />
+      </div>
+      <p className='text-sm text-muted-foreground tabular-nums sm:text-right'>
+        {week.progressChangeCount} changes · {week.completedEvents} completed
+      </p>
+    </div>
+  );
+}
+
+function PlanActivitySection({ plans }: { plans: UsageAnalyticsPlanRow[] }) {
+  return (
+    <Surface>
+      <div className='mb-5 space-y-2'>
+        <h2 className='text-lg font-semibold text-foreground'>Plan activity</h2>
+        <p className='text-sm leading-6 text-muted-foreground'>
+          Per-plan streaks and this week&apos;s recorded progress changes.
+        </p>
+      </div>
+
+      <div className='divide-y divide-border'>
+        {plans.map((plan) => (
+          <PlanActivityRow key={plan.id} plan={plan} />
+        ))}
+      </div>
+    </Surface>
+  );
+}
+
+function PlanActivityRow({ plan }: { plan: UsageAnalyticsPlanRow }) {
+  return (
+    <article className='grid gap-4 py-5 first:pt-0 last:pb-0 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,24rem)] lg:items-center'>
+      <div className='min-w-0'>
+        <h3 className='text-base font-semibold text-foreground'>
+          {plan.topic}
+        </h3>
+        <p className='mt-1 text-sm text-muted-foreground'>
+          {plan.activeDaysThisWeek === 0
+            ? 'No progress changes recorded this week.'
+            : `${formatDayCount(plan.activeDaysThisWeek)} active this week.`}
+        </p>
+      </div>
+
+      <dl className='grid grid-cols-2 gap-3 text-sm sm:grid-cols-4 lg:grid-cols-2'>
+        <Metric label='Streak' value={formatDayCount(plan.currentStreakDays)} />
+        <Metric
+          label='Active days'
+          value={plan.activeDaysThisWeek.toString()}
+        />
+        <Metric
+          label='Completed'
+          value={plan.completedEventsThisWeek.toString()}
+        />
+        <Metric
+          label='Est. added'
+          value={formatMinutes(plan.estimatedCompletionAddedThisWeek)}
+        />
+      </dl>
+    </article>
   );
 }
 
@@ -255,4 +459,8 @@ function ProgressBar({ value }: { value: number }) {
       />
     </div>
   );
+}
+
+function formatDayCount(days: number): string {
+  return `${days} ${days === 1 ? 'day' : 'days'}`;
 }

--- a/src/app/(app)/analytics/usage/usage-analytics-model.ts
+++ b/src/app/(app)/analytics/usage/usage-analytics-model.ts
@@ -1,5 +1,24 @@
 import type { LightweightPlanSummary } from '@/shared/types/db.types';
 
+type ActivityStatus = 'not_started' | 'in_progress' | 'completed';
+
+export type UsageAnalyticsActivityEvent = {
+  planId: string;
+  status: ActivityStatus;
+  taskEstimatedMinutes: number;
+  occurredAt: Date;
+};
+
+export type UsageAnalyticsWeekRow = {
+  weekStartDate: string;
+  label: string;
+  activeDays: number;
+  progressChangeCount: number;
+  completedEvents: number;
+  estimatedCompletionAddedMinutes: number;
+  isCurrentWeek: boolean;
+};
+
 export type UsageAnalyticsPlanRow = {
   id: string;
   topic: string;
@@ -10,6 +29,10 @@ export type UsageAnalyticsPlanRow = {
   totalModules: number;
   completedMinutes: number;
   totalMinutes: number;
+  currentStreakDays: number;
+  activeDaysThisWeek: number;
+  completedEventsThisWeek: number;
+  estimatedCompletionAddedThisWeek: number;
 };
 
 export type UsageAnalyticsModel = {
@@ -23,16 +46,204 @@ export type UsageAnalyticsModel = {
   moduleCompletionPercent: number;
   completedMinutes: number;
   totalMinutes: number;
+  analyticsTimezone: string;
+  history: {
+    hasActivity: boolean;
+    currentStreakDays: number;
+    longestStreakDays: number;
+    currentWeek: UsageAnalyticsWeekRow;
+    weeklyTrends: UsageAnalyticsWeekRow[];
+    maxWeeklyProgressChanges: number;
+  };
 };
+
+type BuildUsageAnalyticsOptions = {
+  activityEvents?: UsageAnalyticsActivityEvent[];
+  analyticsTimezone?: string;
+  referenceDate?: Date;
+};
+
+type MutableWeekRow = Omit<UsageAnalyticsWeekRow, 'activeDays'> & {
+  activeDayKeys: Set<string>;
+};
+
+type MutablePlanHistory = {
+  dayKeys: Set<string>;
+  activeDaysThisWeek: Set<string>;
+  completedEventsThisWeek: number;
+  estimatedCompletionAddedThisWeek: number;
+};
+
+const DEFAULT_ANALYTICS_TIMEZONE = 'UTC';
+const WEEK_TREND_COUNT = 8;
 
 function completionPercent(completed: number, total: number): number {
   if (total <= 0) return 0;
   return completed >= total ? 100 : Math.floor((completed / total) * 100);
 }
 
+function normalizeTimeZone(value: string | undefined): string {
+  if (!value) return DEFAULT_ANALYTICS_TIMEZONE;
+  try {
+    Intl.DateTimeFormat('en-US', { timeZone: value }).format(new Date(0));
+    return value;
+  } catch {
+    return DEFAULT_ANALYTICS_TIMEZONE;
+  }
+}
+
+function dateKeyInTimeZone(date: Date, timeZone: string): string {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(date);
+  const year = parts.find((part) => part.type === 'year')?.value;
+  const month = parts.find((part) => part.type === 'month')?.value;
+  const day = parts.find((part) => part.type === 'day')?.value;
+
+  if (!year || !month || !day) {
+    throw new Error('Unable to format analytics date key');
+  }
+
+  return `${year}-${month}-${day}`;
+}
+
+function dateFromKey(dateKey: string): Date {
+  const [year, month, day] = dateKey.split('-').map(Number);
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function addDays(dateKey: string, days: number): string {
+  const date = dateFromKey(dateKey);
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString().slice(0, 10);
+}
+
+function weekStartKey(dateKey: string): string {
+  const date = dateFromKey(dateKey);
+  const mondayOffset = (date.getUTCDay() + 6) % 7;
+  date.setUTCDate(date.getUTCDate() - mondayOffset);
+  return date.toISOString().slice(0, 10);
+}
+
+function formatWeekLabel(weekStartDate: string): string {
+  const weekEndDate = addDays(weekStartDate, 6);
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    timeZone: DEFAULT_ANALYTICS_TIMEZONE,
+  });
+
+  return `${formatter.format(dateFromKey(weekStartDate))}-${formatter.format(
+    dateFromKey(weekEndDate),
+  )}`;
+}
+
+function buildWeekRows(currentWeekStart: string): MutableWeekRow[] {
+  return Array.from({ length: WEEK_TREND_COUNT }, (_, index) => {
+    const weekStartDate = addDays(
+      currentWeekStart,
+      (index - WEEK_TREND_COUNT + 1) * 7,
+    );
+
+    return {
+      weekStartDate,
+      label: formatWeekLabel(weekStartDate),
+      activeDayKeys: new Set<string>(),
+      progressChangeCount: 0,
+      completedEvents: 0,
+      estimatedCompletionAddedMinutes: 0,
+      isCurrentWeek: weekStartDate === currentWeekStart,
+    };
+  });
+}
+
+function currentStreakDays(dayKeys: Set<string>, todayKey: string): number {
+  let cursor = dayKeys.has(todayKey) ? todayKey : addDays(todayKey, -1);
+  let streak = 0;
+
+  while (dayKeys.has(cursor)) {
+    streak += 1;
+    cursor = addDays(cursor, -1);
+  }
+
+  return streak;
+}
+
+function longestStreakDays(dayKeys: Set<string>): number {
+  let longest = 0;
+  let current = 0;
+  let previous: string | null = null;
+
+  for (const dayKey of [...dayKeys].sort()) {
+    current = previous && dayKey === addDays(previous, 1) ? current + 1 : 1;
+    longest = Math.max(longest, current);
+    previous = dayKey;
+  }
+
+  return longest;
+}
+
 export function buildUsageAnalyticsModel(
   summaries: LightweightPlanSummary[],
+  options: BuildUsageAnalyticsOptions = {},
 ): UsageAnalyticsModel {
+  const analyticsTimezone = normalizeTimeZone(options.analyticsTimezone);
+  const activityEvents = options.activityEvents ?? [];
+  const todayKey = dateKeyInTimeZone(
+    options.referenceDate ?? new Date(),
+    analyticsTimezone,
+  );
+  const currentWeekStart = weekStartKey(todayKey);
+  const weekRows = buildWeekRows(currentWeekStart);
+  const weekRowsByStart = new Map(
+    weekRows.map((row) => [row.weekStartDate, row]),
+  );
+  const globalDayKeys = new Set<string>();
+  const planHistoryById = new Map<string, MutablePlanHistory>();
+
+  for (const summary of summaries) {
+    planHistoryById.set(summary.id, {
+      dayKeys: new Set<string>(),
+      activeDaysThisWeek: new Set<string>(),
+      completedEventsThisWeek: 0,
+      estimatedCompletionAddedThisWeek: 0,
+    });
+  }
+
+  for (const event of activityEvents) {
+    const dayKey = dateKeyInTimeZone(event.occurredAt, analyticsTimezone);
+    const eventWeekStart = weekStartKey(dayKey);
+    const weekRow = weekRowsByStart.get(eventWeekStart);
+    const isCompletedEvent = event.status === 'completed';
+
+    globalDayKeys.add(dayKey);
+
+    if (weekRow) {
+      weekRow.activeDayKeys.add(dayKey);
+      weekRow.progressChangeCount += 1;
+      if (isCompletedEvent) {
+        weekRow.completedEvents += 1;
+        weekRow.estimatedCompletionAddedMinutes += event.taskEstimatedMinutes;
+      }
+    }
+
+    const planHistory = planHistoryById.get(event.planId);
+    if (!planHistory) continue;
+
+    planHistory.dayKeys.add(dayKey);
+    if (eventWeekStart === currentWeekStart) {
+      planHistory.activeDaysThisWeek.add(dayKey);
+      if (isCompletedEvent) {
+        planHistory.completedEventsThisWeek += 1;
+        planHistory.estimatedCompletionAddedThisWeek +=
+          event.taskEstimatedMinutes;
+      }
+    }
+  }
+
   const plans = summaries.map((summary) => ({
     id: summary.id,
     topic: summary.topic,
@@ -46,6 +257,16 @@ export function buildUsageAnalyticsModel(
     totalModules: summary.moduleCount,
     completedMinutes: summary.completedMinutes,
     totalMinutes: summary.totalMinutes,
+    currentStreakDays: currentStreakDays(
+      planHistoryById.get(summary.id)?.dayKeys ?? new Set<string>(),
+      todayKey,
+    ),
+    activeDaysThisWeek:
+      planHistoryById.get(summary.id)?.activeDaysThisWeek.size ?? 0,
+    completedEventsThisWeek:
+      planHistoryById.get(summary.id)?.completedEventsThisWeek ?? 0,
+    estimatedCompletionAddedThisWeek:
+      planHistoryById.get(summary.id)?.estimatedCompletionAddedThisWeek ?? 0,
   }));
 
   const totals = plans.reduce(
@@ -68,6 +289,21 @@ export function buildUsageAnalyticsModel(
     },
   );
 
+  const weeklyTrends = weekRows.map((row) => ({
+    weekStartDate: row.weekStartDate,
+    label: row.label,
+    activeDays: row.activeDayKeys.size,
+    progressChangeCount: row.progressChangeCount,
+    completedEvents: row.completedEvents,
+    estimatedCompletionAddedMinutes: row.estimatedCompletionAddedMinutes,
+    isCurrentWeek: row.isCurrentWeek,
+  }));
+  const currentWeek = weeklyTrends.find((row) => row.isCurrentWeek);
+
+  if (!currentWeek) {
+    throw new Error('Current analytics week missing from trend rows');
+  }
+
   return {
     plans,
     planCount: plans.length,
@@ -85,5 +321,17 @@ export function buildUsageAnalyticsModel(
     ),
     completedMinutes: totals.completedMinutes,
     totalMinutes: totals.totalMinutes,
+    analyticsTimezone,
+    history: {
+      hasActivity: activityEvents.length > 0,
+      currentStreakDays: currentStreakDays(globalDayKeys, todayKey),
+      longestStreakDays: longestStreakDays(globalDayKeys),
+      currentWeek,
+      weeklyTrends,
+      maxWeeklyProgressChanges: Math.max(
+        1,
+        ...weeklyTrends.map((row) => row.progressChangeCount),
+      ),
+    },
   };
 }

--- a/src/app/(app)/analytics/usage/usage-analytics-model.ts
+++ b/src/app/(app)/analytics/usage/usage-analytics-model.ts
@@ -1,10 +1,11 @@
-import type { LightweightPlanSummary } from '@/shared/types/db.types';
-
-type ActivityStatus = 'not_started' | 'in_progress' | 'completed';
+import type {
+  LightweightPlanSummary,
+  ProgressStatus,
+} from '@/shared/types/db.types';
 
 export type UsageAnalyticsActivityEvent = {
   planId: string;
-  status: ActivityStatus;
+  status: ProgressStatus;
   taskEstimatedMinutes: number;
   occurredAt: Date;
 };

--- a/src/app/(app)/analytics/usage/usage-analytics-timezone-sync.tsx
+++ b/src/app/(app)/analytics/usage/usage-analytics-timezone-sync.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { syncAnalyticsTimezoneAction } from './actions';
+import { useRouter } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+
+export function UsageAnalyticsTimezoneSync({
+  analyticsTimezone,
+}: {
+  analyticsTimezone: string;
+}) {
+  const router = useRouter();
+  const syncedRef = useRef(false);
+
+  useEffect(() => {
+    if (syncedRef.current) return;
+    syncedRef.current = true;
+
+    const browserTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    if (!browserTimezone || browserTimezone === analyticsTimezone) return;
+
+    void syncAnalyticsTimezoneAction(browserTimezone)
+      .then((updated) => {
+        if (updated) router.refresh();
+      })
+      .catch(() => {
+        // Best-effort preference sync; analytics still render with the stored timezone.
+      });
+  }, [analyticsTimezone, router]);
+
+  return null;
+}

--- a/src/app/(app)/settings/profile/components/profile-client.ts
+++ b/src/app/(app)/settings/profile/components/profile-client.ts
@@ -8,6 +8,7 @@ const profileSchema = z.object({
   subscriptionTier: z.string(),
   subscriptionStatus: z.string().nullable(),
   createdAt: z.string(),
+  analyticsTimezone: z.string(),
 });
 
 export type ProfileData = z.infer<typeof profileSchema>;

--- a/src/app/(app)/settings/profile/components/profile-client.ts
+++ b/src/app/(app)/settings/profile/components/profile-client.ts
@@ -8,7 +8,11 @@ const profileSchema = z.object({
   subscriptionTier: z.string(),
   subscriptionStatus: z.string().nullable(),
   createdAt: z.string(),
-  analyticsTimezone: z.string(),
+  analyticsTimezone: z
+    .string()
+    .nullable()
+    .optional()
+    .transform((value) => value ?? 'UTC'),
 });
 
 export type ProfileData = z.infer<typeof profileSchema>;

--- a/src/app/api/v1/user/profile/route.ts
+++ b/src/app/api/v1/user/profile/route.ts
@@ -17,6 +17,7 @@ type UserProfileResponse = Pick<
   | 'subscriptionTier'
   | 'subscriptionStatus'
   | 'createdAt'
+  | 'analyticsTimezone'
 >;
 
 function toUserProfileResponse(user: DbUser): UserProfileResponse {
@@ -27,6 +28,7 @@ function toUserProfileResponse(user: DbUser): UserProfileResponse {
     subscriptionTier: user.subscriptionTier,
     subscriptionStatus: user.subscriptionStatus,
     createdAt: user.createdAt,
+    analyticsTimezone: user.analyticsTimezone,
   };
 }
 
@@ -66,7 +68,10 @@ export const PUT = requestBoundary.route(
     const updatedRows = await db
       .update(users)
       .set({
-        name: parsed.data.name,
+        ...(parsed.data.name !== undefined ? { name: parsed.data.name } : {}),
+        ...(parsed.data.analyticsTimezone !== undefined
+          ? { analyticsTimezone: parsed.data.analyticsTimezone }
+          : {}),
         updatedAt: sql<Date>`now()`,
       })
       .where(eq(users.authUserId, actor.authUserId))

--- a/src/app/api/v1/user/profile/validation.ts
+++ b/src/app/api/v1/user/profile/validation.ts
@@ -2,6 +2,30 @@ import { z } from 'zod';
 
 export const USER_PROFILE_NAME_MAX_LENGTH = 100;
 
-export const updateUserProfileSchema = z.strictObject({
-  name: z.string().trim().min(1).max(USER_PROFILE_NAME_MAX_LENGTH).nullable(),
-});
+function isValidTimeZone(value: string): boolean {
+  try {
+    Intl.DateTimeFormat('en-US', { timeZone: value }).format(new Date(0));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export const updateUserProfileSchema = z
+  .strictObject({
+    name: z
+      .string()
+      .trim()
+      .min(1)
+      .max(USER_PROFILE_NAME_MAX_LENGTH)
+      .nullable()
+      .optional(),
+    analyticsTimezone: z.string().trim().refine(isValidTimeZone).optional(),
+  })
+  .refine(
+    (value) =>
+      value.name !== undefined || value.analyticsTimezone !== undefined,
+    {
+      message: 'At least one profile field is required',
+    },
+  );

--- a/src/lib/db/queries/tasks.ts
+++ b/src/lib/db/queries/tasks.ts
@@ -1,5 +1,6 @@
 import type {
   DbTask,
+  DbLearningActivityEvent,
   DbTaskProgress,
   TasksDbClient,
 } from '@/lib/db/queries/types/tasks.types';
@@ -7,8 +8,14 @@ import type { ProgressStatus } from '@/shared/types/db.types';
 import type { SQL } from 'drizzle-orm';
 
 import { getDb } from '@supabase/runtime';
-import { learningPlans, modules, taskProgress, tasks } from '@supabase/schema';
-import { and, eq, inArray, sql } from 'drizzle-orm';
+import {
+  learningActivityEvents,
+  learningPlans,
+  modules,
+  taskProgress,
+  tasks,
+} from '@supabase/schema';
+import { and, asc, eq, inArray, sql } from 'drizzle-orm';
 
 interface TaskProgressBatchScope {
   planId?: string;
@@ -52,6 +59,19 @@ export async function getAllTasksInPlan(
     eq(learningPlans.id, planId),
   );
   return rows.map((row) => row.task);
+}
+
+export async function getLearningActivityEventsForUser(
+  userId: string,
+  dbClient?: TasksDbClient,
+): Promise<DbLearningActivityEvent[]> {
+  const client = dbClient ?? getDb();
+
+  return client
+    .select()
+    .from(learningActivityEvents)
+    .where(eq(learningActivityEvents.userId, userId))
+    .orderBy(asc(learningActivityEvents.occurredAt));
 }
 
 /**

--- a/src/lib/db/queries/users.ts
+++ b/src/lib/db/queries/users.ts
@@ -73,6 +73,7 @@ function isDbUser(user: unknown): user is DbUser {
     typeof maybeUser.monthlyExportCount === 'number' &&
     maybeUser.createdAt instanceof Date &&
     maybeUser.updatedAt instanceof Date &&
+    typeof maybeUser.analyticsTimezone === 'string' &&
     isOptionalString(maybeUser.name) &&
     isOptionalString(maybeUser.stripeCustomerId) &&
     isOptionalString(maybeUser.stripeSubscriptionId) &&

--- a/supabase/migrations/0037_add_user_analytics_timezone.sql
+++ b/supabase/migrations/0037_add_user_analytics_timezone.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "users" ADD COLUMN "analytics_timezone" text DEFAULT 'UTC' NOT NULL;--> statement-breakpoint
+REVOKE UPDATE ON "users" FROM authenticated;--> statement-breakpoint
+GRANT UPDATE (name, preferred_ai_model, analytics_timezone, updated_at) ON "users" TO authenticated;

--- a/supabase/migrations/meta/0037_snapshot.json
+++ b/supabase/migrations/meta/0037_snapshot.json
@@ -1,0 +1,2434 @@
+{
+  "id": "46c1eabf-4a90-492c-9fdb-e67f81fffd7d",
+  "prevId": "e4b2c3ab-d2b4-4f5d-b451-6a983e7e2f0b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.oauth_state_tokens": {
+      "name": "oauth_state_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "state_token_hash": {
+          "name": "state_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_state_tokens_hash_idx": {
+          "name": "oauth_state_tokens_hash_idx",
+          "columns": [
+            {
+              "expression": "state_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_state_tokens_expires_at_idx": {
+          "name": "oauth_state_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "oauth_state_tokens_insert": {
+          "name": "oauth_state_tokens_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"oauth_state_tokens\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'"
+        },
+        "oauth_state_tokens_select": {
+          "name": "oauth_state_tokens_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"oauth_state_tokens\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'"
+        },
+        "oauth_state_tokens_delete": {
+          "name": "oauth_state_tokens_delete",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"oauth_state_tokens\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.job_queue": {
+      "name": "job_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "job_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_job_queue_pending_claim": {
+          "name": "idx_job_queue_pending_claim",
+          "columns": [
+            {
+              "expression": "job_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"job_queue\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_job_queue_user_id": {
+          "name": "idx_job_queue_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_job_queue_plan_id": {
+          "name": "idx_job_queue_plan_id",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_job_queue_created_at": {
+          "name": "idx_job_queue_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "job_queue_plan_id_learning_plans_id_fk": {
+          "name": "job_queue_plan_id_learning_plans_id_fk",
+          "tableFrom": "job_queue",
+          "tableTo": "learning_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "job_queue_user_id_users_id_fk": {
+          "name": "job_queue_user_id_users_id_fk",
+          "tableFrom": "job_queue",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "job_queue_select_own": {
+          "name": "job_queue_select_own",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"job_queue\".\"user_id\" IN (\n        SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n      )"
+        }
+      },
+      "checkConstraints": {
+        "attempts_check": {
+          "name": "attempts_check",
+          "value": "\"job_queue\".\"attempts\" >= 0"
+        },
+        "max_attempts_check": {
+          "name": "max_attempts_check",
+          "value": "\"job_queue\".\"max_attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.generation_attempts": {
+      "name": "generation_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classification": {
+          "name": "classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modules_count": {
+          "name": "modules_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tasks_count": {
+          "name": "tasks_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "truncated_topic": {
+          "name": "truncated_topic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "truncated_notes": {
+          "name": "truncated_notes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "normalized_effort": {
+          "name": "normalized_effort",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "prompt_hash": {
+          "name": "prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_generation_attempts_plan_id": {
+          "name": "idx_generation_attempts_plan_id",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_generation_attempts_created_at_plan_id": {
+          "name": "idx_generation_attempts_created_at_plan_id",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "generation_attempts_plan_id_learning_plans_id_fk": {
+          "name": "generation_attempts_plan_id_learning_plans_id_fk",
+          "tableFrom": "generation_attempts",
+          "tableTo": "learning_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "generation_attempts_select": {
+          "name": "generation_attempts_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n    EXISTS (\n      SELECT 1 FROM \"learning_plans\"\n      WHERE \"learning_plans\".\"id\" = \"generation_attempts\".\"plan_id\"\n      AND \"learning_plans\".\"user_id\" IN (\n        SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n      )\n    )\n  "
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.learning_plans": {
+      "name": "learning_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_level": {
+          "name": "skill_level",
+          "type": "skill_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weekly_hours": {
+          "name": "weekly_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "learning_style": {
+          "name": "learning_style",
+          "type": "learning_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline_date": {
+          "name": "deadline_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "origin": {
+          "name": "origin",
+          "type": "plan_origin",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ai'"
+        },
+        "generation_status": {
+          "name": "generation_status",
+          "type": "generation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'generating'"
+        },
+        "is_quota_eligible": {
+          "name": "is_quota_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_learning_plans_user_created_at_desc": {
+          "name": "idx_learning_plans_user_created_at_desc",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_learning_plans_user_generation_status": {
+          "name": "idx_learning_plans_user_generation_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_learning_plans_user_origin": {
+          "name": "idx_learning_plans_user_origin",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "origin",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_learning_plans_user_quota_generation_status": {
+          "name": "idx_learning_plans_user_quota_generation_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_quota_eligible",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "learning_plans_user_id_users_id_fk": {
+          "name": "learning_plans_user_id_users_id_fk",
+          "tableFrom": "learning_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "learning_plans_select": {
+          "name": "learning_plans_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n    \"learning_plans\".\"user_id\" IN (\n      SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n    )\n  "
+        }
+      },
+      "checkConstraints": {
+        "weekly_hours_check": {
+          "name": "weekly_hours_check",
+          "value": "\"learning_plans\".\"weekly_hours\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.plan_schedules": {
+      "name": "plan_schedules",
+      "schema": "",
+      "columns": {
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_json": {
+          "name": "schedule_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputs_hash": {
+          "name": "inputs_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weekly_hours": {
+          "name": "weekly_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plan_schedules_plan_id_learning_plans_id_fk": {
+          "name": "plan_schedules_plan_id_learning_plans_id_fk",
+          "tableFrom": "plan_schedules",
+          "tableTo": "learning_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "plan_schedules_select": {
+          "name": "plan_schedules_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n    EXISTS (\n      SELECT 1 FROM \"learning_plans\"\n      WHERE \"learning_plans\".\"id\" = \"plan_schedules\".\"plan_id\"\n      AND \"learning_plans\".\"user_id\" IN (\n        SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n      )\n    )\n  "
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.stripe_webhook_events": {
+      "name": "stripe_webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "livemode": {
+          "name": "livemode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_stripe_webhook_events_created_at": {
+          "name": "idx_stripe_webhook_events_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stripe_webhook_events_event_id_unique": {
+          "name": "stripe_webhook_events_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.learning_activity_events": {
+      "name": "learning_activity_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_status": {
+          "name": "previous_status",
+          "type": "progress_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "progress_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_estimated_minutes": {
+          "name": "task_estimated_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_learning_activity_events_user_occurred": {
+          "name": "idx_learning_activity_events_user_occurred",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_learning_activity_events_user_plan_occurred": {
+          "name": "idx_learning_activity_events_user_plan_occurred",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_learning_activity_events_task_occurred": {
+          "name": "idx_learning_activity_events_task_occurred",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "learning_activity_events_user_id_users_id_fk": {
+          "name": "learning_activity_events_user_id_users_id_fk",
+          "tableFrom": "learning_activity_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "learning_activity_events_plan_id_learning_plans_id_fk": {
+          "name": "learning_activity_events_plan_id_learning_plans_id_fk",
+          "tableFrom": "learning_activity_events",
+          "tableTo": "learning_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "learning_activity_events_module_id_modules_id_fk": {
+          "name": "learning_activity_events_module_id_modules_id_fk",
+          "tableFrom": "learning_activity_events",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "learning_activity_events_task_id_tasks_id_fk": {
+          "name": "learning_activity_events_task_id_tasks_id_fk",
+          "tableFrom": "learning_activity_events",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "learning_activity_events_select_own": {
+          "name": "learning_activity_events_select_own",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n    \"learning_activity_events\".\"user_id\" IN (\n      SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n    )\n  "
+        }
+      },
+      "checkConstraints": {
+        "learning_activity_events_task_estimated_minutes_nonneg": {
+          "name": "learning_activity_events_task_estimated_minutes_nonneg",
+          "value": "\"learning_activity_events\".\"task_estimated_minutes\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_minutes": {
+          "name": "estimated_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_generation_status": {
+          "name": "lesson_generation_status",
+          "type": "lesson_generation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_generated'"
+        },
+        "lesson_generation_started_at": {
+          "name": "lesson_generation_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lesson_generation_completed_at": {
+          "name": "lesson_generation_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lesson_generation_failed_at": {
+          "name": "lesson_generation_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lesson_generation_error": {
+          "name": "lesson_generation_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lesson_generation_metadata": {
+          "name": "lesson_generation_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "modules_plan_id_learning_plans_id_fk": {
+          "name": "modules_plan_id_learning_plans_id_fk",
+          "tableFrom": "modules",
+          "tableTo": "learning_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "modules_plan_id_order_unique": {
+          "name": "modules_plan_id_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "plan_id",
+            "order"
+          ]
+        }
+      },
+      "policies": {
+        "modules_select_own_plan": {
+          "name": "modules_select_own_plan",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n    EXISTS (\n      SELECT 1 FROM \"learning_plans\"\n      WHERE \"learning_plans\".\"id\" = \"modules\".\"plan_id\"\n      AND \"learning_plans\".\"user_id\" IN (\n        SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n      )\n    )\n  "
+        }
+      },
+      "checkConstraints": {
+        "order_check": {
+          "name": "order_check",
+          "value": "\"modules\".\"order\" >= 1"
+        },
+        "estimated_minutes_check": {
+          "name": "estimated_minutes_check",
+          "value": "\"modules\".\"estimated_minutes\" >= 0"
+        },
+        "module_lesson_generation_error_length": {
+          "name": "module_lesson_generation_error_length",
+          "value": "(\"modules\".\"lesson_generation_error\" IS NULL OR char_length(\"modules\".\"lesson_generation_error\") <= 4000)"
+        },
+        "module_title_length": {
+          "name": "module_title_length",
+          "value": "char_length(\"modules\".\"title\") <= 500"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.resources": {
+      "name": "resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "resource_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_cents": {
+          "name": "cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_resources_type": {
+          "name": "idx_resources_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "resources_url_unique": {
+          "name": "resources_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {
+        "resources_select_auth": {
+          "name": "resources_select_auth",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {
+        "duration_minutes_check": {
+          "name": "duration_minutes_check",
+          "value": "\"resources\".\"duration_minutes\" >= 0"
+        },
+        "cost_cents_check": {
+          "name": "cost_cents_check",
+          "value": "\"resources\".\"cost_cents\" >= 0"
+        },
+        "resource_title_length": {
+          "name": "resource_title_length",
+          "value": "char_length(\"resources\".\"title\") <= 500"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.task_progress": {
+      "name": "task_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "progress_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_task_progress_user_id": {
+          "name": "idx_task_progress_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_task_progress_task_id": {
+          "name": "idx_task_progress_task_id",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_task_progress_user_task": {
+          "name": "idx_task_progress_user_task",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_progress_task_id_tasks_id_fk": {
+          "name": "task_progress_task_id_tasks_id_fk",
+          "tableFrom": "task_progress",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_progress_user_id_users_id_fk": {
+          "name": "task_progress_user_id_users_id_fk",
+          "tableFrom": "task_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_progress_task_id_user_id_unique": {
+          "name": "task_progress_task_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "task_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {
+        "task_progress_select_own": {
+          "name": "task_progress_select_own",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n    \"task_progress\".\"user_id\" IN (\n      SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n    )\n  "
+        },
+        "task_progress_insert_own": {
+          "name": "task_progress_insert_own",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\n          (\n    \"task_progress\".\"user_id\" IN (\n      SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n    )\n  )\n          AND (\n    EXISTS (\n      SELECT 1 FROM \"tasks\"\n      JOIN \"modules\" ON \"modules\".\"id\" = \"tasks\".\"module_id\"\n      JOIN \"learning_plans\" ON \"learning_plans\".\"id\" = \"modules\".\"plan_id\"\n      WHERE \"tasks\".\"id\" = \"task_progress\".\"task_id\"\n      AND (\n    \"learning_plans\".\"user_id\" IN (\n      SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n    )\n  )\n    )\n  )\n        "
+        },
+        "task_progress_update_own": {
+          "name": "task_progress_update_own",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n    \"task_progress\".\"user_id\" IN (\n      SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n    )\n  ",
+          "withCheck": "\n        (\n    \"task_progress\".\"user_id\" IN (\n      SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n    )\n  )\n        AND (\n    EXISTS (\n      SELECT 1 FROM \"tasks\"\n      JOIN \"modules\" ON \"modules\".\"id\" = \"tasks\".\"module_id\"\n      JOIN \"learning_plans\" ON \"learning_plans\".\"id\" = \"modules\".\"plan_id\"\n      WHERE \"tasks\".\"id\" = \"task_progress\".\"task_id\"\n      AND (\n    \"learning_plans\".\"user_id\" IN (\n      SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n    )\n  )\n    )\n  )\n      "
+        },
+        "task_progress_delete_own": {
+          "name": "task_progress_delete_own",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n    \"task_progress\".\"user_id\" IN (\n      SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n    )\n  "
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.task_resources": {
+      "name": "task_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_task_resources_resource_id": {
+          "name": "idx_task_resources_resource_id",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_resources_task_id_tasks_id_fk": {
+          "name": "task_resources_task_id_tasks_id_fk",
+          "tableFrom": "task_resources",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_resources_resource_id_resources_id_fk": {
+          "name": "task_resources_resource_id_resources_id_fk",
+          "tableFrom": "task_resources",
+          "tableTo": "resources",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_resources_task_id_resource_id_unique": {
+          "name": "task_resources_task_id_resource_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "task_id",
+            "resource_id"
+          ]
+        }
+      },
+      "policies": {
+        "task_resources_select_own_plan": {
+          "name": "task_resources_select_own_plan",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n    EXISTS (\n      SELECT 1 FROM \"tasks\"\n      JOIN \"modules\" ON \"modules\".\"id\" = \"tasks\".\"module_id\"\n      JOIN \"learning_plans\" ON \"learning_plans\".\"id\" = \"modules\".\"plan_id\"\n      WHERE \"tasks\".\"id\" = \"task_resources\".\"task_id\"\n      AND (\n    \"learning_plans\".\"user_id\" IN (\n      SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n    )\n  )\n    )\n  "
+        }
+      },
+      "checkConstraints": {
+        "order_check": {
+          "name": "order_check",
+          "value": "\"task_resources\".\"order\" >= 1"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_minutes": {
+          "name": "estimated_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_micro_explanation": {
+          "name": "has_micro_explanation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lesson_content": {
+          "name": "lesson_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lesson_content_updated_at": {
+          "name": "lesson_content_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_module_id_modules_id_fk": {
+          "name": "tasks_module_id_modules_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tasks_module_id_order_unique": {
+          "name": "tasks_module_id_order_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "module_id",
+            "order"
+          ]
+        }
+      },
+      "policies": {
+        "tasks_select_own_plan": {
+          "name": "tasks_select_own_plan",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n      EXISTS (\n        SELECT 1 FROM \"modules\"\n        WHERE \"modules\".\"id\" = \"tasks\".\"module_id\"\n        AND (\n    EXISTS (\n      SELECT 1 FROM \"learning_plans\"\n      WHERE \"learning_plans\".\"id\" = \"modules\".\"plan_id\"\n      AND \"learning_plans\".\"user_id\" IN (\n        SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n      )\n    )\n  )\n      )\n    "
+        }
+      },
+      "checkConstraints": {
+        "order_check": {
+          "name": "order_check",
+          "value": "\"tasks\".\"order\" >= 1"
+        },
+        "estimated_minutes_check": {
+          "name": "estimated_minutes_check",
+          "value": "\"tasks\".\"estimated_minutes\" >= 0"
+        },
+        "task_lesson_content_json_length": {
+          "name": "task_lesson_content_json_length",
+          "value": "(\"tasks\".\"lesson_content\" IS NULL OR length(\"tasks\".\"lesson_content\"::text) <= 262144)"
+        },
+        "task_title_length": {
+          "name": "task_title_length",
+          "value": "char_length(\"tasks\".\"title\") <= 500"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.ai_usage_events": {
+      "name": "ai_usage_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_cents": {
+          "name": "cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "provider_cost_microusd": {
+          "name": "provider_cost_microusd",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_pricing_snapshot": {
+          "name": "model_pricing_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ai_usage_created_at": {
+          "name": "idx_ai_usage_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_events_user_created_at": {
+          "name": "idx_ai_usage_events_user_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_usage_events_user_id_users_id_fk": {
+          "name": "ai_usage_events_user_id_users_id_fk",
+          "tableFrom": "ai_usage_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "ai_usage_events_select_own": {
+          "name": "ai_usage_events_select_own",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n    \"ai_usage_events\".\"user_id\" IN (\n      SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n    )\n  "
+        }
+      },
+      "checkConstraints": {
+        "ai_usage_events_input_tokens_nonneg": {
+          "name": "ai_usage_events_input_tokens_nonneg",
+          "value": "\"ai_usage_events\".\"input_tokens\" >= 0"
+        },
+        "ai_usage_events_output_tokens_nonneg": {
+          "name": "ai_usage_events_output_tokens_nonneg",
+          "value": "\"ai_usage_events\".\"output_tokens\" >= 0"
+        },
+        "ai_usage_events_cost_cents_nonneg": {
+          "name": "ai_usage_events_cost_cents_nonneg",
+          "value": "\"ai_usage_events\".\"cost_cents\" >= 0"
+        },
+        "ai_usage_events_provider_cost_microusd_nonneg": {
+          "name": "ai_usage_events_provider_cost_microusd_nonneg",
+          "value": "\"ai_usage_events\".\"provider_cost_microusd\" IS NULL OR \"ai_usage_events\".\"provider_cost_microusd\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.usage_metrics": {
+      "name": "usage_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plans_generated": {
+          "name": "plans_generated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "regenerations_used": {
+          "name": "regenerations_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "exports_used": {
+          "name": "exports_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lesson_modules_generated": {
+          "name": "lesson_modules_generated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "usage_metrics_user_id_users_id_fk": {
+          "name": "usage_metrics_user_id_users_id_fk",
+          "tableFrom": "usage_metrics",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "usage_metrics_user_id_month_unique": {
+          "name": "usage_metrics_user_id_month_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "month"
+          ]
+        }
+      },
+      "policies": {
+        "usage_metrics_select_own": {
+          "name": "usage_metrics_select_own",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\n    \"usage_metrics\".\"user_id\" IN (\n      SELECT id FROM \"users\" WHERE \"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'\n    )\n  "
+        }
+      },
+      "checkConstraints": {
+        "plans_generated_nonneg": {
+          "name": "plans_generated_nonneg",
+          "value": "\"usage_metrics\".\"plans_generated\" >= 0"
+        },
+        "regenerations_used_nonneg": {
+          "name": "regenerations_used_nonneg",
+          "value": "\"usage_metrics\".\"regenerations_used\" >= 0"
+        },
+        "exports_used_nonneg": {
+          "name": "exports_used_nonneg",
+          "value": "\"usage_metrics\".\"exports_used\" >= 0"
+        },
+        "lesson_modules_generated_nonneg": {
+          "name": "lesson_modules_generated_nonneg",
+          "value": "\"usage_metrics\".\"lesson_modules_generated\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_tier": {
+          "name": "subscription_tier",
+          "type": "subscription_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_period_end": {
+          "name": "subscription_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "monthly_export_count": {
+          "name": "monthly_export_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preferred_ai_model": {
+          "name": "preferred_ai_model",
+          "type": "preferred_ai_model",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analytics_timezone": {
+          "name": "analytics_timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_auth_user_id_unique": {
+          "name": "users_auth_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth_user_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_stripe_customer_id_unique": {
+          "name": "users_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "users_stripe_subscription_id_unique": {
+          "name": "users_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {
+        "users_select_own": {
+          "name": "users_select_own",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'"
+        },
+        "users_insert_own": {
+          "name": "users_insert_own",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'"
+        },
+        "users_update_own": {
+          "name": "users_update_own",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'",
+          "withCheck": "\"users\".\"auth_user_id\" = current_setting('request.jwt.claims', true)::json->>'sub'"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "public.generation_status": {
+      "name": "generation_status",
+      "schema": "public",
+      "values": [
+        "generating",
+        "pending_retry",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.job_type": {
+      "name": "job_type",
+      "schema": "public",
+      "values": [
+        "plan_regeneration"
+      ]
+    },
+    "public.learning_style": {
+      "name": "learning_style",
+      "schema": "public",
+      "values": [
+        "reading",
+        "video",
+        "practice",
+        "mixed"
+      ]
+    },
+    "public.lesson_generation_status": {
+      "name": "lesson_generation_status",
+      "schema": "public",
+      "values": [
+        "not_generated",
+        "generating",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.plan_origin": {
+      "name": "plan_origin",
+      "schema": "public",
+      "values": [
+        "ai",
+        "template",
+        "manual"
+      ]
+    },
+    "public.preferred_ai_model": {
+      "name": "preferred_ai_model",
+      "schema": "public",
+      "values": [
+        "google/gemini-2.0-flash-exp:free",
+        "openai/gpt-oss-20b:free",
+        "alibaba/tongyi-deepresearch-30b-a3b:free",
+        "anthropic/claude-haiku-4.5",
+        "google/gemini-2.5-flash-lite",
+        "google/gemini-3-flash-preview",
+        "google/gemini-3-pro-preview",
+        "anthropic/claude-sonnet-4.5",
+        "openai/gpt-4o-mini-2024-07-18",
+        "openai/gpt-4o-mini-search-preview",
+        "openai/gpt-4o",
+        "openai/gpt-5.1",
+        "openai/gpt-5.2"
+      ]
+    },
+    "public.progress_status": {
+      "name": "progress_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "in_progress",
+        "completed"
+      ]
+    },
+    "public.resource_type": {
+      "name": "resource_type",
+      "schema": "public",
+      "values": [
+        "video",
+        "article",
+        "course",
+        "doc",
+        "other"
+      ]
+    },
+    "public.skill_level": {
+      "name": "skill_level",
+      "schema": "public",
+      "values": [
+        "beginner",
+        "intermediate",
+        "advanced"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "canceled",
+        "past_due",
+        "trialing"
+      ]
+    },
+    "public.subscription_tier": {
+      "name": "subscription_tier",
+      "schema": "public",
+      "values": [
+        "free",
+        "starter",
+        "pro"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1782430837257,
       "tag": "0036_add_learning_activity_events",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1782437094261,
+      "tag": "0037_add_user_analytics_timezone",
+      "breakpoints": true
     }
   ]
 }

--- a/supabase/privileges/users-authenticated-update-columns.ts
+++ b/supabase/privileges/users-authenticated-update-columns.ts
@@ -1,13 +1,14 @@
 /**
  * PostgreSQL column names the `authenticated` role may UPDATE on `public.users`.
  *
- * Must stay aligned with `supabase/migrations/0018_harden_users_update_columns.sql`.
+ * Must stay aligned with the latest effective migration grant for `public.users`.
  * Consumed by Testcontainers (`tests/setup/testcontainers.ts`) and
  * `tests/helpers/db/rls-bootstrap.ts` when mirroring production grants in ephemeral DBs.
  */
 export const USERS_AUTHENTICATED_UPDATE_COLUMNS = [
   'name',
   'preferred_ai_model',
+  'analytics_timezone',
   'updated_at',
 ] as const;
 

--- a/supabase/schema/tables/users.ts
+++ b/supabase/schema/tables/users.ts
@@ -37,6 +37,7 @@ export const users = pgTable(
     cancelAtPeriodEnd: boolean('cancel_at_period_end').notNull().default(false),
     monthlyExportCount: integer('monthly_export_count').notNull().default(0),
     preferredAiModel: preferredAiModelEnum('preferred_ai_model'),
+    analyticsTimezone: text('analytics_timezone').notNull().default('UTC'),
     ...timestampFields,
   },
   (table) => [

--- a/tests/fixtures/profile.ts
+++ b/tests/fixtures/profile.ts
@@ -9,6 +9,7 @@ interface ProfileFixture {
   subscriptionTier: string;
   subscriptionStatus: string;
   createdAt: string;
+  analyticsTimezone: string;
 }
 
 export function buildProfile(
@@ -21,6 +22,7 @@ export function buildProfile(
     subscriptionTier: 'free',
     subscriptionStatus: 'active',
     createdAt: '2025-06-15T10:00:00.000Z',
+    analyticsTimezone: 'UTC',
     ...overrides,
   };
 }

--- a/tests/fixtures/users.ts
+++ b/tests/fixtures/users.ts
@@ -43,7 +43,10 @@ function resolveSubscriptionLifecycle(
 }
 
 type CreateTestUserParams = Partial<
-  Pick<UserInsert, 'authUserId' | 'email' | 'name' | 'subscriptionTier'> &
+  Pick<
+    UserInsert,
+    'analyticsTimezone' | 'authUserId' | 'email' | 'name' | 'subscriptionTier'
+  > &
     SubscriptionLifecycleFields
 >;
 
@@ -106,6 +109,7 @@ export function buildUserFixture(overrides: Partial<UserRow> = {}): UserRow {
     }),
     monthlyExportCount: 0,
     preferredAiModel: null,
+    analyticsTimezone: 'UTC',
     createdAt: now,
     updatedAt: now,
     ...userOverrides,

--- a/tests/integration/api/user-profile.spec.ts
+++ b/tests/integration/api/user-profile.spec.ts
@@ -64,6 +64,7 @@ describe('GET /api/v1/user/profile', () => {
       email: 'profile@example.com',
       subscriptionTier: 'starter',
       subscriptionStatus: 'active',
+      analyticsTimezone: 'UTC',
     });
     expect(typeof body.id).toBe('string');
     expect(new Date(body.createdAt).toString()).not.toBe('Invalid Date');
@@ -118,6 +119,7 @@ describe('PUT /api/v1/user/profile', () => {
     expect(body).toMatchObject({
       name: 'New Name',
       email: 'update-profile@example.com',
+      analyticsTimezone: 'UTC',
     });
     expect(body).not.toHaveProperty('authUserId');
     expect(body).not.toHaveProperty('stripeCustomerId');
@@ -153,6 +155,29 @@ describe('PUT /api/v1/user/profile', () => {
       where: (fields, operators) => operators.eq(fields.authUserId, authUserId),
     });
     expect(updated?.name).toBeNull();
+  });
+
+  it('updates analytics timezone without requiring a name change', async () => {
+    const { PUT } = await import('@/app/api/v1/user/profile/route');
+    const request = new NextRequest(
+      'http://localhost:3000/api/v1/user/profile',
+      {
+        method: 'PUT',
+        body: JSON.stringify({ analyticsTimezone: 'America/Chicago' }),
+      },
+    );
+
+    const response = await PUT(request);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.analyticsTimezone).toBe('America/Chicago');
+    expect(body.name).toBe('Before Update');
+
+    const updated = await db.query.users.findFirst({
+      where: (fields, operators) => operators.eq(fields.authUserId, authUserId),
+    });
+    expect(updated?.analyticsTimezone).toBe('America/Chicago');
   });
 
   it('returns 400 when PUT body is not valid JSON', async () => {
@@ -194,6 +219,23 @@ describe('PUT /api/v1/user/profile', () => {
     const body = await response.json();
     expect(body.code).toBe('VALIDATION_ERROR');
     expect(typeof body.error).toBe('string');
+  });
+
+  it('rejects invalid analytics timezones', async () => {
+    const { PUT } = await import('@/app/api/v1/user/profile/route');
+    const request = new NextRequest(
+      'http://localhost:3000/api/v1/user/profile',
+      {
+        method: 'PUT',
+        body: JSON.stringify({ analyticsTimezone: 'Not/AZone' }),
+      },
+    );
+
+    const response = await PUT(request);
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.code).toBe('VALIDATION_ERROR');
   });
 
   it('rejects names longer than 100 characters', async () => {

--- a/tests/integration/db/tasks.queries.spec.ts
+++ b/tests/integration/db/tasks.queries.spec.ts
@@ -1,4 +1,7 @@
-import { setTaskProgressBatch } from '@/lib/db/queries/tasks';
+import {
+  getLearningActivityEventsForUser,
+  setTaskProgressBatch,
+} from '@/lib/db/queries/tasks';
 import {
   learningActivityEvents,
   learningPlans,
@@ -10,9 +13,13 @@ import { db } from '@supabase/service-role';
 import { createTestModule, createTestTask } from '@tests/fixtures/modules';
 import { createTestPlan } from '@tests/fixtures/plans';
 import { ensureUser } from '@tests/helpers/db/users';
+import {
+  cleanupTrackedRlsClients,
+  createRlsDbForUser,
+} from '@tests/helpers/rls';
 import { buildTestAuthUserId, buildTestEmail } from '@tests/helpers/testIds';
 import { asc, eq } from 'drizzle-orm';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 const RECENT_TIMESTAMP_THRESHOLD_MS = 10_000;
 
@@ -30,6 +37,10 @@ function expectRecentTimestamp(value: Date) {
 }
 
 describe('Task Queries', () => {
+  afterEach(async () => {
+    await cleanupTrackedRlsClients();
+  });
+
   it('rejects single-item writes when module scope does not match the task module', async () => {
     const authUserId = buildTestAuthUserId('db-tasks-scope');
     const userId = await ensureUser({
@@ -128,6 +139,61 @@ describe('Task Queries', () => {
     });
     expectDate(secondEvent.occurredAt, 'second occurredAt');
     expectRecentTimestamp(secondEvent.occurredAt);
+  });
+
+  it('returns only owner-visible learning activity events from the read path', async () => {
+    const ownerAuthUserId = buildTestAuthUserId('db-tasks-activity-owner');
+    const ownerUserId = await ensureUser({
+      authUserId: ownerAuthUserId,
+      email: buildTestEmail(ownerAuthUserId),
+    });
+    const otherAuthUserId = buildTestAuthUserId('db-tasks-activity-other');
+    const otherUserId = await ensureUser({
+      authUserId: otherAuthUserId,
+      email: buildTestEmail(otherAuthUserId),
+    });
+    const ownerPlan = await createTestPlan({
+      userId: ownerUserId,
+      topic: 'owner activity',
+    });
+    const ownerModule = await createTestModule({ planId: ownerPlan.id });
+    const ownerTask = await createTestTask({ moduleId: ownerModule.id });
+    const otherPlan = await createTestPlan({
+      userId: otherUserId,
+      topic: 'other activity',
+    });
+    const otherModule = await createTestModule({ planId: otherPlan.id });
+    const otherTask = await createTestTask({ moduleId: otherModule.id });
+
+    await setTaskProgressBatch(
+      ownerUserId,
+      [{ taskId: ownerTask.id, status: 'completed' }],
+      db,
+    );
+    await setTaskProgressBatch(
+      otherUserId,
+      [{ taskId: otherTask.id, status: 'completed' }],
+      db,
+    );
+
+    const ownerDb = await createRlsDbForUser(ownerAuthUserId);
+    const ownerRows = await getLearningActivityEventsForUser(
+      ownerUserId,
+      ownerDb,
+    );
+    const crossTenantRows = await getLearningActivityEventsForUser(
+      otherUserId,
+      ownerDb,
+    );
+
+    expect(ownerRows).toHaveLength(1);
+    expect(ownerRows[0]).toMatchObject({
+      userId: ownerUserId,
+      planId: ownerPlan.id,
+      taskId: ownerTask.id,
+      status: 'completed',
+    });
+    expect(crossTenantRows).toHaveLength(0);
   });
 
   it.each([

--- a/tests/unit/app/analytics/usage-analytics-model.spec.ts
+++ b/tests/unit/app/analytics/usage-analytics-model.spec.ts
@@ -2,6 +2,7 @@ import type { LightweightPlanSummary } from '@/shared/types/db.types';
 
 import {
   buildUsageAnalyticsModel,
+  type UsageAnalyticsActivityEvent,
   type UsageAnalyticsModel,
 } from '@/app/(app)/analytics/usage/usage-analytics-model';
 import { describe, expect, it } from 'vitest';
@@ -47,6 +48,18 @@ function pickTotals(model: UsageAnalyticsModel) {
   };
 }
 
+function activityEvent(
+  overrides: Partial<UsageAnalyticsActivityEvent>,
+): UsageAnalyticsActivityEvent {
+  return {
+    planId: 'plan-1',
+    status: 'in_progress',
+    taskEstimatedMinutes: 30,
+    occurredAt: new Date('2026-06-25T12:00:00.000Z'),
+    ...overrides,
+  };
+}
+
 describe('buildUsageAnalyticsModel', () => {
   it('returns zeroed analytics when no plans exist', () => {
     const model = buildUsageAnalyticsModel([]);
@@ -63,6 +76,9 @@ describe('buildUsageAnalyticsModel', () => {
       totalMinutes: 0,
     });
     expect(model.plans).toEqual([]);
+    expect(model.history.hasActivity).toBe(false);
+    expect(model.history.currentStreakDays).toBe(0);
+    expect(model.history.longestStreakDays).toBe(0);
   });
 
   it('keeps available plan scope when no tasks are completed', () => {
@@ -181,5 +197,166 @@ describe('buildUsageAnalyticsModel', () => {
     expect(model.totalMinutes).toBe(140);
     expect(model.plans[0].completedMinutes).toBe(25);
     expect(model.plans[0].totalMinutes).toBe(140);
+  });
+
+  it('buckets activity days in the analytics timezone', () => {
+    const model = buildUsageAnalyticsModel([planSummary({ id: 'plan-1' })], {
+      analyticsTimezone: 'America/Chicago',
+      referenceDate: new Date('2026-06-25T12:00:00.000Z'),
+      activityEvents: [
+        activityEvent({
+          occurredAt: new Date('2026-06-25T04:30:00.000Z'),
+        }),
+        activityEvent({
+          occurredAt: new Date('2026-06-25T05:30:00.000Z'),
+        }),
+      ],
+    });
+
+    expect(model.history.currentStreakDays).toBe(2);
+    expect(model.history.currentWeek.activeDays).toBe(2);
+    expect(model.plans[0].currentStreakDays).toBe(2);
+  });
+
+  it('counts the current streak through yesterday when today has no activity', () => {
+    const model = buildUsageAnalyticsModel([planSummary({ id: 'plan-1' })], {
+      referenceDate: new Date('2026-06-25T12:00:00.000Z'),
+      activityEvents: [
+        activityEvent({
+          occurredAt: new Date('2026-06-24T12:00:00.000Z'),
+        }),
+      ],
+    });
+
+    expect(model.history.currentStreakDays).toBe(1);
+  });
+
+  it('tracks broken streaks and longest streaks independently', () => {
+    const model = buildUsageAnalyticsModel([planSummary({ id: 'plan-1' })], {
+      referenceDate: new Date('2026-06-25T12:00:00.000Z'),
+      activityEvents: [
+        activityEvent({
+          occurredAt: new Date('2026-06-21T12:00:00.000Z'),
+        }),
+        activityEvent({
+          occurredAt: new Date('2026-06-22T12:00:00.000Z'),
+        }),
+        activityEvent({
+          occurredAt: new Date('2026-06-24T12:00:00.000Z'),
+        }),
+      ],
+    });
+
+    expect(model.history.currentStreakDays).toBe(1);
+    expect(model.history.longestStreakDays).toBe(2);
+  });
+
+  it('keeps global and per-plan streaks separate', () => {
+    const model = buildUsageAnalyticsModel(
+      [
+        planSummary({ id: 'plan-1', topic: 'React' }),
+        planSummary({ id: 'plan-2', topic: 'SQL' }),
+      ],
+      {
+        referenceDate: new Date('2026-06-25T12:00:00.000Z'),
+        activityEvents: [
+          activityEvent({
+            planId: 'plan-1',
+            occurredAt: new Date('2026-06-24T12:00:00.000Z'),
+          }),
+          activityEvent({
+            planId: 'plan-2',
+            occurredAt: new Date('2026-06-24T12:00:00.000Z'),
+          }),
+          activityEvent({
+            planId: 'plan-2',
+            occurredAt: new Date('2026-06-25T12:00:00.000Z'),
+          }),
+        ],
+      },
+    );
+
+    expect(model.history.currentStreakDays).toBe(2);
+    expect(model.plans).toMatchObject([
+      { topic: 'React', currentStreakDays: 1 },
+      { topic: 'SQL', currentStreakDays: 2 },
+    ]);
+  });
+
+  it('builds Monday-start weekly trend rows', () => {
+    const model = buildUsageAnalyticsModel([planSummary({ id: 'plan-1' })], {
+      referenceDate: new Date('2026-06-25T12:00:00.000Z'),
+      activityEvents: [
+        activityEvent({
+          occurredAt: new Date('2026-06-21T12:00:00.000Z'),
+        }),
+        activityEvent({
+          occurredAt: new Date('2026-06-22T12:00:00.000Z'),
+        }),
+        activityEvent({
+          occurredAt: new Date('2026-06-28T12:00:00.000Z'),
+        }),
+      ],
+    });
+
+    expect(model.history.weeklyTrends).toHaveLength(8);
+    expect(model.history.currentWeek).toMatchObject({
+      weekStartDate: '2026-06-22',
+      activeDays: 2,
+      progressChangeCount: 2,
+    });
+  });
+
+  it('keeps uncomplete and recomplete events in historical summaries', () => {
+    const model = buildUsageAnalyticsModel([planSummary({ id: 'plan-1' })], {
+      referenceDate: new Date('2026-06-25T12:00:00.000Z'),
+      activityEvents: [
+        activityEvent({
+          status: 'completed',
+          taskEstimatedMinutes: 25,
+          occurredAt: new Date('2026-06-23T12:00:00.000Z'),
+        }),
+        activityEvent({
+          status: 'in_progress',
+          taskEstimatedMinutes: 25,
+          occurredAt: new Date('2026-06-24T12:00:00.000Z'),
+        }),
+        activityEvent({
+          status: 'completed',
+          taskEstimatedMinutes: 25,
+          occurredAt: new Date('2026-06-25T12:00:00.000Z'),
+        }),
+      ],
+    });
+
+    expect(model.history.currentWeek).toMatchObject({
+      activeDays: 3,
+      progressChangeCount: 3,
+      completedEvents: 2,
+      estimatedCompletionAddedMinutes: 50,
+    });
+  });
+
+  it('sums estimated completion added only from completed-status events', () => {
+    const model = buildUsageAnalyticsModel([planSummary({ id: 'plan-1' })], {
+      referenceDate: new Date('2026-06-25T12:00:00.000Z'),
+      activityEvents: [
+        activityEvent({
+          status: 'completed',
+          taskEstimatedMinutes: 40,
+        }),
+        activityEvent({
+          status: 'in_progress',
+          taskEstimatedMinutes: 80,
+        }),
+      ],
+    });
+
+    expect(model.history.currentWeek.completedEvents).toBe(1);
+    expect(model.history.currentWeek.estimatedCompletionAddedMinutes).toBe(40);
+    expect(model.plans[0]).toMatchObject({
+      completedEventsThisWeek: 1,
+      estimatedCompletionAddedThisWeek: 40,
+    });
   });
 });

--- a/tests/unit/db/users-authenticated-update-columns.spec.ts
+++ b/tests/unit/db/users-authenticated-update-columns.spec.ts
@@ -10,6 +10,10 @@ import { describe, expect, it } from 'vitest';
 
 const TEST_DIR = dirname(fileURLToPath(import.meta.url));
 
+type MigrationJournal = {
+  entries: Array<{ tag: string }>;
+};
+
 function normalizeColumns(rawColumns: string): string[] {
   return rawColumns
     .split(',')
@@ -29,19 +33,20 @@ function extractUsersUpdateGrantColumns(fileContents: string): string[][] {
 describe('authenticated users UPDATE allowlist sync', () => {
   const expectedColumns = [...USERS_AUTHENTICATED_UPDATE_COLUMNS].sort();
 
-  it('keeps migration 0018 in sync with the canonical allowlist', () => {
-    const migrationContents = readFileSync(
-      resolve(
-        TEST_DIR,
-        '../../../supabase/migrations/0018_harden_users_update_columns.sql',
-      ),
-      'utf8',
-    );
+  it('keeps the final migration grant in sync with the canonical allowlist', () => {
+    const migrationsDir = resolve(TEST_DIR, '../../../supabase/migrations');
+    const journal = JSON.parse(
+      readFileSync(resolve(migrationsDir, 'meta/_journal.json'), 'utf8'),
+    ) as MigrationJournal;
+    const migrationContents = journal.entries
+      .map((entry) =>
+        readFileSync(resolve(migrationsDir, `${entry.tag}.sql`), 'utf8'),
+      )
+      .join('\n');
 
     const migrationMatches = extractUsersUpdateGrantColumns(migrationContents);
 
-    expect(migrationMatches).toHaveLength(1);
-    expect(migrationMatches[0]).toEqual(expectedColumns);
+    expect(migrationMatches.at(-1)).toEqual(expectedColumns);
   });
 
   it('keeps shared Postgres bootstrap using the canonical column list for users UPDATE', () => {

--- a/tests/unit/settings/profile/profile-client.spec.ts
+++ b/tests/unit/settings/profile/profile-client.spec.ts
@@ -37,6 +37,22 @@ describe('profile-client', () => {
     expect(result).toEqual({ kind: 'success', profile: PROFILE });
   });
 
+  it('defaults missing legacy analytics timezone responses to UTC', async () => {
+    const legacyProfile: Partial<typeof PROFILE> = { ...PROFILE };
+    delete legacyProfile.analyticsTimezone;
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(mockJsonResponse(legacyProfile));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await requestProfile();
+
+    expect(result).toEqual({
+      kind: 'success',
+      profile: { ...legacyProfile, analyticsTimezone: 'UTC' },
+    });
+  });
+
   it('rejects malformed profile responses instead of accepting partial data', async () => {
     vi.stubGlobal(
       'fetch',

--- a/tests/unit/validation/user-profile.spec.ts
+++ b/tests/unit/validation/user-profile.spec.ts
@@ -23,6 +23,17 @@ describe('updateUserProfileSchema', () => {
     }
   });
 
+  it('accepts a valid analytics timezone', () => {
+    const result = updateUserProfileSchema.safeParse({
+      analyticsTimezone: 'America/Chicago',
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.analyticsTimezone).toBe('America/Chicago');
+    }
+  });
+
   it('accepts names at the maximum length boundary', () => {
     const maxLengthName = 'a'.repeat(USER_PROFILE_NAME_MAX_LENGTH);
     const result = updateUserProfileSchema.safeParse({ name: maxLengthName });
@@ -46,6 +57,20 @@ describe('updateUserProfileSchema', () => {
       name: 'Valid Name',
       email: 'should-not-be-allowed@example.com',
     });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid analytics timezones', () => {
+    const result = updateUserProfileSchema.safeParse({
+      analyticsTimezone: 'Not/AZone',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty updates', () => {
+    const result = updateUserProfileSchema.safeParse({});
 
     expect(result.success).toBe(false);
   });


### PR DESCRIPTION
## Summary
- Add persisted `users.analytics_timezone` with validated profile updates and browser timezone sync on `/analytics/usage`.
- Build historical usage analytics from `learning_activity_events`: streaks, current-week summaries, weekly trends, and per-plan activity rows.
- Keep current-state completion metrics separate from event-based historical metrics; no backfill or actual study-time claims.
- Update the usage analytics metric contract, Drizzle schema/migration artifacts, fixtures, and focused tests.

## Validation
- `SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit tests/unit/app/analytics/usage-analytics-model.spec.ts tests/unit/validation/user-profile.spec.ts tests/unit/db/users-authenticated-update-columns.spec.ts tests/unit/settings/profile/profile-client.spec.ts tests/unit/settings/profile/ProfileForm.spec.tsx`
- `NODE_ENV=test pnpm vitest run --config vitest.config.ts --project integration tests/integration/api/user-profile.spec.ts tests/integration/db/tasks.queries.spec.ts`
- `npx -y react-doctor@latest . --verbose --scope changed`
- `pnpm test`
- `pnpm check:full`

## Screenshots
- Captured locally under `screenshots/jcs-28-historical-analytics` and intentionally not committed.
- Captures cover `/analytics/usage` desktop `1440x1000`, tablet `834x1112`, and mobile `390x844` with seeded historical activity visible.

## Review Notes
- Ran the requested review stack: thermos correctness/security, thermos code-quality, frontend-code-review, ponytail-review, and code-review.
- Fixed the in-scope privilege grant drift guard and the React Doctor fetch-in-effect finding.
- Left the raw event read as a non-blocking follow-up optimization because this slice intentionally computes JCS-28 from ordered append-only events and longest streak requires full history.

Closes #371

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a DB migration and broadens authenticated `users` UPDATE grants; analytics correctness depends on timezone bucketing and full event scans, but scope stays read-only analytics with validated timezone writes.
> 
> **Overview**
> **`/analytics/usage`** now shows **historical activity** from `learning_activity_events`, not only current completion snapshots. The page loads plan summaries and ordered activity events, builds a richer model (streaks, Monday-start weeks, 8-week trends, per-plan activity), and replaces the old “coming soon” placeholder with summary cards, weekly trend bars, and plan-level streak/weekly rows when history exists.
> 
> **`buildUsageAnalyticsModel`** buckets days in the user’s **analytics timezone**, counts study days from any progress change, treats `completed` events for estimated minutes added, and supports global vs per-plan streaks (current streak can include yesterday if today is empty).
> 
> **`users.analytics_timezone`** is added (default `UTC`) with migration and RLS column grants. Profile **GET/PUT** and validation accept optional IANA timezones; a client **`UsageAnalyticsTimezoneSync`** best-effort syncs the browser zone via a server action and refreshes when it changes.
> 
> A **`getLearningActivityEventsForUser`** read path feeds the page. The usage analytics metric contract doc is updated to describe shipped historical metrics and timezone semantics. Tests cover the model, profile API, RLS reads, and grant allowlist sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea89f5f85fbdfa6823ae918146633a10da6eb275. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->