### PR TITLE
refactor(ui): polish dashboard activity feed

### DIFF
--- a/src/app/(app)/dashboard/components/ActivityCard.tsx
+++ b/src/app/(app)/dashboard/components/ActivityCard.tsx
@@ -9,19 +9,19 @@ const typeConfig: Record<
   ActivityItem['type'],
   {
     icon: React.ComponentType<{ className?: string }>;
-    color: string;
-    borderColor: string;
+    label: string;
+    stampClassName: string;
   }
 > = {
   milestone: {
     icon: Trophy,
-    color: 'bg-warning/15 text-warning',
-    borderColor: 'border-l-warning',
+    label: 'Milestone',
+    stampClassName: 'border-warning/30 bg-warning/10 text-warning',
   },
   progress: {
     icon: TrendingUp,
-    color: 'bg-accent/15 text-accent-foreground',
-    borderColor: 'border-l-accent',
+    label: 'Progress',
+    stampClassName: 'border-primary/30 bg-primary/10 text-primary',
   },
 };
 
@@ -53,52 +53,43 @@ export function ActivityCard({ activity }: { activity: ActivityItem }) {
   const Icon = config.icon;
 
   return (
-    <Surface
-      variant='interactive'
-      padding='comfortable'
-      className={cn(
-        'group relative overflow-hidden border-l-4',
-        config.borderColor,
-      )}
-    >
-      <div className='flex gap-4'>
-        {/* Icon */}
-        <div
-          className={cn(
-            'flex size-10 flex-shrink-0 items-center justify-center rounded-lg',
-            config.color,
-          )}
-        >
-          <Icon className='size-5' />
-        </div>
-
-        {/* Content */}
-        <div className='min-w-0 flex-1'>
-          <div className='mb-1 flex items-start justify-between gap-2'>
-            <div>
+    <Surface variant='interactive' padding='none' className='overflow-hidden'>
+      <div className='p-4 sm:p-5'>
+        <div className='mb-3 flex flex-wrap items-start justify-between gap-3'>
+          <div className='min-w-0'>
+            <div className='mb-2 flex flex-wrap items-center gap-2'>
+              <span
+                className={cn(
+                  'inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-[11px] font-medium tracking-wide uppercase',
+                  config.stampClassName,
+                )}
+              >
+                <Icon className='size-3' aria-hidden='true' />
+                {config.label}
+              </span>
               <span className='text-xs font-medium text-muted-foreground'>
                 {activity.planTitle}
               </span>
-              <h4 className='font-semibold text-foreground'>
-                {activity.title}
-              </h4>
             </div>
-            <span className='flex-shrink-0 text-xs text-muted-foreground'>
-              {activity.timestamp}
-            </span>
+            <h4 className='font-semibold text-foreground'>{activity.title}</h4>
           </div>
 
-          {activity.description && (
-            <p className='mb-3 text-sm text-muted-foreground'>
-              {activity.description}
-            </p>
-          )}
-
-          {/* Metadata */}
-          {activity.metadata && (
-            <ActivityCardMetadata metadata={activity.metadata} />
-          )}
+          <span className='shrink-0 rounded-md border border-border bg-panel-muted px-2 py-1 text-[11px] font-medium text-muted-foreground'>
+            {activity.timestamp}
+          </span>
         </div>
+
+        {activity.description && (
+          <p className='text-sm text-muted-foreground'>
+            {activity.description}
+          </p>
+        )}
+
+        {activity.metadata && (
+          <div className='mt-4 border-t border-border/70 pt-3'>
+            <ActivityCardMetadata metadata={activity.metadata} />
+          </div>
+        )}
       </div>
     </Surface>
   );

--- a/src/app/(app)/dashboard/components/ActivityFeedClient.tsx
+++ b/src/app/(app)/dashboard/components/ActivityFeedClient.tsx
@@ -25,7 +25,7 @@ export function ActivityFeedClient({ activities }: ActivityFeedClientProps) {
       : activities.filter((activity) => activity.type === filter);
 
   return (
-    <section aria-label='Activity feed' className='lg:col-span-2'>
+    <section aria-label='Activity feed'>
       <div className='mb-6 flex items-center gap-2 border-b border-border pb-4'>
         <Tabs
           value={filter}

--- a/src/app/(app)/dashboard/components/ActivityFeedScoreboard.tsx
+++ b/src/app/(app)/dashboard/components/ActivityFeedScoreboard.tsx
@@ -30,10 +30,10 @@ export function ActivityFeedScoreboard({
     (minutes, summary) => minutes + summary.completedMinutes,
     0,
   );
-  const activePlanCount = summaries.filter(
+  const inProgressPlanCount = summaries.filter(
     (summary) => summary.completion < 1 - COMPLETION_EPSILON,
   ).length;
-  const completedPlanCount = summaries.length - activePlanCount;
+  const completedPlanCount = summaries.length - inProgressPlanCount;
   const taskCompletionPercent =
     totalTasks > 0 ? Math.round((completedTasks / totalTasks) * 100) : 0;
   const activePlanProgress = activePlan
@@ -41,8 +41,8 @@ export function ActivityFeedScoreboard({
     : null;
   const metrics = [
     {
-      label: 'Active plans',
-      value: activePlanCount.toString(),
+      label: 'In-progress plans',
+      value: inProgressPlanCount.toString(),
       detail:
         completedPlanCount > 0
           ? `${completedPlanCount} completed`
@@ -70,7 +70,11 @@ export function ActivityFeedScoreboard({
       label: 'Feed events',
       value: activities.length.toString(),
       detail:
-        activities.length === 1 ? '1 recent signal' : 'Recent learning signals',
+        activities.length === 0
+          ? 'No recent signals'
+          : activities.length === 1
+            ? '1 recent signal'
+            : 'Recent learning signals',
       icon: Activity,
     },
   ];

--- a/src/app/(app)/dashboard/components/ActivityFeedScoreboard.tsx
+++ b/src/app/(app)/dashboard/components/ActivityFeedScoreboard.tsx
@@ -1,0 +1,119 @@
+import type { ActivityItem } from '../types';
+import type { PlanSummary } from '@/shared/types/db.types';
+
+import { Surface } from '@/components/ui/surface';
+import { formatMinutes } from '@/features/plans/formatters';
+import { Activity, CheckCircle2, Clock3, ListChecks } from 'lucide-react';
+
+type ActivityFeedScoreboardProps = {
+  summaries: PlanSummary[];
+  activities: ActivityItem[];
+  activePlan?: PlanSummary;
+};
+
+const COMPLETION_EPSILON = 1e-6;
+
+export function ActivityFeedScoreboard({
+  summaries,
+  activities,
+  activePlan,
+}: ActivityFeedScoreboardProps) {
+  const totalTasks = summaries.reduce(
+    (count, summary) => count + summary.totalTasks,
+    0,
+  );
+  const completedTasks = summaries.reduce(
+    (count, summary) => count + summary.completedTasks,
+    0,
+  );
+  const completedMinutes = summaries.reduce(
+    (minutes, summary) => minutes + summary.completedMinutes,
+    0,
+  );
+  const activePlanCount = summaries.filter(
+    (summary) => summary.completion < 1 - COMPLETION_EPSILON,
+  ).length;
+  const completedPlanCount = summaries.length - activePlanCount;
+  const taskCompletionPercent =
+    totalTasks > 0 ? Math.round((completedTasks / totalTasks) * 100) : 0;
+  const activePlanProgress = activePlan
+    ? Math.round(Math.max(0, Math.min(1, activePlan.completion)) * 100)
+    : null;
+  const metrics = [
+    {
+      label: 'Active plans',
+      value: activePlanCount.toString(),
+      detail:
+        completedPlanCount > 0
+          ? `${completedPlanCount} completed`
+          : 'No completions yet',
+      icon: ListChecks,
+    },
+    {
+      label: 'Task progress',
+      value: `${taskCompletionPercent}%`,
+      detail:
+        totalTasks > 0
+          ? `${completedTasks} / ${totalTasks} complete`
+          : 'No tracked tasks',
+      icon: CheckCircle2,
+    },
+    {
+      label: 'Completed time',
+      value: formatMinutes(completedMinutes),
+      detail: activePlan
+        ? `${activePlanProgress}% current plan`
+        : 'No active plan',
+      icon: Clock3,
+    },
+    {
+      label: 'Feed events',
+      value: activities.length.toString(),
+      detail:
+        activities.length === 1 ? '1 recent signal' : 'Recent learning signals',
+      icon: Activity,
+    },
+  ];
+
+  return (
+    <section aria-label='Activity pulse' className='space-y-6'>
+      <div className='flex items-center gap-2 border-b border-border pb-4'>
+        <p className='px-2 py-1 text-sm font-medium whitespace-nowrap text-muted-foreground'>
+          Activity pulse
+        </p>
+      </div>
+
+      <Surface
+        aria-label='Activity feed scoreboard'
+        padding='comfortable'
+        className='border-primary/20'
+      >
+        <div className='grid gap-3'>
+          {metrics.map((metric) => {
+            const Icon = metric.icon;
+
+            return (
+              <div
+                key={metric.label}
+                className='rounded-xl border border-panel-border bg-panel-muted/70 p-4'
+              >
+                <div className='mb-3 flex items-center gap-2 text-muted-foreground'>
+                  <Icon className='size-4 text-primary' aria-hidden='true' />
+                  <p className='text-xs font-medium tracking-wide uppercase'>
+                    {metric.label}
+                  </p>
+                </div>
+                <p className='text-2xl font-semibold text-foreground tabular-nums'>
+                  {metric.value}
+                </p>
+                <p className='mt-1 text-sm text-muted-foreground'>
+                  {metric.detail}
+                </p>
+              </div>
+            );
+          })}
+        </div>
+      </Surface>
+    </section>
+  );
+}

--- a/src/app/(app)/dashboard/components/DashboardContent.tsx
+++ b/src/app/(app)/dashboard/components/DashboardContent.tsx
@@ -3,6 +3,7 @@ import {
   generateActivities,
 } from '@/app/(app)/dashboard/components/activity-utils';
 import { ActivityFeedClient } from '@/app/(app)/dashboard/components/ActivityFeedClient';
+import { ActivityFeedScoreboard } from '@/app/(app)/dashboard/components/ActivityFeedScoreboard';
 import { ActivityStreamSidebar } from '@/app/(app)/dashboard/components/ActivityStreamSidebar';
 import { ResumeLearningHero } from '@/app/(app)/dashboard/components/ResumeLearningHero';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -37,19 +38,25 @@ export async function DashboardContent() {
 
   return (
     <>
-      {/* ResumeLearningHero - only shown if there's an active plan */}
-      {activePlan && (
-        <section aria-label='Resume learning' className='mb-6'>
+      {activePlan ? (
+        <section aria-label='Resume learning' className='mb-5'>
           <ResumeLearningHero plan={activePlan} />
         </section>
-      )}
+      ) : null}
 
-      <div className='grid gap-6 lg:grid-cols-3'>
-        {/* Client island - only filter logic */}
-        <ActivityFeedClient activities={activities} />
+      <div className='grid items-start gap-5 lg:grid-cols-[minmax(0,2fr)_minmax(18rem,1fr)]'>
+        <div className='min-w-0'>
+          <ActivityFeedClient activities={activities} />
+        </div>
 
-        {/* Sidebar - server rendered */}
-        <ActivityStreamSidebar activePlan={activePlan} />
+        <div className='min-w-0 space-y-5 lg:self-start'>
+          {activePlan ? null : <ActivityStreamSidebar />}
+          <ActivityFeedScoreboard
+            summaries={summaries}
+            activities={activities}
+            activePlan={activePlan}
+          />
+        </div>
       </div>
     </>
   );
@@ -62,7 +69,6 @@ export async function DashboardContent() {
 export function DashboardContentSkeleton() {
   return (
     <>
-      {/* ResumeLearningHero skeleton */}
       <section aria-label='Resume learning loading' className='mb-6'>
         <Surface padding='comfortable' className='flex flex-col gap-4'>
           <div className='flex items-start justify-between gap-4'>
@@ -72,12 +78,6 @@ export function DashboardContentSkeleton() {
 
           <div className='flex flex-wrap items-end justify-between gap-4'>
             <div className='min-w-0 flex-1 space-y-2'>
-              <div className='flex flex-wrap gap-2'>
-                <Skeleton className='h-6 w-20 rounded-full' />
-                <Skeleton className='h-6 w-16 rounded-full' />
-                <Skeleton className='h-6 w-14 rounded-full' />
-                <Skeleton className='h-6 w-24 rounded-full' />
-              </div>
               <Skeleton className='h-9 w-64 md:w-80' />
               <Skeleton className='h-5 w-full max-w-md' />
             </div>
@@ -90,9 +90,8 @@ export function DashboardContentSkeleton() {
         </Surface>
       </section>
 
-      <div className='grid gap-6 lg:grid-cols-3'>
-        {/* Activity Feed skeleton - lg:col-span-2 */}
-        <div className='lg:col-span-2'>
+      <div className='grid items-start gap-5 lg:grid-cols-[minmax(0,2fr)_minmax(18rem,1fr)]'>
+        <div>
           {/* Filter tabs skeleton */}
           <div className='mb-6 flex items-center gap-3'>
             <Skeleton className='h-9 w-16 rounded-lg' />
@@ -123,15 +122,10 @@ export function DashboardContentSkeleton() {
           </div>
         </div>
 
-        {/* Sidebar skeleton */}
-        <aside className='flex w-full flex-col gap-4'>
-          <Surface>
-            <div className='flex flex-col items-center py-6 text-center'>
-              <Skeleton className='mb-4 size-12 rounded-full' />
-              <Skeleton className='mb-2 h-5 w-40' />
-              <Skeleton className='mb-4 h-4 w-56' />
-              <Skeleton className='h-10 w-28 rounded-lg' />
-            </div>
+        <aside className='flex w-full flex-col gap-4 lg:self-start'>
+          <Surface className='border-primary/20'>
+            <Skeleton className='mb-4 h-5 w-28' />
+            <Skeleton className='h-48 w-full rounded-xl' />
           </Surface>
         </aside>
       </div>

--- a/src/app/(app)/dashboard/components/DashboardContent.tsx
+++ b/src/app/(app)/dashboard/components/DashboardContent.tsx
@@ -123,6 +123,14 @@ export function DashboardContentSkeleton() {
         </div>
 
         <aside className='flex w-full flex-col gap-4 lg:self-start'>
+          <Surface className='border-sidebar-border'>
+            <div className='flex flex-col items-center py-6'>
+              <Skeleton className='mb-4 size-12 rounded-full' />
+              <Skeleton className='mb-2 h-5 w-36' />
+              <Skeleton className='mb-4 h-4 w-52' />
+              <Skeleton className='h-10 w-32 rounded-lg' />
+            </div>
+          </Surface>
           <Surface className='border-primary/20'>
             <Skeleton className='mb-4 h-5 w-28' />
             <Skeleton className='h-48 w-full rounded-xl' />

--- a/src/app/(app)/dashboard/components/ResumeLearningHero.tsx
+++ b/src/app/(app)/dashboard/components/ResumeLearningHero.tsx
@@ -2,7 +2,6 @@ import type { PlanSummary } from '@/shared/types/db.types';
 
 import { Button } from '@/components/ui/button';
 import { Surface } from '@/components/ui/surface';
-import { formatMinutes, formatSkillLevel } from '@/features/plans/formatters';
 import { Play } from 'lucide-react';
 import Link from 'next/link';
 
@@ -108,10 +107,6 @@ function HeroCircularProgress({
 }
 
 export function ResumeLearningHero({ plan }: ResumeLearningHeroProps) {
-  const skillLevel = formatSkillLevel(plan.plan.skillLevel ?? 'beginner');
-  const weeklyHours = plan.plan.weeklyHours ?? 10;
-  const moduleCount = plan.modules.length;
-  const totalDuration = formatMinutes(plan.totalMinutes);
   const clampedCompletion = Math.max(0, Math.min(1, plan.completion));
   const progressPercent = Math.round(clampedCompletion * 100);
 
@@ -132,21 +127,6 @@ export function ResumeLearningHero({ plan }: ResumeLearningHeroProps) {
 
       <div className='flex flex-wrap items-start justify-between gap-4 sm:items-end'>
         <div className='min-w-0 flex-1 space-y-2'>
-          <div className='flex flex-wrap gap-2'>
-            {[
-              skillLevel,
-              `${weeklyHours}h/week`,
-              totalDuration,
-              `${moduleCount} modules`,
-            ].map((label) => (
-              <span
-                key={label}
-                className='rounded-full border border-border bg-muted px-3 py-1 text-xs font-medium text-foreground'
-              >
-                {label}
-              </span>
-            ))}
-          </div>
           <h2 className='truncate text-2xl font-semibold text-foreground md:text-3xl'>
             {plan.plan.topic}
           </h2>

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -9,14 +9,15 @@ import { Suspense } from 'react';
  * Dashboard page with Suspense boundary for data-dependent content.
  *
  * Static elements (header with title and subtitle) render immediately.
- * ResumeLearningHero, ActivityFeedClient, and ActivityStreamSidebar wait for user plan data.
+ * ResumeLearningHero, ActivityFeedClient, ActivityFeedScoreboard, and
+ * ActivityStreamSidebar wait for user plan data.
  */
 export default function DashboardPage() {
   return (
     <>
       <PageHeader
         title='Activity Feed'
-        subtitle='Your learning journey, moment by moment'
+        subtitle='Your learning journey with activity metrics beside the stream.'
       />
 
       <Suspense fallback={<DashboardContentSkeleton />}>

--- a/src/app/(app)/plans/components/NoUpcomingEventsCard.tsx
+++ b/src/app/(app)/plans/components/NoUpcomingEventsCard.tsx
@@ -1,34 +1,26 @@
 import { Button } from '@/components/ui/button';
 import { Surface } from '@/components/ui/surface';
 import { ROUTES } from '@/features/navigation/routes';
-import { BookOpen } from 'lucide-react';
+import { Calendar } from 'lucide-react';
 import Link from 'next/link';
 
-function EmptyStateCard() {
+export function NoUpcomingEventsCard() {
   return (
     <Surface className='border-sidebar-border bg-sidebar text-sidebar-foreground'>
       <div className='flex flex-col items-center py-6 text-center'>
         <div className='mb-4 flex size-12 items-center justify-center rounded-full bg-sidebar-accent text-sidebar-accent-foreground'>
-          <BookOpen className='size-6' />
+          <Calendar className='size-6' />
         </div>
         <h3 className='mb-2 font-medium text-sidebar-foreground'>
-          No active learning plan
+          No upcoming events
         </h3>
         <p className='mb-4 text-sm text-sidebar-foreground/70'>
-          Create a new plan to start your learning journey
+          Add sessions to your active plan to keep learning momentum.
         </p>
         <Button asChild>
-          <Link href={ROUTES.PLANS.NEW}>Create New Plan</Link>
+          <Link href={ROUTES.PLANS.ROOT}>View Plans</Link>
         </Button>
       </div>
     </Surface>
-  );
-}
-
-export function ActivityStreamSidebar() {
-  return (
-    <aside className='flex w-full flex-col gap-4'>
-      <EmptyStateCard />
-    </aside>
   );
 }


### PR DESCRIPTION
## Summary
- Selects the dashboard sidebar rail placement for the activity pulse scoreboard.
- Simplifies dashboard activity cards and removes the old colored left rail treatment.
- Moves the upcoming-events empty state into plans components without wiring it into the plans page.

## Verification
- `git diff --cached --check`
- `npx react-doctor@latest --verbose --scope changed` (100/100, no issues)
- Pre-commit hook: `lint-staged` and `ggshield secret scan`

Linear: JCS-29

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only dashboard changes with no API, auth, or data-layer modifications.
> 
> **Overview**
> Reworks the dashboard **Activity Feed** layout so the stream sits in a wider column with an **Activity pulse** scoreboard in a fixed sidebar rail, and updates copy on the page header.
> 
> **Activity cards** drop the colored left border and large side icon in favor of compact type stamps (Milestone / Progress), a bordered timestamp chip, and optional metadata separated by a top border.
> 
> Adds **`ActivityFeedScoreboard`**, aggregating plan summaries and feed length into four metrics (in-progress plans, task %, completed time, feed events). **`DashboardContent`** always shows the scoreboard; the **no active plan** sidebar CTA only appears when there is no active plan (the former “no upcoming events” card is removed from the dashboard).
> 
> **`ResumeLearningHero`** is simplified by removing skill level / hours / duration / module count pills. **`NoUpcomingEventsCard`** is extracted under `plans/components` but is not referenced elsewhere yet. Loading skeletons follow the new two-column layout and scoreboard placeholder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b60538751789d0ae1737f0aa526c693bec47e87c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->