### PR TITLE
fix(plans): address review findings for row status, skeleton, and header spacing

### DIFF
--- a/src/app/(app)/plans/components/PlanRow.tsx
+++ b/src/app/(app)/plans/components/PlanRow.tsx
@@ -65,13 +65,22 @@ function PlanTitle({
 }
 
 function NextTask({ plan }: { plan: PlanListItem }) {
-  const nextTask =
-    plan.status === 'completed'
-      ? 'All tasks completed'
-      : plan.completedTasks === 0
-        ? 'Not started'
-        : 'Continue learning';
-  const showArrow = plan.status !== 'completed' && plan.completedTasks > 0;
+  let nextTask: string;
+  let showArrow: boolean;
+
+  if (plan.status === 'completed') {
+    nextTask = 'All tasks completed';
+    showArrow = false;
+  } else if (plan.status === 'generating' || plan.status === 'failed') {
+    nextTask = PLAN_STATUS_LABELS[plan.status];
+    showArrow = false;
+  } else if (plan.completedTasks === 0) {
+    nextTask = 'Not started';
+    showArrow = false;
+  } else {
+    nextTask = 'Continue learning';
+    showArrow = true;
+  }
 
   return (
     <div className='flex min-w-0 items-center gap-2 text-xs text-muted-foreground'>

--- a/src/app/(app)/plans/components/PlansContentSkeleton.tsx
+++ b/src/app/(app)/plans/components/PlansContentSkeleton.tsx
@@ -1,5 +1,10 @@
+import {
+  ATLAS_CONTROL_CLASS,
+  ATLAS_HERO_SURFACE_CLASS,
+} from '@/app/(app)/plans/components/plans-atlas-classes';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Surface } from '@/components/ui/surface';
+import { cn } from '@/lib/utils';
 import { Search } from 'lucide-react';
 
 /**
@@ -9,7 +14,7 @@ import { Search } from 'lucide-react';
 export function PlansContentSkeleton() {
   return (
     <div className='space-y-5'>
-      <Surface className='space-y-5 border-primary/20 bg-linear-to-br from-primary/10 via-panel to-success/5'>
+      <Surface className={cn('space-y-5', ATLAS_HERO_SURFACE_CLASS)}>
         <div className='flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between'>
           <div className='min-w-0 space-y-2'>
             <Skeleton className='h-8 w-64 max-w-full' />
@@ -30,7 +35,10 @@ export function PlansContentSkeleton() {
         </div>
       </Surface>
 
-      <Surface padding='compact' className='space-y-4'>
+      <Surface
+        padding='compact'
+        className={cn('space-y-4', ATLAS_CONTROL_CLASS)}
+      >
         <div className='relative'>
           <Search className='pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground' />
           <Skeleton className='h-11 w-full rounded-md' />

--- a/src/app/(app)/plans/components/PlansList.tsx
+++ b/src/app/(app)/plans/components/PlansList.tsx
@@ -9,6 +9,11 @@ import type {
 
 import { EmptyPlansList } from '@/app/(app)/plans/components/EmptyPlansList';
 import { PlanRow } from '@/app/(app)/plans/components/PlanRow';
+import {
+  ATLAS_CONTROL_CLASS,
+  ATLAS_HERO_SURFACE_CLASS,
+  ATLAS_TAB_CLASS,
+} from '@/app/(app)/plans/components/plans-atlas-classes';
 import { getPlanStatusDotClassName } from '@/app/(app)/plans/plan-status-theme';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -36,10 +41,6 @@ const FILTER_TABS: {
   { id: 'generating', label: 'Generating', status: 'generating' },
   { id: 'failed', label: 'Failed', status: 'failed' },
 ];
-
-const ATLAS_CONTROL_CLASS = 'border-primary/20 bg-panel';
-const ATLAS_TAB_CLASS =
-  'data-[state=active]:border-primary/40 data-[state=active]:bg-primary/10 data-[state=active]:text-primary-dark dark:data-[state=active]:text-primary';
 
 function plansHref(params: {
   search: string;
@@ -75,7 +76,10 @@ function PlansHero({ page }: { page: PlanListPage }) {
   return (
     <section
       aria-label='Plans overview'
-      className='relative overflow-hidden rounded-2xl border border-primary/20 bg-linear-to-br from-primary/10 via-panel to-success/5 p-5 shadow-sm sm:p-6'
+      className={cn(
+        'relative overflow-hidden rounded-2xl p-5 shadow-sm sm:p-6',
+        ATLAS_HERO_SURFACE_CLASS,
+      )}
     >
       <div className='flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between'>
         <div className='min-w-0'>
@@ -101,9 +105,7 @@ function PlansHero({ page }: { page: PlanListPage }) {
             <div className='text-2xl font-semibold text-foreground tabular-nums'>
               {page.statusCounts.completed}
             </div>
-            <div className='text-xs font-medium text-foreground'>
-              Completed
-            </div>
+            <div className='text-xs font-medium text-foreground'>Completed</div>
             <div className='truncate text-xs text-muted-foreground'>
               Finished plans
             </div>
@@ -122,10 +124,7 @@ function PlansControls({
   query: PlanListQuery;
 }) {
   return (
-    <Surface
-      padding='compact'
-      className={cn('space-y-4', ATLAS_CONTROL_CLASS)}
-    >
+    <Surface padding='compact' className={cn('space-y-4', ATLAS_CONTROL_CLASS)}>
       <form action='/plans' className='relative'>
         <Search
           className='pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground'

--- a/src/app/(app)/plans/components/plans-atlas-classes.ts
+++ b/src/app/(app)/plans/components/plans-atlas-classes.ts
@@ -1,0 +1,5 @@
+export const ATLAS_CONTROL_CLASS = 'border-primary/20 bg-panel';
+export const ATLAS_HERO_SURFACE_CLASS =
+  'border-primary/20 bg-linear-to-br from-primary/10 via-panel to-success/5';
+export const ATLAS_TAB_CLASS =
+  'data-[state=active]:border-primary/40 data-[state=active]:bg-primary/10 data-[state=active]:text-primary-dark dark:data-[state=active]:text-primary';

--- a/src/app/(app)/plans/error.tsx
+++ b/src/app/(app)/plans/error.tsx
@@ -32,12 +32,14 @@ export default function PlansError({ error, reset }: ErrorProps) {
         title='Your Plans'
         subtitle='Search, filter, and compare your learning plan library.'
         actions={
-          <Button asChild>
-            <Link href='/plans/new'>
-              <Plus />
-              New Plan
-            </Link>
-          </Button>
+          <div className='flex items-center gap-2 sm:pt-8'>
+            <Button asChild>
+              <Link href='/plans/new'>
+                <Plus />
+                New Plan
+              </Link>
+            </Button>
+          </div>
         }
       />
 

--- a/src/app/(app)/plans/loading.tsx
+++ b/src/app/(app)/plans/loading.tsx
@@ -9,10 +9,10 @@ export default function PlansLoading() {
         title='Your Plans'
         subtitle='Search, filter, and compare your learning plan library.'
         actions={
-          <>
+          <div className='flex items-center gap-2 sm:pt-8'>
             <Skeleton className='h-6 w-16 rounded-full' />
             <Skeleton className='h-10 w-24 rounded-lg' />
-          </>
+          </div>
         }
       />
       <PlansContentSkeleton />

--- a/src/lib/db/queries/plan-list.ts
+++ b/src/lib/db/queries/plan-list.ts
@@ -199,6 +199,7 @@ export async function getPlanListPageRowsForUser(params: {
       total_tasks
     from status_rows
     ${statusFilter}
+    -- Bucket by status first; each following CASE only sorts within its bucket (NULLS LAST elsewhere).
     order by
       case status
         when 'active' then 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Verified five plans-page review findings against current code. All were still valid and are fixed with minimal, targeted changes.

## Changes

### PlanRow NextTask (`PlanRow.tsx`)
- Added explicit branches for `generating`, `failed`, and `completed` statuses.
- Generating/failed rows now use `PLAN_STATUS_LABELS` (matching `StatusPill`) instead of falling through to "Not started".
- Arrow only shows for in-progress active plans with completed tasks.

### Skeleton / Atlas styling (`PlansContentSkeleton.tsx`, `plans-atlas-classes.ts`, `PlansList.tsx`)
- Extracted shared Atlas surface tokens (`ATLAS_CONTROL_CLASS`, `ATLAS_HERO_SURFACE_CLASS`, `ATLAS_TAB_CLASS`) into `plans-atlas-classes.ts` so skeleton and list stay in sync without crossing the client/server boundary.
- Applied `ATLAS_CONTROL_CLASS` to the controls skeleton Surface to prevent a visual jump when loading finishes.

### plan-list ORDER BY (`plan-list.ts`)
- Added a brief SQL comment documenting bucketed status sorting (leading CASE ranks buckets; subsequent CASE expressions only sort within each bucket).

### Header spacing (`error.tsx`, `loading.tsx`)
- Wrapped actions in the same `flex items-center gap-2 sm:pt-8` container used by `page.tsx` so all three plan states align.

## Validation

- `pnpm check:type` — pass
- `pnpm check:lint` — pass
- `react-doctor` (changed scope) — 100/100, no issues

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1c38-8f3e-7d3b-9912-615b5a01c951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1c38-8f3e-7d3b-9912-615b5a01c951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

