### PR TITLE
fix(ui): refine plans page list chrome

### DIFF
--- a/src/app/(app)/plans/components/PlanCountBadge.tsx
+++ b/src/app/(app)/plans/components/PlanCountBadge.tsx
@@ -11,11 +11,18 @@ interface PlanCountBadgeProps {
 }
 
 export function PlanCountBadge({ usage }: PlanCountBadgeProps) {
+  const limitLabel = formatCompactUsageLimit(usage.activePlans.limit);
+
   return (
     <UsageHoverCard usage={usage}>
-      <span className='cursor-default rounded-full bg-muted-foreground/10 px-2.5 py-0.5 text-xs font-medium text-muted-foreground'>
-        {usage.activePlans.current} /{' '}
-        {formatCompactUsageLimit(usage.activePlans.limit)}
+      <span
+        className='inline-flex cursor-default items-center gap-1 rounded-full border border-border/70 bg-panel px-3 py-1 text-xs font-medium text-muted-foreground'
+        aria-label={`${usage.activePlans.current} of ${limitLabel} active plans used`}
+      >
+        <span className='text-foreground'>{usage.activePlans.current}</span>
+        <span aria-hidden='true'>/</span>
+        <span>{limitLabel}</span>
+        <span>plans</span>
       </span>
     </UsageHoverCard>
   );

--- a/src/app/(app)/plans/components/PlanRow.tsx
+++ b/src/app/(app)/plans/components/PlanRow.tsx
@@ -40,7 +40,7 @@ function StatusPill({ plan }: { plan: PlanListItem }) {
   return (
     <span
       className={cn(
-        'inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-xs font-medium text-muted-foreground',
+        'ml-auto inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-xs font-medium text-muted-foreground',
         getPlanStatusPillClassName(plan.status),
       )}
     >
@@ -52,64 +52,74 @@ function StatusPill({ plan }: { plan: PlanListItem }) {
 function PlanTitle({
   plan,
   progressPercent,
+  lastActivity,
 }: {
   plan: PlanListItem;
   progressPercent: number;
+  lastActivity: string;
 }) {
   return (
-    <div className='flex min-w-0 items-center gap-2'>
+    <div className='flex min-w-0 flex-1 items-center gap-2'>
       <span className='truncate font-semibold text-foreground'>
         {plan.topic}
       </span>
       {progressPercent >= 80 ? (
         <Sparkles className='size-3.5 shrink-0 text-warning' />
       ) : null}
+      <LastActivity value={lastActivity} />
     </div>
   );
 }
 
 function NextTask({ plan }: { plan: PlanListItem }) {
-  let nextTask: string;
-  let showArrow: boolean;
+  let label: string;
+  let showArrow = false;
 
   if (plan.status === 'completed') {
-    nextTask = 'All tasks completed';
-    showArrow = false;
+    label = 'All tasks completed';
   } else if (plan.status === 'generating' || plan.status === 'failed') {
-    nextTask = PLAN_STATUS_LABELS[plan.status];
-    showArrow = false;
+    label = PLAN_STATUS_LABELS[plan.status];
   } else if (plan.completedTasks === 0) {
-    nextTask = 'Not started';
-    showArrow = false;
+    label = 'Not started';
   } else {
-    nextTask = 'Continue learning';
+    label = 'Continue learning';
     showArrow = true;
   }
 
   return (
     <div className='flex min-w-0 items-center gap-2 text-xs text-muted-foreground'>
       {showArrow ? <ArrowRight className='size-3 shrink-0' /> : null}
-      <span className='truncate'>{nextTask}</span>
+      <span className='truncate'>{label}</span>
     </div>
   );
 }
 
-function TaskCount({ plan }: { plan: PlanListItem }) {
+function TaskProgress({
+  plan,
+  progressPercent,
+}: {
+  plan: PlanListItem;
+  progressPercent: number;
+}) {
   return (
-    <div className='flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground'>
-      <CheckCircle2 className='size-3.5 shrink-0' />
-      <span className='truncate tabular-nums'>
-        {plan.completedTasks}/{plan.totalTasks} tasks
-      </span>
+    <div className='space-y-1.5'>
+      <div className='flex items-center justify-between gap-2 text-xs text-muted-foreground'>
+        <NextTask plan={plan} />
+        <span className='flex shrink-0 items-center gap-1.5 tabular-nums'>
+          <CheckCircle2 className='size-3.5 shrink-0' aria-hidden='true' />
+          {plan.completedTasks}/{plan.totalTasks} tasks
+        </span>
+      </div>
+      <ProgressTrack progressPercent={progressPercent} />
     </div>
   );
 }
 
 function LastActivity({ value }: { value: string }) {
   return (
-    <div className='flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground'>
+    <div className='flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground'>
       <Clock className='size-3.5 shrink-0' />
-      <span className='truncate'>{value}</span>
+      <span className='whitespace-nowrap'>{value}</span>
     </div>
   );
 }
@@ -118,7 +128,7 @@ function ProgressTrack({ progressPercent }: { progressPercent: number }) {
   return (
     <>
       <progress className='sr-only' value={progressPercent} max={100}>
-        {progressPercent}% complete
+        {progressPercent}% of tasks complete
       </progress>
       <div className='h-1 overflow-hidden rounded-full bg-muted-foreground/10'>
         <div
@@ -149,25 +159,17 @@ export function PlanRow({
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const rowContent = (
     <>
-      <div className='grid gap-3 md:grid-cols-[minmax(0,1fr)_7.5rem_7rem] md:items-start md:gap-4'>
-        <div className='min-w-0 space-y-1.5'>
-          <div className='flex min-w-0 flex-wrap items-center gap-2'>
-            <StatusPill plan={plan} />
-            <PlanTitle plan={plan} progressPercent={progressPercent} />
-          </div>
-          <NextTask plan={plan} />
-        </div>
-
-        <div className='min-w-0 md:pt-1'>
-          <TaskCount plan={plan} />
-        </div>
-        <div className='min-w-0 md:pt-1'>
-          <LastActivity value={lastActivity} />
-        </div>
+      <div className='flex min-w-0 items-center gap-2'>
+        <PlanTitle
+          plan={plan}
+          progressPercent={progressPercent}
+          lastActivity={lastActivity}
+        />
+        <StatusPill plan={plan} />
       </div>
 
       <div className='mt-3'>
-        <ProgressTrack progressPercent={progressPercent} />
+        <TaskProgress plan={plan} progressPercent={progressPercent} />
       </div>
     </>
   );
@@ -214,7 +216,7 @@ export function PlanRow({
           </div>
 
           {!selectionMode ? (
-            <div className='absolute top-2 right-2'>
+            <div className='absolute inset-y-0 right-2 flex items-center'>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button

--- a/src/app/(app)/plans/components/PlansContent.tsx
+++ b/src/app/(app)/plans/components/PlansContent.tsx
@@ -8,28 +8,48 @@ import { ROUTES } from '@/features/navigation/routes';
 import { redirect } from 'next/navigation';
 
 /**
- * Async component that fetches usage data and renders the plan count badge.
- * Wrapped in its own Suspense boundary by the parent page.
+ * Async component that renders the page-header summary: Active/Completed plan
+ * counts plus the plan quota badge. Reads from the same page-data promise
+ * already awaited by `PlansContent`, so no additional DB calls are made.
+ * Wrapped in its own Suspense boundary by the parent page so the static
+ * title and New Plan CTA can render immediately.
  */
-export async function PlanCountBadgeContent({
+export async function PlanHeaderSummaryContent({
   dataPromise,
 }: {
   dataPromise: Promise<PlansPageData | null>;
 }) {
   const result = await dataPromise;
-  const usage = result?.usage;
+  if (!result) return null;
 
-  if (!usage) return null;
+  const { plansPage, usage } = result;
 
   return (
-    <PlanCountBadge
-      usage={{
-        tier: usage.tier,
-        activePlans: usage.activePlans,
-        regenerations: usage.regenerations,
-        exports: usage.exports,
-      }}
-    />
+    <div className='flex flex-wrap items-center gap-3 sm:gap-4'>
+      <div className='flex items-center gap-3 text-sm text-muted-foreground'>
+        <span>
+          <span className='font-semibold text-foreground tabular-nums'>
+            {plansPage.statusCounts.active}
+          </span>{' '}
+          Active
+        </span>
+        <span>
+          <span className='font-semibold text-foreground tabular-nums'>
+            {plansPage.statusCounts.completed}
+          </span>{' '}
+          Completed
+        </span>
+      </div>
+      <span className='hidden h-4 w-px bg-border sm:block' aria-hidden='true' />
+      <PlanCountBadge
+        usage={{
+          tier: usage.tier,
+          activePlans: usage.activePlans,
+          regenerations: usage.regenerations,
+          exports: usage.exports,
+        }}
+      />
+    </div>
   );
 }
 
@@ -60,19 +80,10 @@ export async function PlansContent({
   ) {
     return (
       <section aria-label='No plans found'>
-        <EmptyPlansList
-          filterStatus='all'
-          isFirstRun
-          searchQuery=''
-        />
+        <EmptyPlansList filterStatus='all' isFirstRun searchQuery='' />
       </section>
     );
   }
 
-  return (
-    <PlansList
-      page={plansPage}
-      query={query}
-    />
-  );
+  return <PlansList page={plansPage} query={query} />;
 }

--- a/src/app/(app)/plans/components/PlansContentSkeleton.tsx
+++ b/src/app/(app)/plans/components/PlansContentSkeleton.tsx
@@ -1,63 +1,42 @@
-import {
-  ATLAS_CONTROL_CLASS,
-  ATLAS_HERO_SURFACE_CLASS,
-} from '@/app/(app)/plans/components/plans-atlas-classes';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Surface } from '@/components/ui/surface';
-import { cn } from '@/lib/utils';
 import { Search } from 'lucide-react';
 
 /**
- * Skeleton for the plans content (search, filters, list).
- * Header title and button are static and rendered by the page.
+ * Skeleton for the plans content (search, filters, list toolbar, list).
+ * Header title, usage summary, and New Plan button are rendered by the page.
  */
 export function PlansContentSkeleton() {
   return (
     <div className='space-y-5'>
-      <Surface className={cn('space-y-5', ATLAS_HERO_SURFACE_CLASS)}>
-        <div className='flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between'>
-          <div className='min-w-0 space-y-2'>
-            <Skeleton className='h-8 w-64 max-w-full' />
-            <Skeleton className='h-4 w-full max-w-xl' />
+      <div className='space-y-4 border-b border-border/60 pb-5'>
+        <div className='flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between'>
+          <div className='relative min-w-0 sm:max-w-sm sm:flex-1'>
+            <Search className='pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground' />
+            <Skeleton className='h-9 w-full rounded-md' />
           </div>
-          <div className='grid gap-3 sm:grid-cols-2 lg:min-w-[16rem]'>
-            {[1, 2].map((statSkeletonId) => (
-              <div
-                key={`plans-stat-skeleton-${statSkeletonId}`}
-                className='border-l border-border/80 pl-3'
-              >
-                <Skeleton className='mb-2 h-7 w-10' />
-                <Skeleton className='mb-1 h-3 w-20' />
-                <Skeleton className='h-3 w-24' />
-              </div>
-            ))}
-          </div>
-        </div>
-      </Surface>
-
-      <Surface
-        padding='compact'
-        className={cn('space-y-4', ATLAS_CONTROL_CLASS)}
-      >
-        <div className='relative'>
-          <Search className='pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground' />
-          <Skeleton className='h-11 w-full rounded-md' />
+          <Skeleton className='h-9 w-32 shrink-0 self-end rounded-md sm:self-auto' />
         </div>
 
-        <div className='flex flex-wrap items-center gap-2'>
-          <Skeleton className='h-9 w-24 rounded-lg' />
-          <Skeleton className='h-9 w-24 rounded-lg' />
-          <Skeleton className='h-9 w-28 rounded-lg' />
-          <Skeleton className='h-9 w-24 rounded-lg' />
-          <Skeleton className='h-9 w-28 rounded-lg' />
-          <Skeleton className='h-9 w-20 rounded-lg' />
+        <div className='flex gap-1.5 overflow-hidden'>
+          <Skeleton className='h-8 w-16 shrink-0 rounded-lg' />
+          <Skeleton className='h-8 w-24 shrink-0 rounded-lg' />
+          <Skeleton className='h-8 w-20 shrink-0 rounded-lg' />
+          <Skeleton className='h-8 w-24 shrink-0 rounded-lg' />
+          <Skeleton className='h-8 w-20 shrink-0 rounded-lg' />
         </div>
-      </Surface>
+      </div>
 
-      <div className='space-y-2'>
-        {[1, 2, 3, 4, 5].map((planSkeletonId) => (
-          <PlanRowSkeleton key={`plan-row-skeleton-${planSkeletonId}`} />
-        ))}
+      <div className='space-y-3'>
+        <div className='flex items-center justify-between'>
+          <Skeleton className='h-3 w-16' />
+          <Skeleton className='h-8 w-20 rounded-md' />
+        </div>
+
+        <div className='space-y-2'>
+          {[1, 2, 3, 4, 5].map((planSkeletonId) => (
+            <PlanRowSkeleton key={`plan-row-skeleton-${planSkeletonId}`} />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/app/(app)/plans/components/PlansList.tsx
+++ b/src/app/(app)/plans/components/PlansList.tsx
@@ -17,7 +17,6 @@ import { EmptyPlansList } from '@/app/(app)/plans/components/EmptyPlansList';
 import { PlanRow } from '@/app/(app)/plans/components/PlanRow';
 import {
   ATLAS_CONTROL_CLASS,
-  ATLAS_HERO_SURFACE_CLASS,
   ATLAS_TAB_CLASS,
 } from '@/app/(app)/plans/components/plans-atlas-classes';
 import { getPlanStatusDotClassName } from '@/app/(app)/plans/plan-status-theme';
@@ -26,7 +25,7 @@ import { Input } from '@/components/ui/input';
 import { Surface } from '@/components/ui/surface';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { cn } from '@/lib/utils';
-import { ChevronLeft, ChevronRight, Search } from 'lucide-react';
+import { ChevronLeft, ChevronRight, ListChecks, Search } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
@@ -93,50 +92,6 @@ function getFilterCount(
   if (tab.id === 'all') return page.totalSearchResults;
   if (tab.id === 'inactive') return page.statusCounts.paused;
   return tab.status ? page.statusCounts[tab.status] : 0;
-}
-
-function PlansHero({ page }: { page: PlanListPage }) {
-  return (
-    <section
-      aria-label='Plans overview'
-      className={cn(
-        'relative overflow-hidden rounded-2xl p-5 shadow-sm sm:p-6',
-        ATLAS_HERO_SURFACE_CLASS,
-      )}
-    >
-      <div className='flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between'>
-        <div className='min-w-0'>
-          <h2 className='text-2xl font-semibold text-foreground sm:text-3xl'>
-            Learning plan library
-          </h2>
-          <p className='mt-2 max-w-2xl text-sm leading-6 text-muted-foreground'>
-            A mapped library with milestone rails and calm progress cues.
-          </p>
-        </div>
-
-        <div className='grid gap-3 sm:grid-cols-2 lg:min-w-[16rem]'>
-          <div className='min-w-0 border-l border-border/80 pl-3'>
-            <div className='text-2xl font-semibold text-foreground tabular-nums'>
-              {page.statusCounts.active}
-            </div>
-            <div className='text-xs font-medium text-foreground'>Active</div>
-            <div className='truncate text-xs text-muted-foreground'>
-              In progress
-            </div>
-          </div>
-          <div className='min-w-0 border-l border-border/80 pl-3'>
-            <div className='text-2xl font-semibold text-foreground tabular-nums'>
-              {page.statusCounts.completed}
-            </div>
-            <div className='text-xs font-medium text-foreground'>Completed</div>
-            <div className='truncate text-xs text-muted-foreground'>
-              Finished plans
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-  );
 }
 
 function BulkPlanActionsToolbar({
@@ -220,44 +175,47 @@ function BulkPlanActionsToolbar({
 function PlansControls({
   page,
   query,
-  selectionMode,
-  onEnterSelectionMode,
-  canEnterSelectionMode,
 }: {
   page: PlanListPage;
   query: PlanListQuery;
-  selectionMode: boolean;
-  onEnterSelectionMode: () => void;
-  canEnterSelectionMode: boolean;
 }) {
   const router = useRouter();
 
   return (
-    <Surface padding='compact' className={cn('space-y-4', ATLAS_CONTROL_CLASS)}>
-      <form action='/plans' className='relative'>
-        <Search
-          className='pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground'
-          aria-hidden='true'
-        />
-        {query.status !== 'all' ? (
-          <input type='hidden' name='status' value={query.status} />
-        ) : null}
-        {query.sort !== 'recommended' ? (
-          <input type='hidden' name='sort' value={query.sort} />
-        ) : null}
-        <Input
-          type='search'
-          name='search'
-          placeholder='Search plans...'
-          aria-label='Search learning plans'
-          className='h-11 border-border bg-background pl-9 dark:bg-input/30'
-          defaultValue={query.search}
-        />
-      </form>
-
+    <div className='space-y-4 border-b border-border/60 pb-5'>
       <div className='flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between'>
-        <form action='/plans' className='flex items-center gap-2'>
-          <label htmlFor='plans-sort' className='text-sm text-muted-foreground'>
+        <form
+          action='/plans'
+          className='relative min-w-0 sm:max-w-sm sm:flex-1'
+        >
+          <Search
+            className='pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground'
+            aria-hidden='true'
+          />
+          {query.status !== 'all' ? (
+            <input type='hidden' name='status' value={query.status} />
+          ) : null}
+          {query.sort !== 'recommended' ? (
+            <input type='hidden' name='sort' value={query.sort} />
+          ) : null}
+          <Input
+            type='search'
+            name='search'
+            placeholder='Search plans...'
+            aria-label='Search learning plans'
+            className='h-9 border-border bg-background pl-9 dark:bg-input/30'
+            defaultValue={query.search}
+          />
+        </form>
+
+        <form
+          action='/plans'
+          className='flex shrink-0 items-center gap-2 self-end sm:self-auto'
+        >
+          <label
+            htmlFor='plans-sort'
+            className='text-xs font-medium tracking-wide text-muted-foreground uppercase'
+          >
             Sort
           </label>
           {query.search ? (
@@ -279,7 +237,7 @@ function PlansControls({
                 }),
               )
             }
-            className='h-9 rounded-md border border-input bg-background px-3 text-sm shadow-xs dark:bg-input/30'
+            className='h-9 max-w-[11rem] truncate rounded-md border border-input bg-background px-2.5 text-sm shadow-xs dark:bg-input/30'
             aria-label='Sort learning plans'
           >
             {SORT_OPTIONS.map((option) => (
@@ -289,22 +247,10 @@ function PlansControls({
             ))}
           </select>
         </form>
-
-        {!selectionMode ? (
-          <Button
-            type='button'
-            variant='outline'
-            size='sm'
-            onClick={onEnterSelectionMode}
-            disabled={!canEnterSelectionMode}
-          >
-            Select
-          </Button>
-        ) : null}
       </div>
 
-      <Tabs value={query.status}>
-        <TabsList className='h-auto flex-wrap gap-1 bg-transparent p-0'>
+      <Tabs value={query.status} aria-label='Filter plans by status'>
+        <TabsList className='h-auto w-full justify-start gap-1.5 overflow-x-auto bg-transparent p-0 [-ms-overflow-style:none] [scrollbar-width:none] sm:flex-wrap sm:overflow-visible [&::-webkit-scrollbar]:hidden'>
           {FILTER_TABS.map((tab) => {
             const count = getFilterCount(tab, page);
             return (
@@ -313,7 +259,7 @@ function PlansControls({
                 key={tab.id}
                 value={tab.id}
                 className={cn(
-                  'rounded-lg border border-transparent px-3 py-1.5 text-sm',
+                  'group inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-transparent px-2.5 py-1.5 text-sm',
                   ATLAS_TAB_CLASS,
                 )}
               >
@@ -327,15 +273,15 @@ function PlansControls({
                   {tab.status ? (
                     <span
                       className={cn(
-                        'size-2 rounded-full',
+                        'size-2 shrink-0 rounded-full',
                         getPlanStatusDotClassName(tab.status),
                       )}
                       aria-hidden='true'
                     />
                   ) : null}
-                  {tab.label}
-                  <span className='text-muted-foreground tabular-nums'>
-                    ({count})
+                  <span>{tab.label}</span>
+                  <span className='rounded-md bg-muted/70 px-1.5 py-0.5 text-xs font-medium text-muted-foreground tabular-nums group-data-[state=active]:bg-primary/15 group-data-[state=active]:text-primary-dark dark:group-data-[state=active]:text-primary'>
+                    {count}
                   </span>
                 </Link>
               </TabsTrigger>
@@ -343,7 +289,7 @@ function PlansControls({
           })}
         </TabsList>
       </Tabs>
-    </Surface>
+    </div>
   );
 }
 
@@ -457,35 +403,46 @@ export function PlansList({ page, query }: PlansListProps) {
 
   return (
     <div className='space-y-5'>
-      <PlansHero page={page} />
-      <PlansControls
-        page={page}
-        query={query}
-        selectionMode={selectionMode}
-        onEnterSelectionMode={handleEnterSelectionMode}
-        canEnterSelectionMode={deletablePlans.length > 0}
-      />
+      <PlansControls page={page} query={query} />
 
-      {selectionMode ? (
-        <BulkPlanActionsToolbar
-          selectedCount={selectedDeletablePlans.length}
-          deletableCount={deletablePlans.length}
-          toolbarMessage={toolbarMessage}
-          onSelectAll={handleSelectAllOnPage}
-          onClear={handleClearSelection}
-          onDelete={() => setBulkDeleteOpen(true)}
-          onCancelSelection={handleCancelSelectionMode}
+      <div className='space-y-3'>
+        <div className='flex items-center justify-between'>
+          <p className='text-xs font-medium tracking-wide text-muted-foreground uppercase'>
+            {page.totalItems} plan{page.totalItems === 1 ? '' : 's'}
+          </p>
+          {!selectionMode ? (
+            <Button
+              type='button'
+              variant='ghost'
+              size='sm'
+              onClick={handleEnterSelectionMode}
+              disabled={deletablePlans.length === 0}
+            >
+              <ListChecks />
+              Select
+            </Button>
+          ) : null}
+        </div>
+
+        {selectionMode ? (
+          <BulkPlanActionsToolbar
+            selectedCount={selectedDeletablePlans.length}
+            deletableCount={deletablePlans.length}
+            toolbarMessage={toolbarMessage}
+            onSelectAll={handleSelectAllOnPage}
+            onClear={handleClearSelection}
+            onDelete={() => setBulkDeleteOpen(true)}
+            onCancelSelection={handleCancelSelectionMode}
+          />
+        ) : null}
+
+        <BulkDeletePlansDialog
+          open={bulkDeleteOpen}
+          onOpenChange={setBulkDeleteOpen}
+          plans={selectedDeletablePlans}
+          onDeleted={handleBulkDeleted}
         />
-      ) : null}
 
-      <BulkDeletePlansDialog
-        open={bulkDeleteOpen}
-        onOpenChange={setBulkDeleteOpen}
-        plans={selectedDeletablePlans}
-        onDeleted={handleBulkDeleted}
-      />
-
-      <div>
         {page.items.length === 0 ? (
           <EmptyPlansList
             searchQuery={query.search}
@@ -511,18 +468,15 @@ export function PlansList({ page, query }: PlansListProps) {
       {page.totalPages > 1 ? (
         <nav
           aria-label='Plans pagination'
-          className={cn(
-            'mt-6 flex flex-col gap-3 rounded-2xl border p-4 text-sm text-muted-foreground shadow-sm sm:flex-row sm:items-center sm:justify-between',
-            ATLAS_CONTROL_CLASS,
-          )}
+          className='flex flex-col gap-3 border-t border-border/60 pt-4 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between'
         >
-          <span>
+          <span className='tabular-nums'>
             Page {page.page} of {page.totalPages}
           </span>
           <div className='flex items-center gap-2'>
             <Button
               asChild={page.page > 1}
-              variant='outline'
+              variant='ghost'
               size='sm'
               disabled={page.page <= 1}
             >
@@ -547,7 +501,7 @@ export function PlansList({ page, query }: PlansListProps) {
             </Button>
             <Button
               asChild={page.page < page.totalPages}
-              variant='outline'
+              variant='ghost'
               size='sm'
               disabled={page.page >= page.totalPages}
             >

--- a/src/app/(app)/plans/components/plans-atlas-classes.ts
+++ b/src/app/(app)/plans/components/plans-atlas-classes.ts
@@ -1,5 +1,3 @@
 export const ATLAS_CONTROL_CLASS = 'border-primary/20 bg-panel';
-export const ATLAS_HERO_SURFACE_CLASS =
-  'border-primary/20 bg-linear-to-br from-primary/10 via-panel to-success/5';
 export const ATLAS_TAB_CLASS =
   'data-[state=active]:border-primary/40 data-[state=active]:bg-primary/10 data-[state=active]:text-primary-dark dark:data-[state=active]:text-primary';

--- a/src/app/(app)/plans/error.tsx
+++ b/src/app/(app)/plans/error.tsx
@@ -30,7 +30,7 @@ export default function PlansError({ error, reset }: ErrorProps) {
     <>
       <PageHeader
         title='Your Plans'
-        subtitle='Search, filter, and compare your learning plan library.'
+        subtitle='Search, filter, and track your learning plan library.'
         actions={
           <div className='flex items-center gap-2'>
             <Button asChild>

--- a/src/app/(app)/plans/error.tsx
+++ b/src/app/(app)/plans/error.tsx
@@ -32,7 +32,7 @@ export default function PlansError({ error, reset }: ErrorProps) {
         title='Your Plans'
         subtitle='Search, filter, and compare your learning plan library.'
         actions={
-          <div className='flex items-center gap-2 sm:pt-8'>
+          <div className='flex items-center gap-2'>
             <Button asChild>
               <Link href='/plans/new'>
                 <Plus />

--- a/src/app/(app)/plans/loading.tsx
+++ b/src/app/(app)/plans/loading.tsx
@@ -9,7 +9,7 @@ export default function PlansLoading() {
         title='Your Plans'
         subtitle='Search, filter, and compare your learning plan library.'
         actions={
-          <div className='flex items-center gap-2 sm:pt-8'>
+          <div className='flex items-center gap-2'>
             <Skeleton className='h-6 w-16 rounded-full' />
             <Skeleton className='h-10 w-24 rounded-lg' />
           </div>

--- a/src/app/(app)/plans/loading.tsx
+++ b/src/app/(app)/plans/loading.tsx
@@ -7,7 +7,7 @@ export default function PlansLoading() {
     <>
       <PageHeader
         title='Your Plans'
-        subtitle='Search, filter, and compare your learning plan library.'
+        subtitle='Search, filter, and track your learning plan library.'
         actions={
           <div className='flex items-center gap-2'>
             <Skeleton className='h-6 w-16 rounded-full' />

--- a/src/app/(app)/plans/page.tsx
+++ b/src/app/(app)/plans/page.tsx
@@ -6,7 +6,7 @@ import type {
 import type { Metadata } from 'next';
 
 import {
-  PlanCountBadgeContent,
+  PlanHeaderSummaryContent,
   PlansContent,
 } from '@/app/(app)/plans/components/PlansContent';
 import { PlansContentSkeleton } from '@/app/(app)/plans/components/PlansContentSkeleton';
@@ -83,14 +83,21 @@ export default async function PlansPage({ searchParams }: PlansPageProps) {
 
   return (
     <>
-      {/* Static header - renders immediately; count waits independently. */}
+      {/* Static header - renders immediately; usage summary streams in independently. */}
       <PageHeader
         title='Your Plans'
-        subtitle='Search, filter, and compare your learning plan library.'
+        subtitle='Search, filter, and track your learning plan library.'
         actions={
-          <div className='flex items-center gap-2 sm:pt-8'>
-            <Suspense fallback={<Skeleton className='h-6 w-16 rounded-full' />}>
-              <PlanCountBadgeContent dataPromise={plansPageData} />
+          <>
+            <Suspense
+              fallback={
+                <div className='flex items-center gap-3'>
+                  <Skeleton className='h-4 w-32' />
+                  <Skeleton className='h-6 w-24 rounded-full' />
+                </div>
+              }
+            >
+              <PlanHeaderSummaryContent dataPromise={plansPageData} />
             </Suspense>
             <Button asChild>
               <Link href='/plans/new'>
@@ -98,7 +105,7 @@ export default async function PlansPage({ searchParams }: PlansPageProps) {
                 New Plan
               </Link>
             </Button>
-          </div>
+          </>
         }
       />
 

--- a/tests/unit/components/PlansList.spec.tsx
+++ b/tests/unit/components/PlansList.spec.tsx
@@ -206,7 +206,7 @@ describe('PlansList', () => {
       'href',
       '/plans?search=react&status=active&sort=newest',
     );
-    expect(screen.getByRole('link', { name: /Next/ })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: /^Next$/ })).toHaveAttribute(
       'href',
       '/plans?search=react&status=active&sort=newest&page=3',
     );
@@ -469,27 +469,49 @@ describe('PlansList', () => {
       'href',
       '/plans?search=react&status=active',
     );
-    expect(screen.getByRole('link', { name: /Next/ })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: /^Next$/ })).toHaveAttribute(
       'href',
       '/plans?search=react&status=active&page=3',
     );
   });
 
+  it('shows the filtered result count in the list toolbar', () => {
+    renderPlansList({
+      page: {
+        totalItems: 2,
+        totalSearchResults: 9,
+        statusCounts: {
+          not_started: 3,
+          active: 2,
+          paused: 1,
+          completed: 2,
+          generating: 1,
+          failed: 0,
+        },
+      },
+      query: { status: 'active' },
+    });
+
+    expect(screen.getByText('2 plans')).toBeInTheDocument();
+    expect(screen.queryByText('9 plans')).not.toBeInTheDocument();
+  });
+
   it.each([
-    ['not_started', 'Not started', '(0)'],
-    ['active', 'Active', '(1)'],
-    ['inactive', 'Inactive', '(0)'],
-    ['completed', 'Completed', '(1)'],
+    ['not_started', 'Not started', '0'],
+    ['active', 'Active', '1'],
+    ['inactive', 'Inactive', '0'],
+    ['completed', 'Completed', '1'],
   ] satisfies [FilterStatus, string, string][])(
     'renders aggregate count for %s filter',
     (_, label, count) => {
       renderPlansList();
 
-      expect(
-        within(screen.getByRole('tablist')).getByRole('link', {
-          name: new RegExp(label),
-        }),
-      ).toHaveTextContent(count);
+      const filterLink = within(screen.getByRole('tablist')).getByRole('link', {
+        name: new RegExp(label),
+      });
+
+      expect(filterLink).toHaveTextContent(label);
+      expect(within(filterLink).getByText(count)).toBeInTheDocument();
     },
   );
 });


### PR DESCRIPTION
## Summary
- streamline the plans page header, filters, list toolbar, and row layout
- keep sort changes on client navigation and use filtered result counts in the list toolbar
- remove the speculative next-task SQL/read-model work after Ponytail review

## Reviews
- Thermos review: addressed filtered toolbar count; removed PageHeader shared-component regression by reverting that shared diff
- Ponytail review: deleted the speculative next-task projection and one-off toolbar component

## Validation
- SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit tests/unit/components/PlansList.spec.tsx
- pnpm check:full
- npx -y react-doctor@latest . --verbose --scope changed --base origin/develop
- pre-push hook: pnpm check:full

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes on the plans list route with no API or data-model changes; behavior is covered by updated `PlansList` unit tests.
> 
> **Overview**
> **Refines the plans list page layout** by moving Active/Completed counts and the quota badge into the page header (`PlanHeaderSummaryContent`), dropping the in-list hero, and updating copy to “track” instead of “compare.”
> 
> **List chrome is flatter:** search, sort, and status tabs use a bordered section instead of `Surface` cards; filter counts show as pill badges; pagination and controls use lighter ghost styling. The list toolbar shows **`page.totalItems`** (filtered page total) with a ghost **Select** action, and bulk-delete UI sits above the rows.
> 
> **Plan rows** consolidate into a title row (topic, last activity inline, status pill on the right) and a **`TaskProgress`** block (next-step label, task fraction, progress bar). **`PlanCountBadge`** gets clearer styling and an `aria-label`.
> 
> Loading/error skeletons match the new header and controls. Unit tests cover toolbar counts, filter badge numbers, and stricter pagination link names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62211b0711d017f34e3a5cdc959c898597bd70ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->