### PR TITLE
fix(ui): redesign plans page

### DIFF
--- a/src/app/(app)/dashboard/components/activity-utils.ts
+++ b/src/app/(app)/dashboard/components/activity-utils.ts
@@ -1,4 +1,5 @@
 import type { ActivityItem } from '../types';
+import type { PlanReadStatus } from '@/features/plans/read-projection/types';
 import type { LearningPlan, PlanSummary } from '@/shared/types/db.types';
 
 import { formatMinutes } from '@/features/plans/formatters';
@@ -8,6 +9,12 @@ import { formatRelativePast } from '@/lib/date/relative-time';
 type DatedActivity = {
   activity: ActivityItem;
   activityDate: Date;
+};
+
+const DASHBOARD_PLAN_STATUS_RANK: Partial<Record<PlanReadStatus, number>> = {
+  active: 0,
+  not_started: 1,
+  generating: 2,
 };
 
 /**
@@ -101,7 +108,7 @@ export function generateActivities(summaries: PlanSummary[]): ActivityItem[] {
 }
 
 /**
- * Finds the most recently active (incomplete) plan from summaries.
+ * Finds the highest-priority incomplete plan from summaries.
  */
 export function findActivePlan(
   summaries: PlanSummary[],
@@ -115,13 +122,14 @@ export function findActivePlan(
         referenceDate: now,
       }),
     }))
-    .filter(({ status }) => status === 'active' || status === 'generating')
+    .filter(({ status }) => status in DASHBOARD_PLAN_STATUS_RANK)
     .toSorted((a, b) => {
-      const aStatus = a.status;
-      const bStatus = b.status;
+      const rankDifference =
+        (DASHBOARD_PLAN_STATUS_RANK[a.status] ?? 99) -
+        (DASHBOARD_PLAN_STATUS_RANK[b.status] ?? 99);
 
-      if (aStatus !== bStatus) {
-        return aStatus === 'active' ? -1 : 1;
+      if (rankDifference !== 0) {
+        return rankDifference;
       }
 
       const aTime = a.summary.plan.updatedAt

--- a/src/app/(app)/plans/components/BulkDeletePlansDialog.tsx
+++ b/src/app/(app)/plans/components/BulkDeletePlansDialog.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import type { PlanListItem } from '@/features/plans/read-projection/types';
+import type { BulkRemovePlanResult } from '@/features/plans/write-service';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { parseApiErrorResponse } from '@/lib/api/error-response';
+import { isAbortError } from '@/lib/errors';
+import { clientLogger } from '@/lib/logging/client';
+import { useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+
+export type BulkDeletePlansResult = {
+  success: boolean;
+  deletedCount: number;
+  failedCount: number;
+  results: BulkRemovePlanResult[];
+};
+
+type BulkDeletePlansDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  plans: Pick<PlanListItem, 'id' | 'topic' | 'status'>[];
+  onDeleted: (result: BulkDeletePlansResult) => void;
+};
+
+type BulkDeleteRequestResult =
+  | { kind: 'success'; result: BulkDeletePlansResult }
+  | { kind: 'aborted' }
+  | { kind: 'error'; message: string; error: unknown };
+
+function startBulkDeleteRequest(abortControllerRef: {
+  current: AbortController | null;
+}): AbortController {
+  abortControllerRef.current?.abort();
+  const controller = new AbortController();
+  abortControllerRef.current = controller;
+  return controller;
+}
+
+async function requestBulkPlanDeletion(
+  planIds: string[],
+  signal: AbortSignal,
+): Promise<BulkDeleteRequestResult> {
+  try {
+    const res = await fetch('/api/v1/plans/bulk-delete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ planIds }),
+      signal,
+    });
+
+    if (!res.ok) {
+      const parsed = await parseApiErrorResponse(
+        res,
+        'Failed to delete selected plans',
+      );
+      return {
+        kind: 'error',
+        message: parsed.error,
+        error: new Error(parsed.error),
+      };
+    }
+
+    return {
+      kind: 'success',
+      result: (await res.json()) as BulkDeletePlansResult,
+    };
+  } catch (error: unknown) {
+    if (isAbortError(error)) {
+      return { kind: 'aborted' };
+    }
+
+    return {
+      kind: 'error',
+      message:
+        error instanceof Error
+          ? error.message
+          : 'Failed to delete selected plans',
+      error,
+    };
+  }
+}
+
+function finalizeBulkDeleteRequest({
+  controller,
+  abortControllerRef,
+  isMountedRef,
+  setDeleting,
+}: {
+  controller: AbortController;
+  abortControllerRef: { current: AbortController | null };
+  isMountedRef: { current: boolean };
+  setDeleting: (value: boolean) => void;
+}): void {
+  if (abortControllerRef.current !== controller) {
+    return;
+  }
+
+  abortControllerRef.current = null;
+  if (isMountedRef.current) {
+    setDeleting(false);
+  }
+}
+
+function formatPlanTopicList(plans: Pick<PlanListItem, 'topic'>[]): string {
+  const preview = plans.slice(0, 5).map((plan) => plan.topic);
+  const remaining = plans.length - preview.length;
+
+  if (remaining > 0) {
+    return `${preview.join(', ')}, and ${remaining} more`;
+  }
+
+  return preview.join(', ');
+}
+
+export function BulkDeletePlansDialog({
+  open,
+  onOpenChange,
+  plans,
+  onDeleted,
+}: BulkDeletePlansDialogProps) {
+  const [deleting, setDeleting] = useState(false);
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+      abortControllerRef.current?.abort();
+      abortControllerRef.current = null;
+    };
+  }, []);
+
+  const handleDelete = async (): Promise<void> => {
+    if (deleting || plans.length === 0) {
+      return;
+    }
+
+    const controller = startBulkDeleteRequest(abortControllerRef);
+    setDeleting(true);
+    const result = await requestBulkPlanDeletion(
+      plans.map((plan) => plan.id),
+      controller.signal,
+    );
+
+    switch (result.kind) {
+      case 'success':
+        finalizeBulkDeleteRequest({
+          controller,
+          abortControllerRef,
+          isMountedRef,
+          setDeleting,
+        });
+        if (isMountedRef.current) {
+          onOpenChange(false);
+          onDeleted(result.result);
+        }
+        return;
+      case 'aborted':
+        finalizeBulkDeleteRequest({
+          controller,
+          abortControllerRef,
+          isMountedRef,
+          setDeleting,
+        });
+        return;
+      case 'error':
+        clientLogger.error('Bulk plan deletion failed', {
+          planIds: plans.map((plan) => plan.id),
+          error: result.error,
+        });
+        toast.error(result.message);
+        finalizeBulkDeleteRequest({
+          controller,
+          abortControllerRef,
+          isMountedRef,
+          setDeleting,
+        });
+        return;
+    }
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete selected plans</AlertDialogTitle>
+          <AlertDialogDescription className='space-y-2'>
+            <p>
+              This will permanently delete {plans.length} selected plan
+              {plans.length === 1 ? '' : 's'} and all associated modules, tasks,
+              progress, schedules, and generation history. This action cannot be
+              undone and you will not receive a refund for the AI generation
+              credits used to generate these plans.
+            </p>
+            <p>Selected: {formatPlanTopicList(plans)}</p>
+            <p>Are you sure you want to delete these plans?</p>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            variant='destructive'
+            disabled={deleting || plans.length === 0}
+            onClick={(event) => {
+              event.preventDefault();
+              void handleDelete();
+            }}
+          >
+            {deleting ? 'Deleting...' : `Delete ${plans.length} plans`}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/app/(app)/plans/components/BulkDeletePlansDialog.tsx
+++ b/src/app/(app)/plans/components/BulkDeletePlansDialog.tsx
@@ -94,22 +94,19 @@ async function requestBulkPlanDeletion(
 function finalizeBulkDeleteRequest({
   controller,
   abortControllerRef,
-  isMountedRef,
   setDeleting,
 }: {
   controller: AbortController;
   abortControllerRef: { current: AbortController | null };
-  isMountedRef: { current: boolean };
   setDeleting: (value: boolean) => void;
-}): void {
+}): boolean {
   if (abortControllerRef.current !== controller) {
-    return;
+    return false;
   }
 
   abortControllerRef.current = null;
-  if (isMountedRef.current) {
-    setDeleting(false);
-  }
+  setDeleting(false);
+  return true;
 }
 
 function formatPlanTopicList(plans: Pick<PlanListItem, 'topic'>[]): string {
@@ -131,11 +128,10 @@ export function BulkDeletePlansDialog({
 }: BulkDeletePlansDialogProps) {
   const [deleting, setDeleting] = useState(false);
   const abortControllerRef = useRef<AbortController | null>(null);
-  const isMountedRef = useRef(true);
 
+  // react-doctor-disable-next-line react-doctor/exhaustive-deps -- unmount cleanup intentionally aborts the active request.
   useEffect(() => {
     return () => {
-      isMountedRef.current = false;
       abortControllerRef.current?.abort();
       abortControllerRef.current = null;
     };
@@ -155,37 +151,36 @@ export function BulkDeletePlansDialog({
 
     switch (result.kind) {
       case 'success':
-        finalizeBulkDeleteRequest({
+        if (!finalizeBulkDeleteRequest({
           controller,
           abortControllerRef,
-          isMountedRef,
           setDeleting,
-        });
-        if (isMountedRef.current) {
-          onOpenChange(false);
-          onDeleted(result.result);
+        })) {
+          return;
         }
+        onOpenChange(false);
+        onDeleted(result.result);
         return;
       case 'aborted':
         finalizeBulkDeleteRequest({
           controller,
           abortControllerRef,
-          isMountedRef,
           setDeleting,
         });
         return;
       case 'error':
+        if (!finalizeBulkDeleteRequest({
+          controller,
+          abortControllerRef,
+          setDeleting,
+        })) {
+          return;
+        }
         clientLogger.error('Bulk plan deletion failed', {
           planIds: plans.map((plan) => plan.id),
           error: result.error,
         });
         toast.error(result.message);
-        finalizeBulkDeleteRequest({
-          controller,
-          abortControllerRef,
-          isMountedRef,
-          setDeleting,
-        });
         return;
     }
   };

--- a/src/app/(app)/plans/components/BulkDeletePlansDialog.tsx
+++ b/src/app/(app)/plans/components/BulkDeletePlansDialog.tsx
@@ -217,7 +217,9 @@ export function BulkDeletePlansDialog({
               void handleDelete();
             }}
           >
-            {deleting ? 'Deleting...' : `Delete ${plans.length} plans`}
+            {deleting
+              ? 'Deleting...'
+              : `Delete ${plans.length} plan${plans.length === 1 ? '' : 's'}`}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/src/app/(app)/plans/components/EmptyPlansList.tsx
+++ b/src/app/(app)/plans/components/EmptyPlansList.tsx
@@ -1,7 +1,7 @@
 import type { FilterStatus } from '@/features/plans/read-projection/types';
 
 import { Button } from '@/components/ui/button';
-import { Surface } from '@/components/ui/surface';
+import { RouteEmptyState } from '@/components/ui/route-empty-state';
 import { FileText, Plus, Sparkles } from 'lucide-react';
 import Link from 'next/link';
 
@@ -26,27 +26,19 @@ export function EmptyPlansList({
   const Icon = isFirstRun ? Sparkles : FileText;
 
   return (
-    <Surface
-      className='flex min-h-72 flex-col items-center justify-center overflow-hidden border-primary/20 bg-linear-to-br from-primary/10 to-panel px-6 py-12 text-center'
-    >
-      <div
-        className='mb-4 flex size-12 items-center justify-center rounded-2xl bg-primary text-primary-foreground'
-        aria-hidden='true'
-      >
-        <Icon className='size-5' />
-      </div>
-      <h2 className='text-xl font-semibold text-foreground'>{title}</h2>
-      <p className='mt-2 max-w-md text-sm leading-6 text-muted-foreground'>
-        {description}
-      </p>
-      <div className='mt-5'>
+    <RouteEmptyState
+      icon={Icon}
+      title={title}
+      description={description}
+      className='flex min-h-72 flex-col items-center justify-center overflow-hidden rounded-2xl border border-primary/20 bg-linear-to-br from-primary/10 to-panel px-6 py-12 text-center'
+      action={
         <Button asChild>
           <Link href='/plans/new'>
             <Plus />
             New plan
           </Link>
         </Button>
-      </div>
-    </Surface>
+      }
+    />
   );
 }

--- a/src/app/(app)/plans/components/EmptyPlansList.tsx
+++ b/src/app/(app)/plans/components/EmptyPlansList.tsx
@@ -1,38 +1,52 @@
 import type { FilterStatus } from '@/features/plans/read-projection/types';
 
 import { Button } from '@/components/ui/button';
-import { RouteEmptyState } from '@/components/ui/route-empty-state';
-import { FileText, Plus } from 'lucide-react';
+import { Surface } from '@/components/ui/surface';
+import { FileText, Plus, Sparkles } from 'lucide-react';
 import Link from 'next/link';
 
 interface EmptyPlansListProps {
   searchQuery: string;
   filterStatus: FilterStatus;
+  isFirstRun?: boolean;
 }
 
 export function EmptyPlansList({
   searchQuery,
   filterStatus,
+  isFirstRun = false,
 }: EmptyPlansListProps) {
-  const hasFilters = searchQuery || filterStatus !== 'all';
+  const hasFilters = Boolean(searchQuery) || filterStatus !== 'all';
+  const title = isFirstRun ? 'No learning plans yet' : 'No plans found';
+  const description = isFirstRun
+    ? "Start by describing what you want to learn and we'll create a personalized learning plan with resources and milestones."
+    : hasFilters
+      ? 'No plans match your search or filters. Try adjusting your criteria.'
+      : "You haven't created any plans yet. Create your first plan to get started.";
+  const Icon = isFirstRun ? Sparkles : FileText;
 
   return (
-    <RouteEmptyState
-      icon={FileText}
-      title='No plans found'
-      description={
-        hasFilters
-          ? 'No plans match your search or filters. Try adjusting your criteria.'
-          : "You haven't created any plans yet. Create your first plan to get started."
-      }
-      action={
+    <Surface
+      className='flex min-h-72 flex-col items-center justify-center overflow-hidden border-primary/20 bg-linear-to-br from-primary/10 to-panel px-6 py-12 text-center'
+    >
+      <div
+        className='mb-4 flex size-12 items-center justify-center rounded-2xl bg-primary text-primary-foreground'
+        aria-hidden='true'
+      >
+        <Icon className='size-5' />
+      </div>
+      <h2 className='text-xl font-semibold text-foreground'>{title}</h2>
+      <p className='mt-2 max-w-md text-sm leading-6 text-muted-foreground'>
+        {description}
+      </p>
+      <div className='mt-5'>
         <Button asChild>
           <Link href='/plans/new'>
             <Plus />
             New plan
           </Link>
         </Button>
-      }
-    />
+      </div>
+    </Surface>
   );
 }

--- a/src/app/(app)/plans/components/PlanRow.tsx
+++ b/src/app/(app)/plans/components/PlanRow.tsx
@@ -65,13 +65,22 @@ function PlanTitle({
 }
 
 function NextTask({ plan }: { plan: PlanListItem }) {
-  const nextTask =
-    plan.status === 'completed'
-      ? 'All tasks completed'
-      : plan.completedTasks === 0
-        ? 'Not started'
-        : 'Continue learning';
-  const showArrow = plan.status !== 'completed' && plan.completedTasks > 0;
+  let nextTask: string;
+  let showArrow: boolean;
+
+  if (plan.status === 'completed') {
+    nextTask = 'All tasks completed';
+    showArrow = false;
+  } else if (plan.status === 'generating' || plan.status === 'failed') {
+    nextTask = PLAN_STATUS_LABELS[plan.status];
+    showArrow = false;
+  } else if (plan.completedTasks === 0) {
+    nextTask = 'Not started';
+    showArrow = false;
+  } else {
+    nextTask = 'Continue learning';
+    showArrow = true;
+  }
 
   return (
     <div className='flex min-w-0 items-center gap-2 text-xs text-muted-foreground'>

--- a/src/app/(app)/plans/components/PlanRow.tsx
+++ b/src/app/(app)/plans/components/PlanRow.tsx
@@ -30,6 +30,10 @@ import { useState } from 'react';
 interface PlanRowProps {
   plan: PlanListItem;
   referenceTimestamp: string;
+  selectionMode?: boolean;
+  selected?: boolean;
+  selectable?: boolean;
+  onSelectionChange?: (planId: string, selected: boolean) => void;
 }
 
 function StatusPill({ plan }: { plan: PlanListItem }) {
@@ -126,7 +130,14 @@ function ProgressTrack({ progressPercent }: { progressPercent: number }) {
   );
 }
 
-export function PlanRow({ plan, referenceTimestamp }: PlanRowProps) {
+export function PlanRow({
+  plan,
+  referenceTimestamp,
+  selectionMode = false,
+  selected = false,
+  selectable = true,
+  onSelectionChange,
+}: PlanRowProps) {
   const progressPercent = Math.max(
     0,
     Math.min(100, Math.round(plan.completion * 100)),
@@ -147,55 +158,81 @@ export function PlanRow({ plan, referenceTimestamp }: PlanRowProps) {
         onOpenChange={setDeleteDialogOpen}
       />
 
-      <div className='relative'>
-        <div className='group rounded-2xl border border-panel-border bg-panel px-4 py-3.5 shadow-sm transition-[border-color,box-shadow,background-color] hover:border-primary/25 hover:bg-panel-muted/35 hover:shadow-md'>
-          <Link href={`/plans/${plan.id}`} className='block min-w-0 pr-12'>
-            <div className='grid gap-3 md:grid-cols-[minmax(0,1fr)_7.5rem_7rem] md:items-start md:gap-4'>
-              <div className='min-w-0 space-y-1.5'>
-                <div className='flex min-w-0 flex-wrap items-center gap-2'>
-                  <StatusPill plan={plan} />
-                  <PlanTitle plan={plan} progressPercent={progressPercent} />
+      <div className='relative flex items-start gap-3'>
+        {selectionMode ? (
+          <div className='flex shrink-0 pt-4'>
+            <input
+              type='checkbox'
+              checked={selected}
+              disabled={!selectable}
+              aria-label={
+                selectable
+                  ? `Select ${plan.topic}`
+                  : `Cannot select ${plan.topic} while it is generating`
+              }
+              onChange={(event) =>
+                onSelectionChange?.(plan.id, event.currentTarget.checked)
+              }
+              className='size-4 rounded border-border text-primary focus-visible:ring-ring/50'
+            />
+          </div>
+        ) : null}
+
+        <div className='relative min-w-0 flex-1'>
+          <div className='group rounded-2xl border border-panel-border bg-panel px-4 py-3.5 shadow-sm transition-[border-color,box-shadow,background-color] hover:border-primary/25 hover:bg-panel-muted/35 hover:shadow-md'>
+            <Link
+              href={`/plans/${plan.id}`}
+              className={cn('block min-w-0', !selectionMode && 'pr-12')}
+            >
+              <div className='grid gap-3 md:grid-cols-[minmax(0,1fr)_7.5rem_7rem] md:items-start md:gap-4'>
+                <div className='min-w-0 space-y-1.5'>
+                  <div className='flex min-w-0 flex-wrap items-center gap-2'>
+                    <StatusPill plan={plan} />
+                    <PlanTitle plan={plan} progressPercent={progressPercent} />
+                  </div>
+                  <NextTask plan={plan} />
                 </div>
-                <NextTask plan={plan} />
+
+                <div className='min-w-0 md:pt-1'>
+                  <TaskCount plan={plan} />
+                </div>
+                <div className='min-w-0 md:pt-1'>
+                  <LastActivity value={lastActivity} />
+                </div>
               </div>
 
-              <div className='min-w-0 md:pt-1'>
-                <TaskCount plan={plan} />
+              <div className='mt-3'>
+                <ProgressTrack progressPercent={progressPercent} />
               </div>
-              <div className='min-w-0 md:pt-1'>
-                <LastActivity value={lastActivity} />
-              </div>
+            </Link>
+          </div>
+
+          {!selectionMode ? (
+            <div className='absolute top-2 right-2'>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant='ghost'
+                    size='icon'
+                    title='Plan actions'
+                    aria-label='Plan actions'
+                  >
+                    <MoreVertical className='size-4' />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align='end'>
+                  <DropdownMenuItem
+                    variant='destructive'
+                    disabled={plan.status === 'generating'}
+                    onSelect={() => setDeleteDialogOpen(true)}
+                  >
+                    <Trash2 className='mr-2 size-4' />
+                    Delete plan
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
-
-            <div className='mt-3'>
-              <ProgressTrack progressPercent={progressPercent} />
-            </div>
-          </Link>
-        </div>
-
-        <div className='absolute top-2 right-2'>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant='ghost'
-                size='icon'
-                title='Plan actions'
-                aria-label='Plan actions'
-              >
-                <MoreVertical className='size-4' />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align='end'>
-              <DropdownMenuItem
-                variant='destructive'
-                disabled={plan.status === 'generating'}
-                onSelect={() => setDeleteDialogOpen(true)}
-              >
-                <Trash2 className='mr-2 size-4' />
-                Delete plan
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          ) : null}
         </div>
       </div>
     </div>

--- a/src/app/(app)/plans/components/PlanRow.tsx
+++ b/src/app/(app)/plans/components/PlanRow.tsx
@@ -147,6 +147,30 @@ export function PlanRow({
     referenceTimestamp,
   );
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const rowContent = (
+    <>
+      <div className='grid gap-3 md:grid-cols-[minmax(0,1fr)_7.5rem_7rem] md:items-start md:gap-4'>
+        <div className='min-w-0 space-y-1.5'>
+          <div className='flex min-w-0 flex-wrap items-center gap-2'>
+            <StatusPill plan={plan} />
+            <PlanTitle plan={plan} progressPercent={progressPercent} />
+          </div>
+          <NextTask plan={plan} />
+        </div>
+
+        <div className='min-w-0 md:pt-1'>
+          <TaskCount plan={plan} />
+        </div>
+        <div className='min-w-0 md:pt-1'>
+          <LastActivity value={lastActivity} />
+        </div>
+      </div>
+
+      <div className='mt-3'>
+        <ProgressTrack progressPercent={progressPercent} />
+      </div>
+    </>
+  );
 
   return (
     <div className='relative'>
@@ -180,31 +204,13 @@ export function PlanRow({
 
         <div className='relative min-w-0 flex-1'>
           <div className='group rounded-2xl border border-panel-border bg-panel px-4 py-3.5 shadow-sm transition-[border-color,box-shadow,background-color] hover:border-primary/25 hover:bg-panel-muted/35 hover:shadow-md'>
-            <Link
-              href={`/plans/${plan.id}`}
-              className={cn('block min-w-0', !selectionMode && 'pr-12')}
-            >
-              <div className='grid gap-3 md:grid-cols-[minmax(0,1fr)_7.5rem_7rem] md:items-start md:gap-4'>
-                <div className='min-w-0 space-y-1.5'>
-                  <div className='flex min-w-0 flex-wrap items-center gap-2'>
-                    <StatusPill plan={plan} />
-                    <PlanTitle plan={plan} progressPercent={progressPercent} />
-                  </div>
-                  <NextTask plan={plan} />
-                </div>
-
-                <div className='min-w-0 md:pt-1'>
-                  <TaskCount plan={plan} />
-                </div>
-                <div className='min-w-0 md:pt-1'>
-                  <LastActivity value={lastActivity} />
-                </div>
-              </div>
-
-              <div className='mt-3'>
-                <ProgressTrack progressPercent={progressPercent} />
-              </div>
-            </Link>
+            {selectionMode ? (
+              <div className='block min-w-0'>{rowContent}</div>
+            ) : (
+              <Link href={`/plans/${plan.id}`} className='block min-w-0 pr-12'>
+                {rowContent}
+              </Link>
+            )}
           </div>
 
           {!selectionMode ? (

--- a/src/app/(app)/plans/components/PlanRow.tsx
+++ b/src/app/(app)/plans/components/PlanRow.tsx
@@ -4,7 +4,6 @@ import type { PlanListItem } from '@/features/plans/read-projection/types';
 
 import { DeletePlanDialog } from '@/app/(app)/plans/components/DeletePlanDialog';
 import { getPlanLastActivityRelative } from '@/app/(app)/plans/components/plan-utils';
-import { getPlanStatusDotClassName } from '@/app/(app)/plans/plan-status-theme';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -29,15 +28,114 @@ interface PlanRowProps {
   referenceTimestamp: string;
 }
 
-function getNextTaskLabel(plan: PlanListItem): string {
-  if (plan.status === 'completed') return 'All tasks completed';
-  if (plan.completedTasks === 0) return 'Not started';
-  return 'Continue learning';
+const PLAN_STATUS_LABELS: Record<PlanListItem['status'], string> = {
+  not_started: 'Not started',
+  active: 'Active',
+  paused: 'Inactive',
+  completed: 'Completed',
+  generating: 'Generating',
+  failed: 'Failed',
+};
+
+const PLAN_STATUS_PILL_CLASS: Record<PlanListItem['status'], string> = {
+  not_started: 'border-muted-foreground/35 bg-muted-foreground/5',
+  active: 'border-success/50 bg-success/5 text-success',
+  paused: 'border-warning/50 bg-warning/5 text-warning',
+  completed: 'border-chart-3/50 bg-chart-3/5 text-chart-3',
+  generating: 'border-primary/50 bg-primary/5 text-primary',
+  failed: 'border-destructive/50 bg-destructive/5 text-destructive',
+};
+
+function StatusPill({ plan }: { plan: PlanListItem }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-xs font-medium text-muted-foreground',
+        PLAN_STATUS_PILL_CLASS[plan.status],
+      )}
+    >
+      {PLAN_STATUS_LABELS[plan.status]}
+    </span>
+  );
+}
+
+function PlanTitle({
+  plan,
+  progressPercent,
+}: {
+  plan: PlanListItem;
+  progressPercent: number;
+}) {
+  return (
+    <div className='flex min-w-0 items-center gap-2'>
+      <span className='truncate font-semibold text-foreground'>
+        {plan.topic}
+      </span>
+      {progressPercent >= 80 ? (
+        <Sparkles className='size-3.5 shrink-0 text-warning' />
+      ) : null}
+    </div>
+  );
+}
+
+function NextTask({ plan }: { plan: PlanListItem }) {
+  const nextTask =
+    plan.status === 'completed'
+      ? 'All tasks completed'
+      : plan.completedTasks === 0
+        ? 'Not started'
+        : 'Continue learning';
+  const showArrow = plan.status !== 'completed' && plan.completedTasks > 0;
+
+  return (
+    <div className='flex min-w-0 items-center gap-2 text-xs text-muted-foreground'>
+      {showArrow ? <ArrowRight className='size-3 shrink-0' /> : null}
+      <span className='truncate'>{nextTask}</span>
+    </div>
+  );
+}
+
+function TaskCount({ plan }: { plan: PlanListItem }) {
+  return (
+    <div className='flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground'>
+      <CheckCircle2 className='size-3.5 shrink-0' />
+      <span className='truncate tabular-nums'>
+        {plan.completedTasks}/{plan.totalTasks} tasks
+      </span>
+    </div>
+  );
+}
+
+function LastActivity({ value }: { value: string }) {
+  return (
+    <div className='flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground'>
+      <Clock className='size-3.5 shrink-0' />
+      <span className='truncate'>{value}</span>
+    </div>
+  );
+}
+
+function ProgressTrack({ progressPercent }: { progressPercent: number }) {
+  return (
+    <>
+      <progress className='sr-only' value={progressPercent} max={100}>
+        {progressPercent}% complete
+      </progress>
+      <div className='h-1 overflow-hidden rounded-full bg-muted-foreground/10'>
+        <div
+          className='h-full rounded-full bg-primary'
+          style={{ width: `${progressPercent}%` }}
+        />
+      </div>
+    </>
+  );
 }
 
 export function PlanRow({ plan, referenceTimestamp }: PlanRowProps) {
-  const progressPercent = Math.round(plan.completion * 100);
-  const nextTask = getNextTaskLabel(plan);
+  const progressPercent = Math.max(
+    0,
+    Math.min(100, Math.round(plan.completion * 100)),
+  );
   const lastActivity = getPlanLastActivityRelative(
     plan.updatedAt ?? plan.createdAt,
     referenceTimestamp,
@@ -45,7 +143,7 @@ export function PlanRow({ plan, referenceTimestamp }: PlanRowProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   return (
-    <>
+    <div className='relative'>
       <DeletePlanDialog
         planId={plan.id}
         planTopic={plan.topic}
@@ -53,105 +151,61 @@ export function PlanRow({ plan, referenceTimestamp }: PlanRowProps) {
         open={deleteDialogOpen}
         onOpenChange={setDeleteDialogOpen}
       />
-      <div
-        className={cn(
-          'group flex items-center gap-4 rounded-2xl px-5 py-4 transition-colors',
-          'hover:bg-muted-foreground/3 dark:hover:bg-foreground/5',
-        )}
-      >
-        <Link
-          href={`/plans/${plan.id}`}
-          className='flex min-w-0 flex-1 items-center gap-4'
-        >
-          {/* Status indicator */}
-          <div className='relative shrink-0'>
-            <div
-              className={cn(
-                'size-3 rounded-full',
-                getPlanStatusDotClassName(plan.status),
-              )}
-            />
-            {plan.status === 'generating' && (
-              <div
-                className={cn(
-                  'absolute inset-0 animate-ping rounded-full opacity-50 motion-reduce:animate-none',
-                  getPlanStatusDotClassName(plan.status),
-                )}
-              />
-            )}
-          </div>
 
-          {/* Title & Next Task */}
-          <div className='min-w-0 flex-1'>
-            <div className='flex items-center gap-2'>
-              <span className='truncate font-medium text-foreground'>
-                {plan.topic}
-              </span>
-              {progressPercent >= 80 && (
-                <Sparkles className='size-3.5 shrink-0 text-warning' />
-              )}
-              {/* Tasks count */}
-              <div className='hidden w-[3.75rem] shrink-0 items-center gap-1.5 text-xs text-muted-foreground sm:flex'>
-                <CheckCircle2 className='size-3.5' />
-                <span className='tabular-nums'>
-                  {plan.completedTasks}/{plan.totalTasks}
-                </span>
+      <div className='relative'>
+        <div className='group rounded-2xl border border-panel-border bg-panel px-4 py-3.5 shadow-sm transition-[border-color,box-shadow,background-color] hover:border-primary/25 hover:bg-panel-muted/35 hover:shadow-md'>
+          <Link
+            href={`/plans/${plan.id}`}
+            className='block min-w-0 pr-12'
+          >
+            <div className='grid gap-3 md:grid-cols-[minmax(0,1fr)_7.5rem_7rem] md:items-start md:gap-4'>
+              <div className='min-w-0 space-y-1.5'>
+                <div className='flex min-w-0 flex-wrap items-center gap-2'>
+                  <StatusPill plan={plan} />
+                  <PlanTitle plan={plan} progressPercent={progressPercent} />
+                </div>
+                <NextTask plan={plan} />
+              </div>
+
+              <div className='min-w-0 md:pt-1'>
+                <TaskCount plan={plan} />
+              </div>
+              <div className='min-w-0 md:pt-1'>
+                <LastActivity value={lastActivity} />
               </div>
             </div>
-            <div className='flex items-center gap-2 text-xs text-muted-foreground'>
-              {plan.completedTasks > 0 &&
-                nextTask !== 'Not started' &&
-                nextTask !== 'All tasks completed' && (
-                  <ArrowRight className='size-3' />
-                )}
-              <span className='truncate'>{nextTask}</span>
+
+            <div className='mt-3'>
+              <ProgressTrack progressPercent={progressPercent} />
             </div>
-          </div>
+          </Link>
+        </div>
 
-          {/* Progress */}
-          <div className='flex w-32 shrink-0 items-center gap-2'>
-            <div className='h-1.5 flex-1 overflow-hidden rounded-full bg-muted-foreground/10'>
-              <div
-                className='h-full rounded-full bg-primary'
-                style={{ width: `${progressPercent}%` }}
-              />
-            </div>
-            <span className='w-8 text-right text-xs font-medium text-muted-foreground tabular-nums'>
-              {progressPercent}%
-            </span>
-          </div>
-
-          {/* Last activity */}
-          <div className='hidden w-48 shrink-0 items-center justify-end gap-1.5 text-xs text-muted-foreground md:flex'>
-            <Clock className='size-3.5' />
-            {lastActivity}
-          </div>
-        </Link>
-
-        {/* Actions menu */}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant='ghost'
-              size='icon'
-              title='Plan actions'
-              aria-label='Plan actions'
-            >
-              <MoreVertical className='size-4' />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align='end'>
-            <DropdownMenuItem
-              variant='destructive'
-              disabled={plan.status === 'generating'}
-              onSelect={() => setDeleteDialogOpen(true)}
-            >
-              <Trash2 className='mr-2 size-4' />
-              Delete plan
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <div className='absolute top-2 right-2'>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant='ghost'
+                size='icon'
+                title='Plan actions'
+                aria-label='Plan actions'
+              >
+                <MoreVertical className='size-4' />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align='end'>
+              <DropdownMenuItem
+                variant='destructive'
+                disabled={plan.status === 'generating'}
+                onSelect={() => setDeleteDialogOpen(true)}
+              >
+                <Trash2 className='mr-2 size-4' />
+                Delete plan
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/src/app/(app)/plans/components/PlanRow.tsx
+++ b/src/app/(app)/plans/components/PlanRow.tsx
@@ -4,6 +4,10 @@ import type { PlanListItem } from '@/features/plans/read-projection/types';
 
 import { DeletePlanDialog } from '@/app/(app)/plans/components/DeletePlanDialog';
 import { getPlanLastActivityRelative } from '@/app/(app)/plans/components/plan-utils';
+import {
+  getPlanStatusPillClassName,
+  PLAN_STATUS_LABELS,
+} from '@/app/(app)/plans/plan-status-theme';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -28,30 +32,12 @@ interface PlanRowProps {
   referenceTimestamp: string;
 }
 
-const PLAN_STATUS_LABELS: Record<PlanListItem['status'], string> = {
-  not_started: 'Not started',
-  active: 'Active',
-  paused: 'Inactive',
-  completed: 'Completed',
-  generating: 'Generating',
-  failed: 'Failed',
-};
-
-const PLAN_STATUS_PILL_CLASS: Record<PlanListItem['status'], string> = {
-  not_started: 'border-muted-foreground/35 bg-muted-foreground/5',
-  active: 'border-success/50 bg-success/5 text-success',
-  paused: 'border-warning/50 bg-warning/5 text-warning',
-  completed: 'border-chart-3/50 bg-chart-3/5 text-chart-3',
-  generating: 'border-primary/50 bg-primary/5 text-primary',
-  failed: 'border-destructive/50 bg-destructive/5 text-destructive',
-};
-
 function StatusPill({ plan }: { plan: PlanListItem }) {
   return (
     <span
       className={cn(
         'inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-xs font-medium text-muted-foreground',
-        PLAN_STATUS_PILL_CLASS[plan.status],
+        getPlanStatusPillClassName(plan.status),
       )}
     >
       {PLAN_STATUS_LABELS[plan.status]}
@@ -154,10 +140,7 @@ export function PlanRow({ plan, referenceTimestamp }: PlanRowProps) {
 
       <div className='relative'>
         <div className='group rounded-2xl border border-panel-border bg-panel px-4 py-3.5 shadow-sm transition-[border-color,box-shadow,background-color] hover:border-primary/25 hover:bg-panel-muted/35 hover:shadow-md'>
-          <Link
-            href={`/plans/${plan.id}`}
-            className='block min-w-0 pr-12'
-          >
+          <Link href={`/plans/${plan.id}`} className='block min-w-0 pr-12'>
             <div className='grid gap-3 md:grid-cols-[minmax(0,1fr)_7.5rem_7rem] md:items-start md:gap-4'>
               <div className='min-w-0 space-y-1.5'>
                 <div className='flex min-w-0 flex-wrap items-center gap-2'>

--- a/src/app/(app)/plans/components/PlansContent.tsx
+++ b/src/app/(app)/plans/components/PlansContent.tsx
@@ -1,13 +1,10 @@
 import type { PlansPageData } from '@/app/(app)/plans/plans-page-data';
 import type { PlanListQuery } from '@/features/plans/read-projection/types';
 
+import { EmptyPlansList } from '@/app/(app)/plans/components/EmptyPlansList';
 import { PlanCountBadge } from '@/app/(app)/plans/components/PlanCountBadge';
 import { PlansList } from '@/app/(app)/plans/components/PlansList';
-import { Button } from '@/components/ui/button';
-import { RouteEmptyState } from '@/components/ui/route-empty-state';
 import { ROUTES } from '@/features/navigation/routes';
-import { Plus, Sparkles } from 'lucide-react';
-import Link from 'next/link';
 import { redirect } from 'next/navigation';
 
 /**
@@ -54,7 +51,7 @@ export async function PlansContent({
     );
   }
 
-  const { plansPage, usage } = result;
+  const { plansPage } = result;
 
   if (
     plansPage.totalSearchResults === 0 &&
@@ -63,19 +60,10 @@ export async function PlansContent({
   ) {
     return (
       <section aria-label='No plans found'>
-        <RouteEmptyState
-          className='min-h-72'
-          icon={Sparkles}
-          title='No learning plans yet'
-          description="Start by describing what you want to learn and we'll create a personalized learning plan with resources and milestones."
-          action={
-            <Button asChild size='lg'>
-              <Link href='/plans/new'>
-                <Plus />
-                Create your first plan
-              </Link>
-            </Button>
-          }
+        <EmptyPlansList
+          filterStatus='all'
+          isFirstRun
+          searchQuery=''
         />
       </section>
     );
@@ -85,12 +73,6 @@ export async function PlansContent({
     <PlansList
       page={plansPage}
       query={query}
-      usage={{
-        tier: usage.tier,
-        activePlans: usage.activePlans,
-        regenerations: usage.regenerations,
-        exports: usage.exports,
-      }}
     />
   );
 }

--- a/src/app/(app)/plans/components/PlansContentSkeleton.tsx
+++ b/src/app/(app)/plans/components/PlansContentSkeleton.tsx
@@ -1,5 +1,10 @@
+import {
+  ATLAS_CONTROL_CLASS,
+  ATLAS_HERO_SURFACE_CLASS,
+} from '@/app/(app)/plans/components/plans-atlas-classes';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Surface } from '@/components/ui/surface';
+import { cn } from '@/lib/utils';
 import { Search } from 'lucide-react';
 
 /**
@@ -9,7 +14,7 @@ import { Search } from 'lucide-react';
 export function PlansContentSkeleton() {
   return (
     <div className='space-y-5'>
-      <Surface className='space-y-5 border-primary/20 bg-linear-to-br from-primary/10 via-panel to-success/5'>
+      <Surface className={cn('space-y-5', ATLAS_HERO_SURFACE_CLASS)}>
         <div className='flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between'>
           <div className='min-w-0 space-y-2'>
             <Skeleton className='h-8 w-64 max-w-full' />
@@ -30,7 +35,10 @@ export function PlansContentSkeleton() {
         </div>
       </Surface>
 
-      <Surface padding='compact' className='space-y-4'>
+      <Surface
+        padding='compact'
+        className={cn('space-y-4', ATLAS_CONTROL_CLASS)}
+      >
         <div className='relative'>
           <Search className='pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground' />
           <Skeleton className='h-11 w-full rounded-md' />

--- a/src/app/(app)/plans/components/PlansContentSkeleton.tsx
+++ b/src/app/(app)/plans/components/PlansContentSkeleton.tsx
@@ -1,4 +1,5 @@
 import { Skeleton } from '@/components/ui/skeleton';
+import { Surface } from '@/components/ui/surface';
 import { Search } from 'lucide-react';
 
 /**
@@ -7,29 +8,50 @@ import { Search } from 'lucide-react';
  */
 export function PlansContentSkeleton() {
   return (
-    <>
-      {/* Search Bar skeleton */}
-      <div className='relative mb-6'>
-        <Search className='pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground' />
-        <Skeleton className='h-11 w-full rounded-md' />
-      </div>
+    <div className='space-y-5'>
+      <Surface className='space-y-5 border-primary/20 bg-linear-to-br from-primary/10 via-panel to-success/5'>
+        <div className='flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between'>
+          <div className='min-w-0 space-y-2'>
+            <Skeleton className='h-8 w-64 max-w-full' />
+            <Skeleton className='h-4 w-full max-w-xl' />
+          </div>
+          <div className='grid gap-3 sm:grid-cols-2 lg:min-w-[16rem]'>
+            {[1, 2].map((statSkeletonId) => (
+              <div
+                key={`plans-stat-skeleton-${statSkeletonId}`}
+                className='border-l border-border/80 pl-3'
+              >
+                <Skeleton className='mb-2 h-7 w-10' />
+                <Skeleton className='mb-1 h-3 w-20' />
+                <Skeleton className='h-3 w-24' />
+              </div>
+            ))}
+          </div>
+        </div>
+      </Surface>
 
-      <div className='mb-6 flex flex-wrap items-center gap-2 border-b border-border pb-4'>
-        <Skeleton className='h-9 w-24 rounded-lg' />
-        <Skeleton className='h-9 w-24 rounded-lg' />
-        <Skeleton className='h-9 w-28 rounded-lg' />
-        <Skeleton className='h-9 w-24 rounded-lg' />
-        <Skeleton className='h-9 w-28 rounded-lg' />
-        <Skeleton className='h-9 w-20 rounded-lg' />
-      </div>
+      <Surface padding='compact' className='space-y-4'>
+        <div className='relative'>
+          <Search className='pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground' />
+          <Skeleton className='h-11 w-full rounded-md' />
+        </div>
 
-      {/* Plans List skeleton */}
+        <div className='flex flex-wrap items-center gap-2'>
+          <Skeleton className='h-9 w-24 rounded-lg' />
+          <Skeleton className='h-9 w-24 rounded-lg' />
+          <Skeleton className='h-9 w-28 rounded-lg' />
+          <Skeleton className='h-9 w-24 rounded-lg' />
+          <Skeleton className='h-9 w-28 rounded-lg' />
+          <Skeleton className='h-9 w-20 rounded-lg' />
+        </div>
+      </Surface>
+
       <div className='space-y-2'>
         {[1, 2, 3, 4, 5].map((planSkeletonId) => (
           <PlanRowSkeleton key={`plan-row-skeleton-${planSkeletonId}`} />
         ))}
       </div>
-    </>
+    </div>
   );
 }
 

--- a/src/app/(app)/plans/components/PlansList.tsx
+++ b/src/app/(app)/plans/components/PlansList.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import type { UsageData } from '@/app/_shared/usage-formatting';
 import type {
   FilterStatus,
   PlanListPage,
@@ -13,6 +12,7 @@ import { PlanRow } from '@/app/(app)/plans/components/PlanRow';
 import { getPlanStatusDotClassName } from '@/app/(app)/plans/plan-status-theme';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Surface } from '@/components/ui/surface';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { cn } from '@/lib/utils';
 import { ChevronLeft, ChevronRight, Search } from 'lucide-react';
@@ -21,7 +21,6 @@ import Link from 'next/link';
 interface PlansListProps {
   page: PlanListPage;
   query: PlanListQuery;
-  usage?: UsageData;
 }
 
 const FILTER_TABS: {
@@ -30,12 +29,17 @@ const FILTER_TABS: {
   status?: PlanReadStatus;
 }[] = [
   { id: 'all', label: 'All' },
+  { id: 'not_started', label: 'Not started', status: 'not_started' },
   { id: 'active', label: 'Active', status: 'active' },
   { id: 'completed', label: 'Completed', status: 'completed' },
   { id: 'inactive', label: 'Inactive', status: 'paused' },
   { id: 'generating', label: 'Generating', status: 'generating' },
   { id: 'failed', label: 'Failed', status: 'failed' },
 ];
+
+const ATLAS_CONTROL_CLASS = 'border-primary/20 bg-panel';
+const ATLAS_TAB_CLASS =
+  'data-[state=active]:border-primary/40 data-[state=active]:bg-primary/10 data-[state=active]:text-primary-dark dark:data-[state=active]:text-primary';
 
 function plansHref(params: {
   search: string;
@@ -67,10 +71,62 @@ function getFilterCount(
   return tab.status ? page.statusCounts[tab.status] : 0;
 }
 
-export function PlansList({ page, query, usage: _usage }: PlansListProps) {
+function PlansHero({ page }: { page: PlanListPage }) {
   return (
-    <>
-      <form action='/plans' className='relative mb-6'>
+    <section
+      aria-label='Plans overview'
+      className='relative overflow-hidden rounded-2xl border border-primary/20 bg-linear-to-br from-primary/10 via-panel to-success/5 p-5 shadow-sm sm:p-6'
+    >
+      <div className='flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between'>
+        <div className='min-w-0'>
+          <h2 className='text-2xl font-semibold text-foreground sm:text-3xl'>
+            Learning plan library
+          </h2>
+          <p className='mt-2 max-w-2xl text-sm leading-6 text-muted-foreground'>
+            A mapped library with milestone rails and calm progress cues.
+          </p>
+        </div>
+
+        <div className='grid gap-3 sm:grid-cols-2 lg:min-w-[16rem]'>
+          <div className='min-w-0 border-l border-border/80 pl-3'>
+            <div className='text-2xl font-semibold text-foreground tabular-nums'>
+              {page.statusCounts.active}
+            </div>
+            <div className='text-xs font-medium text-foreground'>Active</div>
+            <div className='truncate text-xs text-muted-foreground'>
+              In progress
+            </div>
+          </div>
+          <div className='min-w-0 border-l border-border/80 pl-3'>
+            <div className='text-2xl font-semibold text-foreground tabular-nums'>
+              {page.statusCounts.completed}
+            </div>
+            <div className='text-xs font-medium text-foreground'>
+              Completed
+            </div>
+            <div className='truncate text-xs text-muted-foreground'>
+              Finished plans
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function PlansControls({
+  page,
+  query,
+}: {
+  page: PlanListPage;
+  query: PlanListQuery;
+}) {
+  return (
+    <Surface
+      padding='compact'
+      className={cn('space-y-4', ATLAS_CONTROL_CLASS)}
+    >
+      <form action='/plans' className='relative'>
         <Search
           className='pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground'
           aria-hidden='true'
@@ -81,51 +137,61 @@ export function PlansList({ page, query, usage: _usage }: PlansListProps) {
         <Input
           type='search'
           name='search'
-          placeholder='Search plans…'
+          placeholder='Search plans...'
           aria-label='Search learning plans'
-          className='h-11 border-border bg-muted/50 pl-9 dark:bg-muted/30'
+          className='h-11 border-border bg-background pl-9 dark:bg-input/30'
           defaultValue={query.search}
         />
       </form>
 
-      <div className='mb-6 flex items-center gap-2 border-b border-border pb-4'>
-        <Tabs value={query.status}>
-          <TabsList className='h-auto flex-wrap gap-1 bg-transparent p-0'>
-            {FILTER_TABS.map((tab) => {
-              const count = getFilterCount(tab, page);
-              return (
-                <TabsTrigger
-                  asChild
-                  key={tab.id}
-                  value={tab.id}
-                  className='rounded-lg px-3 py-1.5'
+      <Tabs value={query.status}>
+        <TabsList className='h-auto flex-wrap gap-1 bg-transparent p-0'>
+          {FILTER_TABS.map((tab) => {
+            const count = getFilterCount(tab, page);
+            return (
+              <TabsTrigger
+                asChild
+                key={tab.id}
+                value={tab.id}
+                className={cn(
+                  'rounded-lg border border-transparent px-3 py-1.5 text-sm',
+                  ATLAS_TAB_CLASS,
+                )}
+              >
+                <Link
+                  href={plansHref({
+                    search: query.search,
+                    status: tab.id,
+                  })}
                 >
-                  <Link
-                    href={plansHref({
-                      search: query.search,
-                      status: tab.id,
-                    })}
-                  >
-                    {tab.status ? (
-                      <span
-                        className={cn(
-                          'size-2 rounded-full',
-                          getPlanStatusDotClassName(tab.status),
-                        )}
-                        aria-hidden='true'
-                      />
-                    ) : null}
-                    {tab.label}
-                    <span className='text-muted-foreground tabular-nums'>
-                      ({count})
-                    </span>
-                  </Link>
-                </TabsTrigger>
-              );
-            })}
-          </TabsList>
-        </Tabs>
-      </div>
+                  {tab.status ? (
+                    <span
+                      className={cn(
+                        'size-2 rounded-full',
+                        getPlanStatusDotClassName(tab.status),
+                      )}
+                      aria-hidden='true'
+                    />
+                  ) : null}
+                  {tab.label}
+                  <span className='text-muted-foreground tabular-nums'>
+                    ({count})
+                  </span>
+                </Link>
+              </TabsTrigger>
+            );
+          })}
+        </TabsList>
+      </Tabs>
+    </Surface>
+  );
+}
+
+export function PlansList({ page, query }: PlansListProps) {
+  return (
+    <div className='space-y-5'>
+      <PlansHero page={page} />
+      <PlansControls page={page} query={query} />
 
       <div>
         {page.items.length === 0 ? (
@@ -134,7 +200,7 @@ export function PlansList({ page, query, usage: _usage }: PlansListProps) {
             filterStatus={query.status}
           />
         ) : (
-          <div className='space-y-2'>
+          <section aria-label='Learning plans' className='space-y-3'>
             {page.items.map((plan) => (
               <PlanRow
                 key={plan.id}
@@ -142,14 +208,17 @@ export function PlansList({ page, query, usage: _usage }: PlansListProps) {
                 referenceTimestamp={page.referenceTimestamp}
               />
             ))}
-          </div>
+          </section>
         )}
       </div>
 
       {page.totalPages > 1 ? (
         <nav
           aria-label='Plans pagination'
-          className='mt-6 flex items-center justify-between gap-4 text-sm text-muted-foreground'
+          className={cn(
+            'mt-6 flex flex-col gap-3 rounded-2xl border p-4 text-sm text-muted-foreground shadow-sm sm:flex-row sm:items-center sm:justify-between',
+            ATLAS_CONTROL_CLASS,
+          )}
         >
           <span>
             Page {page.page} of {page.totalPages}
@@ -206,6 +275,6 @@ export function PlansList({ page, query, usage: _usage }: PlansListProps) {
           </div>
         </nav>
       ) : null}
-    </>
+    </div>
   );
 }

--- a/src/app/(app)/plans/components/PlansList.tsx
+++ b/src/app/(app)/plans/components/PlansList.tsx
@@ -2,11 +2,17 @@
 
 import type {
   FilterStatus,
+  PlanListItem,
   PlanListPage,
   PlanListQuery,
+  PlanListSort,
   PlanReadStatus,
 } from '@/features/plans/read-projection/types';
 
+import {
+  BulkDeletePlansDialog,
+  type BulkDeletePlansResult,
+} from '@/app/(app)/plans/components/BulkDeletePlansDialog';
 import { EmptyPlansList } from '@/app/(app)/plans/components/EmptyPlansList';
 import { PlanRow } from '@/app/(app)/plans/components/PlanRow';
 import {
@@ -22,6 +28,9 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { cn } from '@/lib/utils';
 import { ChevronLeft, ChevronRight, Search } from 'lucide-react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
 
 interface PlansListProps {
   page: PlanListPage;
@@ -42,9 +51,20 @@ const FILTER_TABS: {
   { id: 'failed', label: 'Failed', status: 'failed' },
 ];
 
+const SORT_OPTIONS: { value: PlanListSort; label: string }[] = [
+  { value: 'recommended', label: 'Recommended' },
+  { value: 'recently_updated', label: 'Recently updated' },
+  { value: 'newest', label: 'Newest' },
+];
+
+function isPlanBulkDeletable(plan: PlanListItem): boolean {
+  return plan.status !== 'generating';
+}
+
 function plansHref(params: {
   search: string;
   status: FilterStatus;
+  sort: PlanListSort;
   page?: number;
 }): string {
   const searchParams = new URLSearchParams();
@@ -54,6 +74,9 @@ function plansHref(params: {
   }
   if (params.status !== 'all') {
     searchParams.set('status', params.status);
+  }
+  if (params.sort !== 'recommended') {
+    searchParams.set('sort', params.sort);
   }
   if (params.page && params.page > 1) {
     searchParams.set('page', String(params.page));
@@ -116,12 +139,96 @@ function PlansHero({ page }: { page: PlanListPage }) {
   );
 }
 
+function BulkPlanActionsToolbar({
+  selectedCount,
+  deletableCount,
+  toolbarMessage,
+  onSelectAll,
+  onClear,
+  onDelete,
+  onCancelSelection,
+}: {
+  selectedCount: number;
+  deletableCount: number;
+  toolbarMessage: string | null;
+  onSelectAll: () => void;
+  onClear: () => void;
+  onDelete: () => void;
+  onCancelSelection: () => void;
+}) {
+  return (
+    <Surface
+      padding='compact'
+      className={cn('space-y-3', ATLAS_CONTROL_CLASS)}
+      aria-label='Bulk plan actions'
+    >
+      <div className='flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between'>
+        <div className='space-y-1'>
+          <p className='text-sm font-medium text-foreground'>
+            {selectedCount} selected
+          </p>
+          {toolbarMessage ? (
+            <p className='text-sm text-destructive'>{toolbarMessage}</p>
+          ) : deletableCount === 0 ? (
+            <p className='text-sm text-muted-foreground'>
+              No deletable plans on this page.
+            </p>
+          ) : null}
+        </div>
+        <div className='flex flex-wrap items-center gap-2'>
+          <Button
+            type='button'
+            variant='outline'
+            size='sm'
+            onClick={onSelectAll}
+            disabled={deletableCount === 0}
+          >
+            Select all on page
+          </Button>
+          <Button
+            type='button'
+            variant='outline'
+            size='sm'
+            onClick={onClear}
+            disabled={selectedCount === 0}
+          >
+            Clear
+          </Button>
+          <Button
+            type='button'
+            variant='destructive'
+            size='sm'
+            onClick={onDelete}
+            disabled={selectedCount === 0}
+          >
+            Delete selected
+          </Button>
+          <Button
+            type='button'
+            variant='ghost'
+            size='sm'
+            onClick={onCancelSelection}
+          >
+            Cancel
+          </Button>
+        </div>
+      </div>
+    </Surface>
+  );
+}
+
 function PlansControls({
   page,
   query,
+  selectionMode,
+  onEnterSelectionMode,
+  canEnterSelectionMode,
 }: {
   page: PlanListPage;
   query: PlanListQuery;
+  selectionMode: boolean;
+  onEnterSelectionMode: () => void;
+  canEnterSelectionMode: boolean;
 }) {
   return (
     <Surface padding='compact' className={cn('space-y-4', ATLAS_CONTROL_CLASS)}>
@@ -133,6 +240,9 @@ function PlansControls({
         {query.status !== 'all' ? (
           <input type='hidden' name='status' value={query.status} />
         ) : null}
+        {query.sort !== 'recommended' ? (
+          <input type='hidden' name='sort' value={query.sort} />
+        ) : null}
         <Input
           type='search'
           name='search'
@@ -142,6 +252,46 @@ function PlansControls({
           defaultValue={query.search}
         />
       </form>
+
+      <div className='flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between'>
+        <form action='/plans' className='flex items-center gap-2'>
+          <label htmlFor='plans-sort' className='text-sm text-muted-foreground'>
+            Sort
+          </label>
+          {query.search ? (
+            <input type='hidden' name='search' value={query.search} />
+          ) : null}
+          {query.status !== 'all' ? (
+            <input type='hidden' name='status' value={query.status} />
+          ) : null}
+          <select
+            id='plans-sort'
+            name='sort'
+            defaultValue={query.sort}
+            onChange={(event) => event.currentTarget.form?.requestSubmit()}
+            className='h-9 rounded-md border border-input bg-background px-3 text-sm shadow-xs dark:bg-input/30'
+            aria-label='Sort learning plans'
+          >
+            {SORT_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </form>
+
+        {!selectionMode ? (
+          <Button
+            type='button'
+            variant='outline'
+            size='sm'
+            onClick={onEnterSelectionMode}
+            disabled={!canEnterSelectionMode}
+          >
+            Select
+          </Button>
+        ) : null}
+      </div>
 
       <Tabs value={query.status}>
         <TabsList className='h-auto flex-wrap gap-1 bg-transparent p-0'>
@@ -161,6 +311,7 @@ function PlansControls({
                   href={plansHref({
                     search: query.search,
                     status: tab.id,
+                    sort: query.sort,
                   })}
                 >
                   {tab.status ? (
@@ -187,10 +338,151 @@ function PlansControls({
 }
 
 export function PlansList({ page, query }: PlansListProps) {
+  const router = useRouter();
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selectedPlanIds, setSelectedPlanIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
+  const [toolbarMessage, setToolbarMessage] = useState<string | null>(null);
+
+  const visiblePlanIds = useMemo(
+    () => page.items.map((plan) => plan.id).join(','),
+    [page.items],
+  );
+
+  const deletablePlans = useMemo(
+    () => page.items.filter(isPlanBulkDeletable),
+    [page.items],
+  );
+  const selectedPlans = useMemo(
+    () => page.items.filter((plan) => selectedPlanIds.has(plan.id)),
+    [page.items, selectedPlanIds],
+  );
+  const selectedDeletablePlans = useMemo(
+    () => selectedPlans.filter(isPlanBulkDeletable),
+    [selectedPlans],
+  );
+
+  useEffect(() => {
+    const visibleIds = new Set(page.items.map((plan) => plan.id));
+    setSelectedPlanIds((current) => {
+      const next = new Set(
+        [...current].filter((planId) => visibleIds.has(planId)),
+      );
+      return next.size === current.size ? current : next;
+    });
+  }, [visiblePlanIds, page.items]);
+
+  const handleSelectionChange = (planId: string, selected: boolean): void => {
+    setSelectedPlanIds((current) => {
+      const next = new Set(current);
+      if (selected) {
+        next.add(planId);
+      } else {
+        next.delete(planId);
+      }
+      return next;
+    });
+    setToolbarMessage(null);
+  };
+
+  const handleSelectAllOnPage = (): void => {
+    setSelectedPlanIds(() => new Set(deletablePlans.map((plan) => plan.id)));
+    setToolbarMessage(null);
+  };
+
+  const handleClearSelection = (): void => {
+    setSelectedPlanIds(() => new Set());
+    setToolbarMessage(null);
+  };
+
+  const handleEnterSelectionMode = (): void => {
+    setSelectionMode(true);
+    setToolbarMessage(null);
+  };
+
+  const handleCancelSelectionMode = (): void => {
+    setSelectionMode(false);
+    setSelectedPlanIds(() => new Set());
+    setToolbarMessage(null);
+  };
+
+  const handleBulkDeleted = (result: BulkDeletePlansResult): void => {
+    const deletedIds = new Set(
+      result.results
+        .filter((entry) => entry.success)
+        .map((entry) => entry.planId),
+    );
+    const failedResults = result.results.filter((entry) => !entry.success);
+
+    setSelectedPlanIds((current) => {
+      const next = new Set(
+        [...current].filter((planId) => !deletedIds.has(planId)),
+      );
+      return next;
+    });
+
+    if (result.deletedCount > 0 && result.failedCount === 0) {
+      toast.success(
+        `Deleted ${result.deletedCount} plan${result.deletedCount === 1 ? '' : 's'}`,
+      );
+      setSelectionMode(false);
+      setSelectedPlanIds(() => new Set());
+      setToolbarMessage(null);
+      router.refresh();
+      return;
+    }
+
+    if (result.deletedCount > 0 && result.failedCount > 0) {
+      toast.error(
+        `Deleted ${result.deletedCount} plans. ${result.failedCount} could not be deleted.`,
+      );
+      const hasGeneratingFailure = failedResults.some(
+        (entry) => entry.reason === 'currently_generating',
+      );
+      setToolbarMessage(
+        hasGeneratingFailure
+          ? 'Some plans started generating and could not be deleted.'
+          : (failedResults[0]?.message ?? null),
+      );
+      router.refresh();
+      return;
+    }
+
+    toast.error('No plans were deleted');
+    setToolbarMessage(failedResults[0]?.message ?? null);
+  };
+
   return (
     <div className='space-y-5'>
       <PlansHero page={page} />
-      <PlansControls page={page} query={query} />
+      <PlansControls
+        page={page}
+        query={query}
+        selectionMode={selectionMode}
+        onEnterSelectionMode={handleEnterSelectionMode}
+        canEnterSelectionMode={deletablePlans.length > 0}
+      />
+
+      {selectionMode ? (
+        <BulkPlanActionsToolbar
+          selectedCount={selectedDeletablePlans.length}
+          deletableCount={deletablePlans.length}
+          toolbarMessage={toolbarMessage}
+          onSelectAll={handleSelectAllOnPage}
+          onClear={handleClearSelection}
+          onDelete={() => setBulkDeleteOpen(true)}
+          onCancelSelection={handleCancelSelectionMode}
+        />
+      ) : null}
+
+      <BulkDeletePlansDialog
+        open={bulkDeleteOpen}
+        onOpenChange={setBulkDeleteOpen}
+        plans={selectedDeletablePlans}
+        onDeleted={handleBulkDeleted}
+      />
 
       <div>
         {page.items.length === 0 ? (
@@ -205,6 +497,10 @@ export function PlansList({ page, query }: PlansListProps) {
                 key={plan.id}
                 plan={plan}
                 referenceTimestamp={page.referenceTimestamp}
+                selectionMode={selectionMode}
+                selected={selectedPlanIds.has(plan.id)}
+                selectable={isPlanBulkDeletable(plan)}
+                onSelectionChange={handleSelectionChange}
               />
             ))}
           </section>
@@ -234,6 +530,7 @@ export function PlansList({ page, query }: PlansListProps) {
                   href={plansHref({
                     search: query.search,
                     status: query.status,
+                    sort: query.sort,
                     page: page.page - 1,
                   })}
                 >
@@ -258,6 +555,7 @@ export function PlansList({ page, query }: PlansListProps) {
                   href={plansHref({
                     search: query.search,
                     status: query.status,
+                    sort: query.sort,
                     page: page.page + 1,
                   })}
                 >

--- a/src/app/(app)/plans/components/PlansList.tsx
+++ b/src/app/(app)/plans/components/PlansList.tsx
@@ -9,6 +9,11 @@ import type {
 
 import { EmptyPlansList } from '@/app/(app)/plans/components/EmptyPlansList';
 import { PlanRow } from '@/app/(app)/plans/components/PlanRow';
+import {
+  ATLAS_CONTROL_CLASS,
+  ATLAS_HERO_SURFACE_CLASS,
+  ATLAS_TAB_CLASS,
+} from '@/app/(app)/plans/components/plans-atlas-classes';
 import { getPlanStatusDotClassName } from '@/app/(app)/plans/plan-status-theme';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -36,10 +41,6 @@ const FILTER_TABS: {
   { id: 'generating', label: 'Generating', status: 'generating' },
   { id: 'failed', label: 'Failed', status: 'failed' },
 ];
-
-const ATLAS_CONTROL_CLASS = 'border-primary/20 bg-panel';
-const ATLAS_TAB_CLASS =
-  'data-[state=active]:border-primary/40 data-[state=active]:bg-primary/10 data-[state=active]:text-primary-dark dark:data-[state=active]:text-primary';
 
 function plansHref(params: {
   search: string;
@@ -75,7 +76,10 @@ function PlansHero({ page }: { page: PlanListPage }) {
   return (
     <section
       aria-label='Plans overview'
-      className='relative overflow-hidden rounded-2xl border border-primary/20 bg-linear-to-br from-primary/10 via-panel to-success/5 p-5 shadow-sm sm:p-6'
+      className={cn(
+        'relative overflow-hidden rounded-2xl p-5 shadow-sm sm:p-6',
+        ATLAS_HERO_SURFACE_CLASS,
+      )}
     >
       <div className='flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between'>
         <div className='min-w-0'>
@@ -101,9 +105,7 @@ function PlansHero({ page }: { page: PlanListPage }) {
             <div className='text-2xl font-semibold text-foreground tabular-nums'>
               {page.statusCounts.completed}
             </div>
-            <div className='text-xs font-medium text-foreground'>
-              Completed
-            </div>
+            <div className='text-xs font-medium text-foreground'>Completed</div>
             <div className='truncate text-xs text-muted-foreground'>
               Finished plans
             </div>
@@ -122,10 +124,7 @@ function PlansControls({
   query: PlanListQuery;
 }) {
   return (
-    <Surface
-      padding='compact'
-      className={cn('space-y-4', ATLAS_CONTROL_CLASS)}
-    >
+    <Surface padding='compact' className={cn('space-y-4', ATLAS_CONTROL_CLASS)}>
       <form action='/plans' className='relative'>
         <Search
           className='pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground'

--- a/src/app/(app)/plans/components/PlansList.tsx
+++ b/src/app/(app)/plans/components/PlansList.tsx
@@ -29,7 +29,7 @@ import { cn } from '@/lib/utils';
 import { ChevronLeft, ChevronRight, Search } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useEffect, useMemo, useState } from 'react';
+import { useState } from 'react';
 import { toast } from 'sonner';
 
 interface PlansListProps {
@@ -345,34 +345,18 @@ export function PlansList({ page, query }: PlansListProps) {
   );
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
   const [toolbarMessage, setToolbarMessage] = useState<string | null>(null);
+  const deletablePlans: PlanListItem[] = [];
+  const selectedDeletablePlans: PlanListItem[] = [];
 
-  const visiblePlanIds = useMemo(
-    () => page.items.map((plan) => plan.id).join(','),
-    [page.items],
-  );
-
-  const deletablePlans = useMemo(
-    () => page.items.filter(isPlanBulkDeletable),
-    [page.items],
-  );
-  const selectedPlans = useMemo(
-    () => page.items.filter((plan) => selectedPlanIds.has(plan.id)),
-    [page.items, selectedPlanIds],
-  );
-  const selectedDeletablePlans = useMemo(
-    () => selectedPlans.filter(isPlanBulkDeletable),
-    [selectedPlans],
-  );
-
-  useEffect(() => {
-    const visibleIds = new Set(page.items.map((plan) => plan.id));
-    setSelectedPlanIds((current) => {
-      const next = new Set(
-        [...current].filter((planId) => visibleIds.has(planId)),
-      );
-      return next.size === current.size ? current : next;
-    });
-  }, [visiblePlanIds, page.items]);
+  for (const plan of page.items) {
+    if (!isPlanBulkDeletable(plan)) {
+      continue;
+    }
+    deletablePlans.push(plan);
+    if (selectedPlanIds.has(plan.id)) {
+      selectedDeletablePlans.push(plan);
+    }
+  }
 
   const handleSelectionChange = (planId: string, selected: boolean): void => {
     setSelectedPlanIds((current) => {
@@ -409,12 +393,19 @@ export function PlansList({ page, query }: PlansListProps) {
   };
 
   const handleBulkDeleted = (result: BulkDeletePlansResult): void => {
-    const deletedIds = new Set(
-      result.results
-        .filter((entry) => entry.success)
-        .map((entry) => entry.planId),
-    );
-    const failedResults = result.results.filter((entry) => !entry.success);
+    const deletedIds = new Set<string>();
+    const failedResults: Extract<
+      BulkDeletePlansResult['results'][number],
+      { success: false }
+    >[] = [];
+
+    for (const entry of result.results) {
+      if (entry.success) {
+        deletedIds.add(entry.planId);
+      } else {
+        failedResults.push(entry);
+      }
+    }
 
     setSelectedPlanIds((current) => {
       const next = new Set(

--- a/src/app/(app)/plans/components/plans-atlas-classes.ts
+++ b/src/app/(app)/plans/components/plans-atlas-classes.ts
@@ -1,0 +1,5 @@
+export const ATLAS_CONTROL_CLASS = 'border-primary/20 bg-panel';
+export const ATLAS_HERO_SURFACE_CLASS =
+  'border-primary/20 bg-linear-to-br from-primary/10 via-panel to-success/5';
+export const ATLAS_TAB_CLASS =
+  'data-[state=active]:border-primary/40 data-[state=active]:bg-primary/10 data-[state=active]:text-primary-dark dark:data-[state=active]:text-primary';

--- a/src/app/(app)/plans/error.tsx
+++ b/src/app/(app)/plans/error.tsx
@@ -30,6 +30,7 @@ export default function PlansError({ error, reset }: ErrorProps) {
     <>
       <PageHeader
         title='Your Plans'
+        subtitle='Search, filter, and compare your learning plan library.'
         actions={
           <Button asChild>
             <Link href='/plans/new'>
@@ -41,6 +42,7 @@ export default function PlansError({ error, reset }: ErrorProps) {
       />
 
       <RouteErrorState
+        className='border-destructive/20 bg-destructive/5'
         title='Error Loading Plans'
         message="We couldn't load your learning plans. This could be a temporary issue."
         onRetry={reset}

--- a/src/app/(app)/plans/error.tsx
+++ b/src/app/(app)/plans/error.tsx
@@ -32,12 +32,14 @@ export default function PlansError({ error, reset }: ErrorProps) {
         title='Your Plans'
         subtitle='Search, filter, and compare your learning plan library.'
         actions={
-          <Button asChild>
-            <Link href='/plans/new'>
-              <Plus />
-              New Plan
-            </Link>
-          </Button>
+          <div className='flex items-center gap-2 sm:pt-8'>
+            <Button asChild>
+              <Link href='/plans/new'>
+                <Plus />
+                New Plan
+              </Link>
+            </Button>
+          </div>
         }
       />
 

--- a/src/app/(app)/plans/loading.tsx
+++ b/src/app/(app)/plans/loading.tsx
@@ -9,10 +9,10 @@ export default function PlansLoading() {
         title='Your Plans'
         subtitle='Search, filter, and compare your learning plan library.'
         actions={
-          <>
+          <div className='flex items-center gap-2 sm:pt-8'>
             <Skeleton className='h-6 w-16 rounded-full' />
             <Skeleton className='h-10 w-24 rounded-lg' />
-          </>
+          </div>
         }
       />
       <PlansContentSkeleton />

--- a/src/app/(app)/plans/loading.tsx
+++ b/src/app/(app)/plans/loading.tsx
@@ -7,6 +7,7 @@ export default function PlansLoading() {
     <>
       <PageHeader
         title='Your Plans'
+        subtitle='Search, filter, and compare your learning plan library.'
         actions={
           <>
             <Skeleton className='h-6 w-16 rounded-full' />

--- a/src/app/(app)/plans/page.tsx
+++ b/src/app/(app)/plans/page.tsx
@@ -36,6 +36,7 @@ type PlansPageProps = {
 
 const PLAN_FILTERS = new Set<FilterStatus>([
   'all',
+  'not_started',
   'active',
   'completed',
   'generating',
@@ -76,8 +77,9 @@ export default async function PlansPage({ searchParams }: PlansPageProps) {
       {/* Static header - renders immediately; count waits independently. */}
       <PageHeader
         title='Your Plans'
+        subtitle='Search, filter, and compare your learning plan library.'
         actions={
-          <>
+          <div className='flex items-center gap-2 sm:pt-8'>
             <Suspense fallback={<Skeleton className='h-6 w-16 rounded-full' />}>
               <PlanCountBadgeContent dataPromise={plansPageData} />
             </Suspense>
@@ -87,7 +89,7 @@ export default async function PlansPage({ searchParams }: PlansPageProps) {
                 New Plan
               </Link>
             </Button>
-          </>
+          </div>
         }
       />
 

--- a/src/app/(app)/plans/page.tsx
+++ b/src/app/(app)/plans/page.tsx
@@ -14,6 +14,7 @@ import { loadPlansPageData } from '@/app/(app)/plans/plans-page-data';
 import { Button } from '@/components/ui/button';
 import { PageHeader } from '@/components/ui/page-header';
 import { Skeleton } from '@/components/ui/skeleton';
+import { PLAN_LIST_SORTS } from '@/features/plans/read-projection/types';
 import { Plus } from 'lucide-react';
 import Link from 'next/link';
 import { Suspense } from 'react';
@@ -45,11 +46,7 @@ const PLAN_FILTERS = new Set<FilterStatus>([
   'inactive',
 ]);
 
-const PLAN_SORTS = new Set<PlanListSort>([
-  'recommended',
-  'recently_updated',
-  'newest',
-]);
+const PLAN_SORTS = new Set<PlanListSort>(PLAN_LIST_SORTS);
 
 function firstSearchParam(value: string | string[] | undefined): string {
   return Array.isArray(value) ? (value[0] ?? '') : (value ?? '');

--- a/src/app/(app)/plans/page.tsx
+++ b/src/app/(app)/plans/page.tsx
@@ -1,6 +1,7 @@
 import type {
   FilterStatus,
   PlanListQuery,
+  PlanListSort,
 } from '@/features/plans/read-projection/types';
 import type { Metadata } from 'next';
 
@@ -44,6 +45,12 @@ const PLAN_FILTERS = new Set<FilterStatus>([
   'inactive',
 ]);
 
+const PLAN_SORTS = new Set<PlanListSort>([
+  'recommended',
+  'recently_updated',
+  'newest',
+]);
+
 function firstSearchParam(value: string | string[] | undefined): string {
   return Array.isArray(value) ? (value[0] ?? '') : (value ?? '');
 }
@@ -59,12 +66,17 @@ async function parsePlansQuery(
   const status = PLAN_FILTERS.has(canonicalStatusValue as FilterStatus)
     ? (canonicalStatusValue as FilterStatus)
     : 'all';
+  const sortValue = firstSearchParam(params?.sort);
+  const sort = PLAN_SORTS.has(sortValue as PlanListSort)
+    ? (sortValue as PlanListSort)
+    : 'recommended';
 
   return {
     page:
       Number.isFinite(pageValue) && pageValue >= 1 ? Math.floor(pageValue) : 1,
     search: firstSearchParam(params?.search).trim(),
     status,
+    sort,
   };
 }
 

--- a/src/app/(app)/plans/plan-status-theme.ts
+++ b/src/app/(app)/plans/plan-status-theme.ts
@@ -1,5 +1,14 @@
 import type { PlanReadStatus } from '@/features/plans/read-projection/types';
 
+export const PLAN_STATUS_LABELS: Record<PlanReadStatus, string> = {
+  not_started: 'Not started',
+  active: 'Active',
+  paused: 'Inactive',
+  completed: 'Completed',
+  generating: 'Generating',
+  failed: 'Failed',
+};
+
 /** Semantic dot color for plan list rows and filter indicators. */
 const PLAN_STATUS_DOT_CLASS: Record<PlanReadStatus, string> = {
   not_started: 'bg-muted-foreground',
@@ -12,4 +21,17 @@ const PLAN_STATUS_DOT_CLASS: Record<PlanReadStatus, string> = {
 
 export function getPlanStatusDotClassName(status: PlanReadStatus): string {
   return PLAN_STATUS_DOT_CLASS[status];
+}
+
+const PLAN_STATUS_PILL_CLASS: Record<PlanReadStatus, string> = {
+  not_started: 'border-muted-foreground/35 bg-muted-foreground/5',
+  active: 'border-success/50 bg-success/5 text-success',
+  paused: 'border-warning/50 bg-warning/5 text-warning',
+  completed: 'border-chart-3/50 bg-chart-3/5 text-chart-3',
+  generating: 'border-primary/50 bg-primary/5 text-primary',
+  failed: 'border-destructive/50 bg-destructive/5 text-destructive',
+};
+
+export function getPlanStatusPillClassName(status: PlanReadStatus): string {
+  return PLAN_STATUS_PILL_CLASS[status];
 }

--- a/src/app/(app)/plans/plan-status-theme.ts
+++ b/src/app/(app)/plans/plan-status-theme.ts
@@ -2,6 +2,7 @@ import type { PlanReadStatus } from '@/features/plans/read-projection/types';
 
 /** Semantic dot color for plan list rows and filter indicators. */
 const PLAN_STATUS_DOT_CLASS: Record<PlanReadStatus, string> = {
+  not_started: 'bg-muted-foreground',
   active: 'bg-success',
   paused: 'bg-warning',
   completed: 'bg-chart-3',

--- a/src/app/api/v1/plans/bulk-delete/route.ts
+++ b/src/app/api/v1/plans/bulk-delete/route.ts
@@ -30,19 +30,19 @@ function parseBulkDeletePlanIds(body: BulkDeleteRequestBody): string[] {
     });
   }
 
-  const dedupedPlanIds = [...new Set(body.planIds)];
-
-  if (dedupedPlanIds.length === 0) {
+  if (body.planIds.length === 0) {
     throw new ValidationError('Invalid bulk delete request.', {
       planIds: 'At least one plan ID is required.',
     });
   }
 
-  if (dedupedPlanIds.length > PLAN_LIST_PAGE_SIZE) {
+  if (body.planIds.length > PLAN_LIST_PAGE_SIZE) {
     throw new ValidationError('Invalid bulk delete request.', {
       planIds: `No more than ${PLAN_LIST_PAGE_SIZE} plan IDs are allowed.`,
     });
   }
+
+  const dedupedPlanIds = [...new Set(body.planIds)];
 
   const invalidIds = dedupedPlanIds.filter(
     (planId) => typeof planId !== 'string' || !UUID_REGEX.test(planId),

--- a/src/app/api/v1/plans/bulk-delete/route.ts
+++ b/src/app/api/v1/plans/bulk-delete/route.ts
@@ -1,0 +1,107 @@
+import { PLAN_LIST_PAGE_SIZE } from '@/features/plans/read-projection/types';
+import {
+  removePlansForWrite,
+  type BulkRemovePlanResult,
+} from '@/features/plans/write-service';
+import { ValidationError } from '@/lib/api/errors';
+import { parseJsonBody } from '@/lib/api/parse-json-body';
+import { requestBoundary } from '@/lib/api/request-boundary';
+import { json } from '@/lib/api/response';
+import { logger } from '@/lib/logging/logger';
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+type BulkDeleteRequestBody = {
+  planIds?: unknown;
+};
+
+type BulkDeleteResponse = {
+  success: boolean;
+  deletedCount: number;
+  failedCount: number;
+  results: BulkRemovePlanResult[];
+};
+
+function parseBulkDeletePlanIds(body: BulkDeleteRequestBody): string[] {
+  if (!body || typeof body !== 'object' || !Array.isArray(body.planIds)) {
+    throw new ValidationError('Invalid bulk delete request.', {
+      planIds: 'planIds must be an array.',
+    });
+  }
+
+  const dedupedPlanIds = [...new Set(body.planIds)];
+
+  if (dedupedPlanIds.length === 0) {
+    throw new ValidationError('Invalid bulk delete request.', {
+      planIds: 'At least one plan ID is required.',
+    });
+  }
+
+  if (dedupedPlanIds.length > PLAN_LIST_PAGE_SIZE) {
+    throw new ValidationError('Invalid bulk delete request.', {
+      planIds: `No more than ${PLAN_LIST_PAGE_SIZE} plan IDs are allowed.`,
+    });
+  }
+
+  const invalidIds = dedupedPlanIds.filter(
+    (planId) => typeof planId !== 'string' || !UUID_REGEX.test(planId),
+  );
+
+  if (invalidIds.length > 0) {
+    throw new ValidationError('Invalid bulk delete request.', {
+      planIds: 'Every plan ID must be a valid UUID.',
+    });
+  }
+
+  return dedupedPlanIds as string[];
+}
+
+/**
+ * POST /api/v1/plans/bulk-delete
+ * Deletes up to one page of user-owned plans and returns per-plan results.
+ */
+export const POST = requestBoundary.route(
+  { rateLimit: 'mutation' },
+  async ({ req, actor }) => {
+    const body = (await parseJsonBody(req, {
+      mode: 'required',
+      onMalformedJson: () =>
+        new ValidationError('Invalid bulk delete request.', {
+          body: 'Request body must be valid JSON.',
+        }),
+    })) as BulkDeleteRequestBody;
+    const planIds = parseBulkDeletePlanIds(body);
+
+    logger.info(
+      { userId: actor.id, planCount: planIds.length },
+      'Bulk deleting learning plans',
+    );
+
+    const results = await removePlansForWrite({
+      planIds,
+      userId: actor.id,
+    });
+
+    const deletedCount = results.filter((result) => result.success).length;
+    const failedCount = results.length - deletedCount;
+
+    logger.info(
+      {
+        userId: actor.id,
+        deletedCount,
+        failedCount,
+      },
+      'Bulk learning plan deletion completed',
+    );
+
+    const response: BulkDeleteResponse = {
+      success: deletedCount > 0,
+      deletedCount,
+      failedCount,
+      results,
+    };
+
+    return json(response);
+  },
+);

--- a/src/features/plans/read-projection/selectors.ts
+++ b/src/features/plans/read-projection/selectors.ts
@@ -6,7 +6,8 @@ import { toValidDate } from '@/lib/date/relative-time';
 
 /**
  * UI-facing plan status for list/dashboard: canonical summary status plus
- * inactivity → `paused` when underlying status is `active`.
+ * no progress → `not_started` and inactivity → `paused` when underlying
+ * status is `active`.
  *
  * `referenceDate` defaults to `new Date()` so callers only need to pass it when
  * they want deterministic comparisons (for example, tests).
@@ -23,6 +24,10 @@ export function derivePlanSummaryDisplayStatus(params: {
 
   if (canonicalStatus !== 'active') {
     return canonicalStatus;
+  }
+
+  if (summary.modules.length > 0 && summary.completedTasks === 0) {
+    return 'not_started';
   }
 
   const updatedAt = toValidDate(summary.plan.updatedAt);

--- a/src/features/plans/read-projection/types.ts
+++ b/src/features/plans/read-projection/types.ts
@@ -5,6 +5,7 @@ import type { LessonContent } from '@/shared/types/lesson-content.types';
 export type PlanDbClient = DbClient;
 
 export type PlanReadStatus =
+  | 'not_started'
   | 'active'
   | 'paused'
   | 'completed'
@@ -14,6 +15,7 @@ export type PlanReadStatus =
 /**
  * List-filter status used by plan read projections.
  * `inactive` is the canonical URL/UI aggregate for paused rows.
+ * `not_started` is the URL/UI bucket for ready plans with no completed tasks.
  */
 export type FilterStatus =
   | 'all'

--- a/src/features/plans/read-projection/types.ts
+++ b/src/features/plans/read-projection/types.ts
@@ -24,10 +24,13 @@ export type FilterStatus =
 
 export const PLAN_LIST_PAGE_SIZE = 20 as const;
 
+export type PlanListSort = 'recommended' | 'recently_updated' | 'newest';
+
 export type PlanListQuery = {
   page: number;
   search: string;
   status: FilterStatus;
+  sort: PlanListSort;
 };
 
 export type PlanListItem = {

--- a/src/features/plans/read-projection/types.ts
+++ b/src/features/plans/read-projection/types.ts
@@ -24,7 +24,13 @@ export type FilterStatus =
 
 export const PLAN_LIST_PAGE_SIZE = 20 as const;
 
-export type PlanListSort = 'recommended' | 'recently_updated' | 'newest';
+export const PLAN_LIST_SORTS = [
+  'recommended',
+  'recently_updated',
+  'newest',
+] as const;
+
+export type PlanListSort = (typeof PLAN_LIST_SORTS)[number];
 
 export type PlanListQuery = {
   page: number;

--- a/src/features/plans/write-service/index.ts
+++ b/src/features/plans/write-service/index.ts
@@ -27,3 +27,62 @@ export async function removePlanForWrite(params: {
 
   throw new ConflictError('Cannot delete learning plan in its current state.');
 }
+
+export type BulkRemovePlanFailureReason =
+  | 'not_found'
+  | 'currently_generating'
+  | 'unknown';
+
+export type BulkRemovePlanResult =
+  | { planId: string; success: true }
+  | {
+      planId: string;
+      success: false;
+      reason: BulkRemovePlanFailureReason;
+      message: string;
+    };
+
+export async function removePlansForWrite(params: {
+  planIds: string[];
+  userId: string;
+}): Promise<BulkRemovePlanResult[]> {
+  const results: BulkRemovePlanResult[] = [];
+
+  for (const planId of params.planIds) {
+    const result = await deletePlan(planId, params.userId);
+
+    if (result.success) {
+      results.push({ planId, success: true });
+      continue;
+    }
+
+    if (result.reason === 'not_found') {
+      results.push({
+        planId,
+        success: false,
+        reason: 'not_found',
+        message: 'Learning plan not found.',
+      });
+      continue;
+    }
+
+    if (result.reason === 'currently_generating') {
+      results.push({
+        planId,
+        success: false,
+        reason: 'currently_generating',
+        message: 'Cannot delete a plan that is currently generating.',
+      });
+      continue;
+    }
+
+    results.push({
+      planId,
+      success: false,
+      reason: 'unknown',
+      message: 'Cannot delete learning plan in its current state.',
+    });
+  }
+
+  return results;
+}

--- a/src/features/plans/write-service/index.ts
+++ b/src/features/plans/write-service/index.ts
@@ -1,33 +1,6 @@
 import { ConflictError, NotFoundError } from '@/lib/api/errors';
 import { deletePlan } from '@/lib/db/queries/plans';
 
-/**
- * Deletes a user-owned plan through the feature service boundary so route
- * handlers do not reach into the query layer directly.
- */
-export async function removePlanForWrite(params: {
-  planId: string;
-  userId: string;
-}): Promise<void> {
-  const result = await deletePlan(params.planId, params.userId);
-
-  if (result.success) {
-    return;
-  }
-
-  if (result.reason === 'not_found') {
-    throw new NotFoundError('Learning plan not found.');
-  }
-
-  if (result.reason === 'currently_generating') {
-    throw new ConflictError(
-      'Cannot delete a plan that is currently generating.',
-    );
-  }
-
-  throw new ConflictError('Cannot delete learning plan in its current state.');
-}
-
 export type BulkRemovePlanFailureReason =
   | 'not_found'
   | 'currently_generating'
@@ -42,47 +15,88 @@ export type BulkRemovePlanResult =
       message: string;
     };
 
+const REMOVE_PLAN_FAILURE_MESSAGES: Record<
+  BulkRemovePlanFailureReason,
+  string
+> = {
+  not_found: 'Learning plan not found.',
+  currently_generating: 'Cannot delete a plan that is currently generating.',
+  unknown: 'Cannot delete learning plan in its current state.',
+};
+
+function normalizeRemovePlanFailureReason(
+  reason: string,
+): BulkRemovePlanFailureReason {
+  return reason === 'not_found' || reason === 'currently_generating'
+    ? reason
+    : 'unknown';
+}
+
+/**
+ * Deletes a user-owned plan through the feature service boundary so route
+ * handlers do not reach into the query layer directly.
+ */
+export async function removePlanForWrite(params: {
+  planId: string;
+  userId: string;
+}): Promise<void> {
+  const result = await deletePlan(params.planId, params.userId);
+
+  if (result.success) {
+    return;
+  }
+
+  const reason = normalizeRemovePlanFailureReason(result.reason);
+
+  if (reason === 'not_found') {
+    throw new NotFoundError(REMOVE_PLAN_FAILURE_MESSAGES.not_found);
+  }
+
+  if (reason === 'currently_generating') {
+    throw new ConflictError(REMOVE_PLAN_FAILURE_MESSAGES.currently_generating);
+  }
+
+  throw new ConflictError(REMOVE_PLAN_FAILURE_MESSAGES.unknown);
+}
+
+async function removePlanForBulkWrite(params: {
+  planId: string;
+  userId: string;
+}): Promise<BulkRemovePlanResult> {
+  try {
+    const result = await deletePlan(params.planId, params.userId);
+
+    if (result.success) {
+      return { planId: params.planId, success: true };
+    }
+
+    const reason = normalizeRemovePlanFailureReason(result.reason);
+    return {
+      planId: params.planId,
+      success: false,
+      reason,
+      message: REMOVE_PLAN_FAILURE_MESSAGES[reason],
+    };
+  } catch {
+    return {
+      planId: params.planId,
+      success: false,
+      reason: 'unknown',
+      message: REMOVE_PLAN_FAILURE_MESSAGES.unknown,
+    };
+  }
+}
+
 export async function removePlansForWrite(params: {
   planIds: string[];
   userId: string;
 }): Promise<BulkRemovePlanResult[]> {
-  const results: BulkRemovePlanResult[] = [];
-
-  for (const planId of params.planIds) {
-    const result = await deletePlan(planId, params.userId);
-
-    if (result.success) {
-      results.push({ planId, success: true });
-      continue;
-    }
-
-    if (result.reason === 'not_found') {
-      results.push({
+  return Promise.all(
+    params.planIds.map((planId) =>
+      removePlanForBulkWrite({
         planId,
-        success: false,
-        reason: 'not_found',
-        message: 'Learning plan not found.',
-      });
-      continue;
-    }
-
-    if (result.reason === 'currently_generating') {
-      results.push({
-        planId,
-        success: false,
-        reason: 'currently_generating',
-        message: 'Cannot delete a plan that is currently generating.',
-      });
-      continue;
-    }
-
-    results.push({
-      planId,
-      success: false,
-      reason: 'unknown',
-      message: 'Cannot delete learning plan in its current state.',
-    });
-  }
-
-  return results;
+        userId: params.userId,
+      }),
+    ),
+  );
 }

--- a/src/lib/db/queries/plan-list.ts
+++ b/src/lib/db/queries/plan-list.ts
@@ -1,28 +1,18 @@
+import type {
+  FilterStatus,
+  PlanListQuery,
+  PlanListSort,
+  PlanReadStatus,
+} from '@/features/plans/read-projection/types';
 import type { DbClient } from '@/lib/db/types';
 
 import { getAttemptCap } from '@/lib/config/env';
 import { getDb } from '@supabase/runtime';
 import { sql, type SQL } from 'drizzle-orm';
 
-export type PlanListRowStatus =
-  | 'not_started'
-  | 'active'
-  | 'paused'
-  | 'completed'
-  | 'generating'
-  | 'failed';
-export type PlanListFilterStatus =
-  | 'all'
-  | Exclude<PlanListRowStatus, 'paused'>
-  | 'inactive';
-export type PlanListSort = 'recommended' | 'recently_updated' | 'newest';
-
-export type PlanListPageQuery = {
-  page: number;
-  search: string;
-  status: PlanListFilterStatus;
-  sort: PlanListSort;
-};
+export type PlanListRowStatus = PlanReadStatus;
+export type PlanListFilterStatus = FilterStatus;
+export type PlanListPageQuery = PlanListQuery;
 export type PlanListQueryItemRow = {
   id: string;
   topic: string;
@@ -160,22 +150,23 @@ function planListRowsSql(params: {
         up.topic,
         up.created_at,
         up.updated_at,
-        coalesce(tm.total_tasks, 0)::int as total_tasks,
-        coalesce(tm.completed_tasks, 0)::int as completed_tasks,
-        case
-          when coalesce(mc.module_count, 0) > 0
-            and coalesce(tm.total_tasks, 0) > 0
-            and tm.completed_tasks >= tm.total_tasks then 'completed'
+	        coalesce(tm.total_tasks, 0)::int as total_tasks,
+	        coalesce(tm.completed_tasks, 0)::int as completed_tasks,
+	        case
+	          when up.generation_status = 'failed' then 'failed'
+	          when up.generation_status in ('generating', 'pending_retry') then 'generating'
+	          when coalesce(mc.module_count, 0) > 0
+	            and coalesce(tm.total_tasks, 0) > 0
+	            and tm.completed_tasks >= tm.total_tasks then 'completed'
           when coalesce(mc.module_count, 0) > 0
             and coalesce(tm.completed_tasks, 0) = 0 then 'not_started'
           when coalesce(mc.module_count, 0) > 0
-            and up.updated_at is not null
-            and ${params.referenceTimestamp}::timestamptz - up.updated_at >= interval '30 days' then 'paused'
-          when coalesce(mc.module_count, 0) > 0 then 'active'
-          when up.generation_status = 'failed' then 'failed'
-          when coalesce(ac.attempt_count, 0) >= ${attemptCap} then 'failed'
-          else 'generating'
-        end as status
+	            and up.updated_at is not null
+	            and ${params.referenceTimestamp}::timestamptz - up.updated_at >= interval '30 days' then 'paused'
+	          when coalesce(mc.module_count, 0) > 0 then 'active'
+	          when coalesce(ac.attempt_count, 0) >= ${attemptCap} then 'failed'
+	          else 'generating'
+	        end as status
       from filtered_user_plans up
       left join module_counts mc on mc.plan_id = up.id
       left join attempt_counts ac on ac.plan_id = up.id

--- a/src/lib/db/queries/plan-list.ts
+++ b/src/lib/db/queries/plan-list.ts
@@ -15,10 +15,13 @@ export type PlanListFilterStatus =
   | 'all'
   | Exclude<PlanListRowStatus, 'paused'>
   | 'inactive';
+export type PlanListSort = 'recommended' | 'recently_updated' | 'newest';
+
 export type PlanListPageQuery = {
   page: number;
   search: string;
   status: PlanListFilterStatus;
+  sort: PlanListSort;
 };
 export type PlanListQueryItemRow = {
   id: string;
@@ -70,6 +73,34 @@ function normalizedStatus(
 ): PlanListRowStatus | null {
   if (status === 'all') return null;
   return status === 'inactive' ? 'paused' : status;
+}
+
+function planListOrderBy(sort: PlanListSort): SQL {
+  if (sort === 'recently_updated') {
+    return sql`order by coalesce(updated_at, created_at) desc, id desc`;
+  }
+
+  if (sort === 'newest') {
+    return sql`order by created_at desc, id desc`;
+  }
+
+  return sql`
+    -- Bucket by status first; each following CASE only sorts within its bucket (NULLS LAST elsewhere).
+    order by
+      case status
+        when 'active' then 0
+        when 'not_started' then 1
+        when 'generating' then 2
+        when 'failed' then 3
+        when 'paused' then 4
+        when 'completed' then 5
+        else 6
+      end,
+      case when status = 'active' then coalesce(updated_at, created_at) end desc nulls last,
+      case when status = 'not_started' then created_at end desc nulls last,
+      case when status in ('generating', 'failed', 'paused', 'completed') then coalesce(updated_at, created_at) end desc nulls last,
+      id desc
+  `;
 }
 
 function planListRowsSql(params: {
@@ -199,21 +230,7 @@ export async function getPlanListPageRowsForUser(params: {
       total_tasks
     from status_rows
     ${statusFilter}
-    -- Bucket by status first; each following CASE only sorts within its bucket (NULLS LAST elsewhere).
-    order by
-      case status
-        when 'active' then 0
-        when 'not_started' then 1
-        when 'generating' then 2
-        when 'failed' then 3
-        when 'paused' then 4
-        when 'completed' then 5
-        else 6
-      end,
-      case when status = 'active' then coalesce(updated_at, created_at) end desc nulls last,
-      case when status = 'not_started' then created_at end desc nulls last,
-      case when status in ('generating', 'failed', 'paused', 'completed') then coalesce(updated_at, created_at) end desc nulls last,
-      id desc
+    ${planListOrderBy(params.query.sort)}
     limit ${pageSize}
     offset ${(page - 1) * pageSize}
   `)) as PlanListItemRow[];

--- a/src/lib/db/queries/plan-list.ts
+++ b/src/lib/db/queries/plan-list.ts
@@ -5,6 +5,7 @@ import { getDb } from '@supabase/runtime';
 import { sql, type SQL } from 'drizzle-orm';
 
 export type PlanListRowStatus =
+  | 'not_started'
   | 'active'
   | 'paused'
   | 'completed'
@@ -52,6 +53,7 @@ type PlanListItemRow = {
 };
 
 const EMPTY_STATUS_COUNTS: PlanListQueryStatusCounts = {
+  not_started: 0,
   active: 0,
   paused: 0,
   completed: 0,
@@ -134,6 +136,8 @@ function planListRowsSql(params: {
             and coalesce(tm.total_tasks, 0) > 0
             and tm.completed_tasks >= tm.total_tasks then 'completed'
           when coalesce(mc.module_count, 0) > 0
+            and coalesce(tm.completed_tasks, 0) = 0 then 'not_started'
+          when coalesce(mc.module_count, 0) > 0
             and up.updated_at is not null
             and ${params.referenceTimestamp}::timestamptz - up.updated_at >= interval '30 days' then 'paused'
           when coalesce(mc.module_count, 0) > 0 then 'active'
@@ -195,7 +199,20 @@ export async function getPlanListPageRowsForUser(params: {
       total_tasks
     from status_rows
     ${statusFilter}
-    order by created_at desc, id desc
+    order by
+      case status
+        when 'active' then 0
+        when 'not_started' then 1
+        when 'generating' then 2
+        when 'failed' then 3
+        when 'paused' then 4
+        when 'completed' then 5
+        else 6
+      end,
+      case when status = 'active' then coalesce(updated_at, created_at) end desc nulls last,
+      case when status = 'not_started' then created_at end desc nulls last,
+      case when status in ('generating', 'failed', 'paused', 'completed') then coalesce(updated_at, created_at) end desc nulls last,
+      id desc
     limit ${pageSize}
     offset ${(page - 1) * pageSize}
   `)) as PlanListItemRow[];

--- a/src/lib/db/queries/plan-list.ts
+++ b/src/lib/db/queries/plan-list.ts
@@ -199,6 +199,7 @@ export async function getPlanListPageRowsForUser(params: {
       total_tasks
     from status_rows
     ${statusFilter}
+    -- Bucket by status first; each following CASE only sorts within its bucket (NULLS LAST elsewhere).
     order by
       case status
         when 'active' then 0

--- a/tests/integration/contract/plans.bulk-delete.spec.ts
+++ b/tests/integration/contract/plans.bulk-delete.spec.ts
@@ -1,0 +1,272 @@
+import { setTestUser } from '../../helpers/auth';
+import { ensureUser } from '../../helpers/db/users';
+import { buildTestAuthUserId, buildTestEmail } from '../../helpers/testIds';
+import { POST } from '@/app/api/v1/plans/bulk-delete/route';
+import { learningPlans } from '@supabase/schema';
+import { db } from '@supabase/service-role';
+import { eq, inArray } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+
+function buildBulkDeleteRequest(
+  planIds: string[],
+  options: { body?: string } = {},
+) {
+  return new Request('http://localhost/api/v1/plans/bulk-delete', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: options.body ?? JSON.stringify({ planIds }),
+  });
+}
+
+function buildPlanValues(
+  userId: string,
+  topic: string,
+  generationStatus: 'ready' | 'failed' | 'pending_retry' | 'generating',
+) {
+  return {
+    userId,
+    topic,
+    skillLevel: 'beginner' as const,
+    weeklyHours: 4,
+    learningStyle: 'reading' as const,
+    visibility: 'private' as const,
+    origin: 'ai' as const,
+    generationStatus,
+  };
+}
+
+describe('POST /api/v1/plans/bulk-delete', () => {
+  const ownerAuthId = buildTestAuthUserId('plan-bulk-delete-owner');
+  const ownerEmail = buildTestEmail(ownerAuthId);
+
+  it('deletes multiple owned ready plans and returns per-plan results', async () => {
+    setTestUser(ownerAuthId);
+    const ownerId = await ensureUser({
+      authUserId: ownerAuthId,
+      email: ownerEmail,
+    });
+
+    const plans = await db
+      .insert(learningPlans)
+      .values([
+        {
+          userId: ownerId,
+          topic: 'Bulk Delete One',
+          skillLevel: 'beginner',
+          weeklyHours: 4,
+          learningStyle: 'reading',
+          visibility: 'private',
+          origin: 'ai',
+          generationStatus: 'ready',
+        },
+        {
+          userId: ownerId,
+          topic: 'Bulk Delete Two',
+          skillLevel: 'beginner',
+          weeklyHours: 4,
+          learningStyle: 'reading',
+          visibility: 'private',
+          origin: 'ai',
+          generationStatus: 'ready',
+        },
+      ])
+      .returning();
+
+    const response = await POST(
+      buildBulkDeleteRequest(plans.map((plan) => plan.id)),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      success: true,
+      deletedCount: 2,
+      failedCount: 0,
+    });
+    expect(body.results).toEqual(
+      expect.arrayContaining([
+        { planId: plans[0].id, success: true },
+        { planId: plans[1].id, success: true },
+      ]),
+    );
+
+    const remaining = await db
+      .select({ id: learningPlans.id })
+      .from(learningPlans)
+      .where(
+        inArray(
+          learningPlans.id,
+          plans.map((plan) => plan.id),
+        ),
+      );
+    expect(remaining).toHaveLength(0);
+  });
+
+  it('returns partial failures when some plans cannot be deleted', async () => {
+    setTestUser(ownerAuthId);
+    const ownerId = await ensureUser({
+      authUserId: ownerAuthId,
+      email: ownerEmail,
+    });
+
+    const [deletablePlan, generatingPlan] = await db
+      .insert(learningPlans)
+      .values([
+        {
+          userId: ownerId,
+          topic: 'Bulk Partial Ready',
+          skillLevel: 'beginner',
+          weeklyHours: 4,
+          learningStyle: 'reading',
+          visibility: 'private',
+          origin: 'ai',
+          generationStatus: 'ready',
+        },
+        {
+          userId: ownerId,
+          topic: 'Bulk Partial Generating',
+          skillLevel: 'beginner',
+          weeklyHours: 4,
+          learningStyle: 'reading',
+          visibility: 'private',
+          origin: 'ai',
+          generationStatus: 'generating',
+        },
+      ])
+      .returning();
+
+    const response = await POST(
+      buildBulkDeleteRequest([deletablePlan.id, generatingPlan.id]),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      success: true,
+      deletedCount: 1,
+      failedCount: 1,
+    });
+    expect(body.results).toEqual(
+      expect.arrayContaining([
+        { planId: deletablePlan.id, success: true },
+        {
+          planId: generatingPlan.id,
+          success: false,
+          reason: 'currently_generating',
+          message: 'Cannot delete a plan that is currently generating.',
+        },
+      ]),
+    );
+
+    const remaining = await db
+      .select({ id: learningPlans.id })
+      .from(learningPlans)
+      .where(eq(learningPlans.id, generatingPlan.id));
+    expect(remaining).toHaveLength(1);
+  });
+
+  it('deletes owned failed and pending_retry plans', async () => {
+    setTestUser(ownerAuthId);
+    const ownerId = await ensureUser({
+      authUserId: ownerAuthId,
+      email: ownerEmail,
+    });
+
+    const plans = await db
+      .insert(learningPlans)
+      .values([
+        buildPlanValues(ownerId, 'Bulk Failed Plan', 'failed'),
+        buildPlanValues(ownerId, 'Bulk Pending Retry Plan', 'pending_retry'),
+      ])
+      .returning();
+
+    const response = await POST(
+      buildBulkDeleteRequest(plans.map((plan) => plan.id)),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      success: true,
+      deletedCount: 2,
+      failedCount: 0,
+    });
+
+    const remaining = await db
+      .select({ id: learningPlans.id })
+      .from(learningPlans)
+      .where(
+        inArray(
+          learningPlans.id,
+          plans.map((plan) => plan.id),
+        ),
+      );
+    expect(remaining).toHaveLength(0);
+  });
+
+  it('returns not_found for an unowned plan without deleting it', async () => {
+    const otherAuthId = buildTestAuthUserId('plan-bulk-delete-other');
+    setTestUser(ownerAuthId);
+    const ownerId = await ensureUser({
+      authUserId: ownerAuthId,
+      email: ownerEmail,
+    });
+    await ensureUser({
+      authUserId: otherAuthId,
+      email: buildTestEmail(otherAuthId),
+    });
+
+    const [ownedPlan] = await db
+      .insert(learningPlans)
+      .values([buildPlanValues(ownerId, 'Owned Plan', 'ready')])
+      .returning();
+
+    setTestUser(otherAuthId);
+    const response = await POST(buildBulkDeleteRequest([ownedPlan.id]));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      success: false,
+      deletedCount: 0,
+      failedCount: 1,
+    });
+    expect(body.results).toEqual([
+      {
+        planId: ownedPlan.id,
+        success: false,
+        reason: 'not_found',
+        message: 'Learning plan not found.',
+      },
+    ]);
+
+    const remaining = await db
+      .select({ id: learningPlans.id })
+      .from(learningPlans)
+      .where(eq(learningPlans.id, ownedPlan.id));
+    expect(remaining).toHaveLength(1);
+  });
+
+  it('returns 400 for invalid bulk delete payloads', async () => {
+    setTestUser(ownerAuthId);
+    await ensureUser({
+      authUserId: ownerAuthId,
+      email: ownerEmail,
+    });
+
+    const emptyResponse = await POST(buildBulkDeleteRequest([]));
+    expect(emptyResponse.status).toBe(400);
+
+    const invalidResponse = await POST(buildBulkDeleteRequest(['not-a-uuid']));
+    expect(invalidResponse.status).toBe(400);
+
+    const tooManyIds = Array.from({ length: 21 }, () => crypto.randomUUID());
+    const tooManyResponse = await POST(buildBulkDeleteRequest(tooManyIds));
+    expect(tooManyResponse.status).toBe(400);
+
+    const malformedResponse = await POST(
+      buildBulkDeleteRequest([], { body: '{not-json' }),
+    );
+    expect(malformedResponse.status).toBe(400);
+  });
+});

--- a/tests/integration/contract/plans.bulk-delete.spec.ts
+++ b/tests/integration/contract/plans.bulk-delete.spec.ts
@@ -264,6 +264,12 @@ describe('POST /api/v1/plans/bulk-delete', () => {
     const tooManyResponse = await POST(buildBulkDeleteRequest(tooManyIds));
     expect(tooManyResponse.status).toBe(400);
 
+    const repeatedId = crypto.randomUUID();
+    const tooManyRawIdsResponse = await POST(
+      buildBulkDeleteRequest(Array.from({ length: 21 }, () => repeatedId)),
+    );
+    expect(tooManyRawIdsResponse.status).toBe(400);
+
     const malformedResponse = await POST(
       buildBulkDeleteRequest([], { body: '{not-json' }),
     );

--- a/tests/integration/db/plan-list-page.spec.ts
+++ b/tests/integration/db/plan-list-page.spec.ts
@@ -23,7 +23,13 @@ async function createUser(scenario: string): Promise<string> {
 }
 
 function query(overrides: Partial<PlanListQuery> = {}): PlanListQuery {
-  return { page: 1, search: '', status: 'all', ...overrides };
+  return {
+    page: 1,
+    search: '',
+    status: 'all',
+    sort: 'recommended',
+    ...overrides,
+  };
 }
 
 describe('aggregate plans page query', () => {
@@ -346,5 +352,59 @@ describe('aggregate plans page query', () => {
       generating: 1,
       failed: 1,
     });
+  });
+
+  it('orders plans by recently updated when sort is recently_updated', async () => {
+    const userId = await createUser('sort-recent');
+    const older = await createTestPlan({
+      userId,
+      topic: 'Older Update',
+      generationStatus: 'ready',
+      createdAt: new Date('2026-05-01T12:00:00.000Z'),
+      updatedAt: new Date('2026-05-10T12:00:00.000Z'),
+    });
+    const newer = await createTestPlan({
+      userId,
+      topic: 'Newer Update',
+      generationStatus: 'ready',
+      createdAt: new Date('2026-05-01T12:00:00.000Z'),
+      updatedAt: new Date('2026-06-15T12:00:00.000Z'),
+    });
+
+    const page = await getPlansPageForRead({
+      userId,
+      dbClient: db,
+      query: query({ sort: 'recently_updated' }),
+      referenceTimestamp: REFERENCE_TIMESTAMP,
+    });
+
+    expect(page.items.map((item) => item.id)).toEqual([newer.id, older.id]);
+  });
+
+  it('orders plans by created date when sort is newest', async () => {
+    const userId = await createUser('sort-newest');
+    const older = await createTestPlan({
+      userId,
+      topic: 'Older Created',
+      generationStatus: 'ready',
+      createdAt: new Date('2026-04-01T12:00:00.000Z'),
+      updatedAt: new Date('2026-06-01T12:00:00.000Z'),
+    });
+    const newer = await createTestPlan({
+      userId,
+      topic: 'Newer Created',
+      generationStatus: 'ready',
+      createdAt: new Date('2026-06-01T12:00:00.000Z'),
+      updatedAt: new Date('2026-04-01T12:00:00.000Z'),
+    });
+
+    const page = await getPlansPageForRead({
+      userId,
+      dbClient: db,
+      query: query({ sort: 'newest' }),
+      referenceTimestamp: REFERENCE_TIMESTAMP,
+    });
+
+    expect(page.items.map((item) => item.id)).toEqual([newer.id, older.id]);
   });
 });

--- a/tests/integration/db/plan-list-page.spec.ts
+++ b/tests/integration/db/plan-list-page.spec.ts
@@ -121,6 +121,7 @@ describe('aggregate plans page query', () => {
     expect(page.items.map((item) => item.id)).toEqual([literal.id]);
     expect(page.totalSearchResults).toBe(1);
     expect(page.statusCounts).toEqual({
+      not_started: 0,
       active: 0,
       paused: 0,
       completed: 0,
@@ -145,15 +146,52 @@ describe('aggregate plans page query', () => {
     });
     const activeModule = await createTestModule({ planId: activePlan.id });
     const activeTask = await createTestTask({ moduleId: activeModule.id });
+    const activeRemainingTask = await createTestTask({
+      moduleId: activeModule.id,
+      order: 2,
+    });
+    await db.insert(taskProgress).values({
+      taskId: activeTask.id,
+      userId,
+      status: 'completed',
+    });
     statusFixtures.push({
       expectedFilter: 'active',
       summary: {
         plan: activePlan,
         modules: [activeModule],
+        completion: 0.5,
+        completedTasks: 1,
+        totalTasks: 2,
+        totalMinutes:
+          activeTask.estimatedMinutes + activeRemainingTask.estimatedMinutes,
+        completedMinutes: activeTask.estimatedMinutes,
+        completedModules: 0,
+        attemptsCount: 0,
+      },
+    });
+
+    const notStartedPlan = await createTestPlan({
+      userId,
+      topic: 'Scope Not started',
+      generationStatus: 'ready',
+      updatedAt: new Date('2026-06-20T18:00:00.000Z'),
+    });
+    const notStartedModule = await createTestModule({
+      planId: notStartedPlan.id,
+    });
+    const notStartedTask = await createTestTask({
+      moduleId: notStartedModule.id,
+    });
+    statusFixtures.push({
+      expectedFilter: 'not_started',
+      summary: {
+        plan: notStartedPlan,
+        modules: [notStartedModule],
         completion: 0,
         completedTasks: 0,
         totalTasks: 1,
-        totalMinutes: activeTask.estimatedMinutes,
+        totalMinutes: notStartedTask.estimatedMinutes,
         completedMinutes: 0,
         completedModules: 0,
         attemptsCount: 0,
@@ -168,16 +206,26 @@ describe('aggregate plans page query', () => {
     });
     const pausedModule = await createTestModule({ planId: pausedPlan.id });
     const pausedTask = await createTestTask({ moduleId: pausedModule.id });
+    const pausedRemainingTask = await createTestTask({
+      moduleId: pausedModule.id,
+      order: 2,
+    });
+    await db.insert(taskProgress).values({
+      taskId: pausedTask.id,
+      userId,
+      status: 'completed',
+    });
     statusFixtures.push({
       expectedFilter: 'inactive',
       summary: {
         plan: pausedPlan,
         modules: [pausedModule],
-        completion: 0,
-        completedTasks: 0,
-        totalTasks: 1,
-        totalMinutes: pausedTask.estimatedMinutes,
-        completedMinutes: 0,
+        completion: 0.5,
+        completedTasks: 1,
+        totalTasks: 2,
+        totalMinutes:
+          pausedTask.estimatedMinutes + pausedRemainingTask.estimatedMinutes,
+        completedMinutes: pausedTask.estimatedMinutes,
         completedModules: 0,
         attemptsCount: 0,
       },
@@ -291,6 +339,7 @@ describe('aggregate plans page query', () => {
     }
 
     expect(all.statusCounts).toEqual({
+      not_started: 1,
       active: 1,
       paused: 1,
       completed: 1,

--- a/tests/integration/db/plan-list-page.spec.ts
+++ b/tests/integration/db/plan-list-page.spec.ts
@@ -354,6 +354,43 @@ describe('aggregate plans page query', () => {
     });
   });
 
+  it('keeps non-ready plans with modules out of the not-started bucket', async () => {
+    const userId = await createUser('non-ready-modules');
+    const generatingPlan = await createTestPlan({
+      userId,
+      topic: 'Lifecycle Generating With Modules',
+      generationStatus: 'generating',
+    });
+    const generatingModule = await createTestModule({
+      planId: generatingPlan.id,
+    });
+    await createTestTask({ moduleId: generatingModule.id });
+
+    const failedPlan = await createTestPlan({
+      userId,
+      topic: 'Lifecycle Failed With Modules',
+      generationStatus: 'failed',
+    });
+    const failedModule = await createTestModule({ planId: failedPlan.id });
+    await createTestTask({ moduleId: failedModule.id });
+
+    const page = await getPlansPageForRead({
+      userId,
+      dbClient: db,
+      query: query({ search: 'lifecycle' }),
+      referenceTimestamp: REFERENCE_TIMESTAMP,
+    });
+    const byId = new Map(page.items.map((item) => [item.id, item.status]));
+
+    expect(byId.get(generatingPlan.id)).toBe('generating');
+    expect(byId.get(failedPlan.id)).toBe('failed');
+    expect(page.statusCounts).toMatchObject({
+      not_started: 0,
+      generating: 1,
+      failed: 1,
+    });
+  });
+
   it('orders plans by recently updated when sort is recently_updated', async () => {
     const userId = await createUser('sort-recent');
     const older = await createTestPlan({

--- a/tests/unit/app/dashboard/activity-utils.spec.ts
+++ b/tests/unit/app/dashboard/activity-utils.spec.ts
@@ -1,0 +1,54 @@
+import { findActivePlan } from '@/app/(app)/dashboard/components/activity-utils';
+import {
+  buildModuleRows,
+  buildPlan,
+  buildPlanSummary,
+} from '@tests/fixtures/plan-detail';
+import { describe, expect, it } from 'vitest';
+
+function planSummary(overrides: {
+  id: string;
+  topic: string;
+  completedTasks?: number;
+  completion?: number;
+  generationStatus?: 'ready' | 'generating';
+  moduleCount?: number;
+  updatedAt: string;
+}) {
+  const { modules: _modules, ...plan } = buildPlan({
+    id: overrides.id,
+    topic: overrides.topic,
+    generationStatus: overrides.generationStatus ?? 'ready',
+    updatedAt: new Date(overrides.updatedAt),
+  });
+
+  const completedTasks = overrides.completedTasks ?? 0;
+  const totalTasks = 2;
+
+  return buildPlanSummary({
+    plan,
+    modules: buildModuleRows(plan.id, overrides.moduleCount ?? 1),
+    completedTasks,
+    totalTasks,
+    completion: overrides.completion ?? completedTasks / totalTasks,
+  });
+}
+
+describe('findActivePlan', () => {
+  it('keeps not-started plans eligible for the dashboard resume slot', () => {
+    const notStarted = planSummary({
+      id: 'plan-not-started',
+      topic: 'Not started',
+      updatedAt: '2026-06-21T00:00:00.000Z',
+    });
+    const generating = planSummary({
+      id: 'plan-generating',
+      topic: 'Generating',
+      generationStatus: 'generating',
+      moduleCount: 0,
+      updatedAt: '2026-06-22T00:00:00.000Z',
+    });
+
+    expect(findActivePlan([generating, notStarted])).toBe(notStarted);
+  });
+});

--- a/tests/unit/components/PlansList.spec.tsx
+++ b/tests/unit/components/PlansList.spec.tsx
@@ -9,7 +9,7 @@ import type React from 'react';
 
 import { PlansList } from '@/app/(app)/plans/components/PlansList';
 import { PLAN_LIST_PAGE_SIZE } from '@/features/plans/read-projection/types';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('next/link', () => ({
@@ -30,6 +30,7 @@ describe('PlansList', () => {
   const referenceTimestamp = '2024-06-01T00:00:00.000Z';
 
   const statusCounts: PlanListStatusCounts = {
+    not_started: 0,
     active: 1,
     paused: 0,
     completed: 1,
@@ -106,6 +107,7 @@ describe('PlansList', () => {
         totalPages: 0,
         totalSearchResults: 0,
         statusCounts: {
+          not_started: 0,
           active: 0,
           paused: 0,
           completed: 0,
@@ -137,7 +139,11 @@ describe('PlansList', () => {
       query: { search: 'react hooks' },
     });
 
-    expect(screen.getByRole('link', { name: /Active/ })).toHaveAttribute(
+    expect(
+      within(screen.getByRole('tablist')).getByRole('link', {
+        name: /Active/,
+      }),
+    ).toHaveAttribute(
       'href',
       '/plans?search=react+hooks&status=active',
     );
@@ -181,6 +187,7 @@ describe('PlansList', () => {
   });
 
   it.each([
+    ['not_started', 'Not started', '(0)'],
     ['active', 'Active', '(1)'],
     ['inactive', 'Inactive', '(0)'],
     ['completed', 'Completed', '(1)'],
@@ -190,7 +197,9 @@ describe('PlansList', () => {
       renderPlansList();
 
       expect(
-        screen.getByRole('link', { name: new RegExp(label) }),
+        within(screen.getByRole('tablist')).getByRole('link', {
+          name: new RegExp(label),
+        }),
       ).toHaveTextContent(count);
     },
   );

--- a/tests/unit/components/PlansList.spec.tsx
+++ b/tests/unit/components/PlansList.spec.tsx
@@ -221,6 +221,12 @@ describe('PlansList', () => {
     const user = userEvent.setup();
     renderPlansList();
 
+    expect(
+      screen
+        .getAllByRole('link')
+        .filter((link) => link.getAttribute('href')?.startsWith('/plans/')),
+    ).toHaveLength(2);
+
     await user.click(screen.getByRole('button', { name: 'Select' }));
 
     expect(screen.getByLabelText('Bulk plan actions')).toBeInTheDocument();
@@ -230,6 +236,11 @@ describe('PlansList', () => {
     expect(
       screen.getByRole('checkbox', { name: 'Select Learn TypeScript' }),
     ).toBeInTheDocument();
+    expect(
+      screen
+        .getAllByRole('link')
+        .filter((link) => link.getAttribute('href')?.startsWith('/plans/')),
+    ).toHaveLength(0);
   });
 
   it('disables selection for generating plans', async () => {
@@ -307,6 +318,21 @@ describe('PlansList', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: 'Delete 2 plans' }),
+    ).toBeInTheDocument();
+  });
+
+  it('pluralizes the bulk delete action for one selected plan', async () => {
+    const user = userEvent.setup();
+    renderPlansList();
+
+    await user.click(screen.getByRole('button', { name: 'Select' }));
+    await user.click(
+      screen.getByRole('checkbox', { name: 'Select Master React Hooks' }),
+    );
+    await user.click(screen.getByRole('button', { name: 'Delete selected' }));
+
+    expect(
+      screen.getByRole('button', { name: 'Delete 1 plan' }),
     ).toBeInTheDocument();
   });
 

--- a/tests/unit/components/PlansList.spec.tsx
+++ b/tests/unit/components/PlansList.spec.tsx
@@ -10,7 +10,10 @@ import type React from 'react';
 import { PlansList } from '@/app/(app)/plans/components/PlansList';
 import { PLAN_LIST_PAGE_SIZE } from '@/features/plans/read-projection/types';
 import { render, screen, within } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockRefresh = vi.fn();
 
 vi.mock('next/link', () => ({
   default: ({
@@ -23,11 +26,20 @@ vi.mock('next/link', () => ({
 }));
 
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+  useRouter: () => ({ push: vi.fn(), refresh: mockRefresh }),
 }));
+
+import { toast } from 'sonner';
 
 describe('PlansList', () => {
   const referenceTimestamp = '2024-06-01T00:00:00.000Z';
+
+  beforeEach(() => {
+    mockRefresh.mockReset();
+    vi.mocked(toast.success).mockReset();
+    vi.mocked(toast.error).mockReset();
+    vi.stubGlobal('fetch', vi.fn());
+  });
 
   const statusCounts: PlanListStatusCounts = {
     not_started: 0,
@@ -65,6 +77,7 @@ describe('PlansList', () => {
       page: 1,
       search: '',
       status: 'all',
+      sort: 'recommended',
       ...overrides,
     };
   }
@@ -143,10 +156,239 @@ describe('PlansList', () => {
       within(screen.getByRole('tablist')).getByRole('link', {
         name: /Active/,
       }),
+    ).toHaveAttribute('href', '/plans?search=react+hooks&status=active');
+  });
+
+  it('renders sort control with the current selected value', () => {
+    renderPlansList({
+      query: { sort: 'recently_updated' },
+    });
+
+    expect(screen.getByLabelText('Sort learning plans')).toHaveValue(
+      'recently_updated',
+    );
+  });
+
+  it('preserves sort in filter tab links and pagination links', () => {
+    renderPlansList({
+      page: { page: 2, totalPages: 3, totalItems: 45 },
+      query: { page: 2, search: 'react', status: 'active', sort: 'newest' },
+    });
+
+    expect(
+      within(screen.getByRole('tablist')).getByRole('link', {
+        name: /Completed/,
+      }),
     ).toHaveAttribute(
       'href',
-      '/plans?search=react+hooks&status=active',
+      '/plans?search=react&status=completed&sort=newest',
     );
+    expect(screen.getByRole('link', { name: /Previous/ })).toHaveAttribute(
+      'href',
+      '/plans?search=react&status=active&sort=newest',
+    );
+    expect(screen.getByRole('link', { name: /Next/ })).toHaveAttribute(
+      'href',
+      '/plans?search=react&status=active&sort=newest&page=3',
+    );
+  });
+
+  it('includes hidden status in the search form without preserving page', () => {
+    renderPlansList({
+      page: { page: 2, totalPages: 3 },
+      query: {
+        page: 2,
+        search: 'typescript',
+        status: 'completed',
+        sort: 'newest',
+      },
+    });
+
+    const searchForm = screen.getByRole('searchbox').closest('form');
+    expect(searchForm).not.toBeNull();
+    expect(within(searchForm!).getByDisplayValue('completed')).toHaveAttribute(
+      'name',
+      'status',
+    );
+    expect(within(searchForm!).getByDisplayValue('newest')).toHaveAttribute(
+      'name',
+      'sort',
+    );
+    expect(within(searchForm!).queryByDisplayValue('2')).toBeNull();
+  });
+
+  it('enters selection mode and toggles row checkboxes', async () => {
+    const user = userEvent.setup();
+    renderPlansList();
+
+    await user.click(screen.getByRole('button', { name: 'Select' }));
+
+    expect(screen.getByLabelText('Bulk plan actions')).toBeInTheDocument();
+    expect(
+      screen.getByRole('checkbox', { name: 'Select Master React Hooks' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('checkbox', { name: 'Select Learn TypeScript' }),
+    ).toBeInTheDocument();
+  });
+
+  it('disables selection for generating plans', async () => {
+    const user = userEvent.setup();
+    renderPlansList({
+      page: {
+        items: [
+          activePlan,
+          {
+            ...completedPlan,
+            id: 'plan-generating',
+            topic: 'Generating Plan',
+            status: 'generating',
+          },
+        ],
+      },
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Select' }));
+
+    expect(
+      screen.getByRole('checkbox', {
+        name: 'Cannot select Generating Plan while it is generating',
+      }),
+    ).toBeDisabled();
+  });
+
+  it('selects all deletable plans on the current page', async () => {
+    const user = userEvent.setup();
+    renderPlansList();
+
+    await user.click(screen.getByRole('button', { name: 'Select' }));
+    await user.click(
+      screen.getByRole('button', { name: 'Select all on page' }),
+    );
+
+    expect(screen.getByText('2 selected')).toBeInTheDocument();
+    expect(
+      screen.getByRole('checkbox', { name: 'Select Master React Hooks' }),
+    ).toBeChecked();
+    expect(
+      screen.getByRole('checkbox', { name: 'Select Learn TypeScript' }),
+    ).toBeChecked();
+  });
+
+  it('clears the current selection', async () => {
+    const user = userEvent.setup();
+    renderPlansList();
+
+    await user.click(screen.getByRole('button', { name: 'Select' }));
+    await user.click(
+      screen.getByRole('button', { name: 'Select all on page' }),
+    );
+    await user.click(screen.getByRole('button', { name: 'Clear' }));
+
+    expect(screen.getByText('0 selected')).toBeInTheDocument();
+    expect(
+      screen.getByRole('checkbox', { name: 'Select Master React Hooks' }),
+    ).not.toBeChecked();
+  });
+
+  it('opens bulk delete confirmation with selected plan topics', async () => {
+    const user = userEvent.setup();
+    renderPlansList();
+
+    await user.click(screen.getByRole('button', { name: 'Select' }));
+    await user.click(
+      screen.getByRole('button', { name: 'Select all on page' }),
+    );
+    await user.click(screen.getByRole('button', { name: 'Delete selected' }));
+
+    expect(screen.getByText('Delete selected plans')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Master React Hooks, Learn TypeScript/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Delete 2 plans' }),
+    ).toBeInTheDocument();
+  });
+
+  it('refreshes and exits selection mode after a successful bulk delete', async () => {
+    const user = userEvent.setup();
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: true,
+          deletedCount: 2,
+          failedCount: 0,
+          results: [
+            { planId: 'plan-1', success: true },
+            { planId: 'plan-2', success: true },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+    renderPlansList();
+
+    await user.click(screen.getByRole('button', { name: 'Select' }));
+    await user.click(
+      screen.getByRole('button', { name: 'Select all on page' }),
+    );
+    await user.click(screen.getByRole('button', { name: 'Delete selected' }));
+    await user.click(screen.getByRole('button', { name: 'Delete 2 plans' }));
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/v1/plans/bulk-delete',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ planIds: ['plan-1', 'plan-2'] }),
+      }),
+    );
+    expect(toast.success).toHaveBeenCalledWith('Deleted 2 plans');
+    expect(mockRefresh).toHaveBeenCalled();
+    expect(
+      screen.queryByLabelText('Bulk plan actions'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows a partial failure toast and keeps selection mode open', async () => {
+    const user = userEvent.setup();
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: true,
+          deletedCount: 1,
+          failedCount: 1,
+          results: [
+            { planId: 'plan-1', success: true },
+            {
+              planId: 'plan-2',
+              success: false,
+              reason: 'currently_generating',
+              message: 'Cannot delete a plan that is currently generating.',
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+    renderPlansList();
+
+    await user.click(screen.getByRole('button', { name: 'Select' }));
+    await user.click(
+      screen.getByRole('button', { name: 'Select all on page' }),
+    );
+    await user.click(screen.getByRole('button', { name: 'Delete selected' }));
+    await user.click(screen.getByRole('button', { name: 'Delete 2 plans' }));
+
+    expect(toast.error).toHaveBeenCalledWith(
+      'Deleted 1 plans. 1 could not be deleted.',
+    );
+    expect(
+      screen.getByText(
+        'Some plans started generating and could not be deleted.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText('Bulk plan actions')).toBeInTheDocument();
+    expect(mockRefresh).toHaveBeenCalled();
   });
 
   it('resets page when submitting search or changing filters', () => {
@@ -155,8 +397,10 @@ describe('PlansList', () => {
       query: { page: 2, search: 'typescript', status: 'completed' },
     });
 
+    const searchForm = screen.getByRole('searchbox').closest('form');
+    expect(searchForm).not.toBeNull();
     expect(screen.getByRole('searchbox')).toHaveValue('typescript');
-    expect(screen.getByDisplayValue('completed')).toHaveAttribute(
+    expect(within(searchForm!).getByDisplayValue('completed')).toHaveAttribute(
       'name',
       'status',
     );

--- a/tests/unit/features/plans/read-projection-display-status.spec.ts
+++ b/tests/unit/features/plans/read-projection-display-status.spec.ts
@@ -5,7 +5,11 @@ import { getGenerationAttemptCap } from '@/features/ai/generation-policy';
 import { derivePlanSummaryDisplayStatus } from '@/features/plans/read-projection/client';
 import { deriveCanonicalPlanSummaryStatus } from '@/features/plans/read-projection/summary-status';
 import { createId } from '@tests/fixtures/ids';
-import { buildPlan, buildPlanSummary } from '@tests/fixtures/plan-detail';
+import {
+  buildModuleRows,
+  buildPlan,
+  buildPlanSummary,
+} from '@tests/fixtures/plan-detail';
 import { describe, expect, it } from 'vitest';
 
 type SummaryFixture = Omit<Partial<PlanSummary>, 'plan'> & {
@@ -33,7 +37,7 @@ function summary(partial: SummaryFixture = {}): PlanSummary {
 
   return buildPlanSummary({
     plan,
-    modules: partial.modules ?? [],
+    modules: partial.modules ?? buildModuleRows(planId, 1),
     completion: partial.completion ?? 0,
     completedTasks: partial.completedTasks ?? 0,
     totalTasks: partial.totalTasks ?? 1,
@@ -53,8 +57,13 @@ describe('derivePlanSummaryDisplayStatus', () => {
     expected: PlanReadStatus;
   }>([
     {
-      name: 'active when canonical active and recently updated',
+      name: 'not_started when canonical active has no progress',
       overrides: {},
+      expected: 'not_started',
+    },
+    {
+      name: 'active when canonical active is started and recently updated',
+      overrides: { completion: 0.5, completedTasks: 1, totalTasks: 2 },
       expected: 'active',
     },
     {
@@ -81,6 +90,9 @@ describe('derivePlanSummaryDisplayStatus', () => {
       name: 'paused when canonical active but not updated 30+ days',
       overrides: {
         plan: { updatedAt: new Date('2026-03-01T00:00:00.000Z') },
+        completion: 0.5,
+        completedTasks: 1,
+        totalTasks: 2,
       },
       expected: 'paused',
     },
@@ -88,6 +100,9 @@ describe('derivePlanSummaryDisplayStatus', () => {
       name: 'active when <30d since update (boundary)',
       overrides: {
         plan: { updatedAt: new Date('2026-03-24T00:00:00.000Z') },
+        completion: 0.5,
+        completedTasks: 1,
+        totalTasks: 2,
       },
       expected: 'active',
     },
@@ -168,6 +183,9 @@ describe('derivePlanSummaryDisplayStatus', () => {
       derivePlanSummaryDisplayStatus({
         summary: summary({
           plan: { updatedAt: new Date(Number.NaN) },
+          completion: 0.5,
+          completedTasks: 1,
+          totalTasks: 2,
         }),
         referenceDate: ref,
       }),
@@ -178,6 +196,9 @@ describe('derivePlanSummaryDisplayStatus', () => {
     expect(
       derivePlanSummaryDisplayStatus({
         summary: summary({
+          completion: 0.5,
+          completedTasks: 1,
+          totalTasks: 2,
           plan: {
             updatedAt: 'not-a-date' as unknown as Date,
           },
@@ -192,6 +213,9 @@ describe('derivePlanSummaryDisplayStatus', () => {
       derivePlanSummaryDisplayStatus({
         summary: summary({
           plan: { updatedAt: new Date('2026-03-01T00:00:00.000Z') },
+          completion: 0.5,
+          completedTasks: 1,
+          totalTasks: 2,
         }),
         referenceDate: 'not-a-date',
       }),

--- a/tests/unit/features/plans/write-service.spec.ts
+++ b/tests/unit/features/plans/write-service.spec.ts
@@ -115,14 +115,25 @@ describe('removePlansForWrite', () => {
     ]);
   });
 
-  it('rethrows unexpected deletePlan errors instead of swallowing them', async () => {
-    mockDeletePlan.mockRejectedValueOnce(new Error('database unavailable'));
+  it('returns per-plan unknown failures when deletePlan throws', async () => {
+    mockDeletePlan
+      .mockRejectedValueOnce(new Error('database unavailable'))
+      .mockResolvedValueOnce({ success: true });
 
-    await expect(
-      removePlansForWrite({
-        planIds: [firstPlanId],
-        userId,
-      }),
-    ).rejects.toThrow('database unavailable');
+    const results = await removePlansForWrite({
+      planIds: [firstPlanId, secondPlanId],
+      userId,
+    });
+
+    expect(mockDeletePlan).toHaveBeenCalledTimes(2);
+    expect(results).toEqual([
+      {
+        planId: firstPlanId,
+        success: false,
+        reason: 'unknown',
+        message: 'Cannot delete learning plan in its current state.',
+      },
+      { planId: secondPlanId, success: true },
+    ]);
   });
 });

--- a/tests/unit/features/plans/write-service.spec.ts
+++ b/tests/unit/features/plans/write-service.spec.ts
@@ -1,4 +1,7 @@
-import { removePlanForWrite } from '@/features/plans/write-service';
+import {
+  removePlanForWrite,
+  removePlansForWrite,
+} from '@/features/plans/write-service';
 import { deletePlan } from '@/lib/db/queries/plans';
 import { createId } from '@tests/fixtures/ids';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -42,5 +45,84 @@ describe('removePlanForWrite', () => {
     await expect(removePlanForWrite({ planId, userId })).rejects.toThrow(
       'Cannot delete a plan that is currently generating.',
     );
+  });
+});
+
+describe('removePlansForWrite', () => {
+  const userId = createId('user');
+  const firstPlanId = createId('plan');
+  const secondPlanId = createId('plan');
+
+  beforeEach(() => {
+    mockDeletePlan.mockReset();
+  });
+
+  it('returns all successes when every plan deletes', async () => {
+    mockDeletePlan.mockResolvedValue({ success: true });
+
+    const results = await removePlansForWrite({
+      planIds: [firstPlanId, secondPlanId],
+      userId,
+    });
+
+    expect(results).toEqual([
+      { planId: firstPlanId, success: true },
+      { planId: secondPlanId, success: true },
+    ]);
+  });
+
+  it('returns per-plan success and failure results without throwing', async () => {
+    mockDeletePlan
+      .mockResolvedValueOnce({ success: true })
+      .mockResolvedValueOnce({ success: false, reason: 'not_found' });
+
+    const results = await removePlansForWrite({
+      planIds: [firstPlanId, secondPlanId],
+      userId,
+    });
+
+    expect(mockDeletePlan).toHaveBeenNthCalledWith(1, firstPlanId, userId);
+    expect(mockDeletePlan).toHaveBeenNthCalledWith(2, secondPlanId, userId);
+    expect(results).toEqual([
+      { planId: firstPlanId, success: true },
+      {
+        planId: secondPlanId,
+        success: false,
+        reason: 'not_found',
+        message: 'Learning plan not found.',
+      },
+    ]);
+  });
+
+  it('maps currently_generating failures to readable messages', async () => {
+    mockDeletePlan.mockResolvedValue({
+      success: false,
+      reason: 'currently_generating',
+    });
+
+    const results = await removePlansForWrite({
+      planIds: [firstPlanId],
+      userId,
+    });
+
+    expect(results).toEqual([
+      {
+        planId: firstPlanId,
+        success: false,
+        reason: 'currently_generating',
+        message: 'Cannot delete a plan that is currently generating.',
+      },
+    ]);
+  });
+
+  it('rethrows unexpected deletePlan errors instead of swallowing them', async () => {
+    mockDeletePlan.mockRejectedValueOnce(new Error('database unavailable'));
+
+    await expect(
+      removePlansForWrite({
+        planIds: [firstPlanId],
+        userId,
+      }),
+    ).rejects.toThrow('database unavailable');
   });
 });


### PR DESCRIPTION
## Summary
- Redesign `/plans` around the Atlas direction with updated hero, controls, rows, empty/loading/error states, and responsive layout.
- Add `not_started` as a first-class plans-list filter/status and sort active, not-started, remaining, and completed plans intentionally.
- Address Thermos review findings by preserving not-started plans in the dashboard resume slot and centralizing plans status presentation metadata.

## Verification
- `pnpm check:full` via pre-push hook
- `SKIP_DB_TEST_SETUP=true NODE_ENV=test ./node_modules/.bin/vitest run --config vitest.config.ts --project unit tests/unit/app/dashboard/activity-utils.spec.ts tests/unit/components/PlansList.spec.tsx tests/unit/features/plans/read-projection-display-status.spec.ts`
- `NODE_ENV=test ./node_modules/.bin/vitest run --config vitest.config.ts --project integration tests/integration/db/plan-list-page.spec.ts`
- Thermos review completed; verified and fixed confirmed findings.

Closes #377
Linear: JCS-30

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces bulk plan deletion (destructive, user-scoped) and changes status bucketing/sort order across list and dashboard resume logic; mitigated by validation, ownership checks, and integration tests.
> 
> **Overview**
> Redesigns **`/plans`** with Atlas-style hero, controls, card rows (status pills, progress), and updated empty/loading/error states. Adds **sort** (`recommended`, `recently updated`, `newest`) via URL and SQL ordering, plus a **Not started** filter backed by a new **`not_started`** display status in list SQL and `derivePlanSummaryDisplayStatus`.
> 
> **Bulk delete** lets users select plans on a page (excluding generating), confirm in a dialog, and call **`POST /api/v1/plans/bulk-delete`** with per-plan success/failure results via `removePlansForWrite`. Dashboard **`findActivePlan`** now prioritizes active → not started → generating instead of only active/generating by recency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c84a649f9434ba52d33c3adcfad49c65ee854a36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->