### PR TITLE
feat(settings): add email notification preferences

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-switch": "^1.3.1",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@sentry/nextjs": "^10.49.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,10 +39,10 @@ importers:
         version: 8.5.0(zod@4.3.6)
       '@clerk/nextjs':
         specifier: ^7.3.0
-        version: 7.3.0(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 7.3.0(next@16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@flags-sdk/vercel':
         specifier: ^1.3.0
-        version: 1.3.0(@aws-sdk/credential-provider-web-identity@3.972.13)(flags@4.0.6(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 1.3.0(@aws-sdk/credential-provider-web-identity@3.972.13)(flags@4.0.6(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(next@16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@openrouter/sdk':
         specifier: ^0.2.11
         version: 0.2.11
@@ -76,6 +76,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-switch':
+        specifier: ^1.3.1
+        version: 1.3.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-tabs':
         specifier: ^1.1.13
         version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -84,13 +87,13 @@ importers:
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@sentry/nextjs':
         specifier: ^10.49.0
-        version: 10.49.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(supports-color@8.1.1)(webpack@5.103.0(@swc/core@1.15.3))
+        version: 10.49.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(supports-color@8.1.1)(webpack@5.103.0(@swc/core@1.15.3))
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 2.0.1(next@16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 2.0.0(next@16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -105,7 +108,7 @@ importers:
         version: 0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(postgres@3.4.9)
       flags:
         specifier: ^4.0.6
-        version: 4.0.6(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 4.0.6(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       lru-cache:
         specifier: ^11.3.5
         version: 11.3.5
@@ -114,7 +117,7 @@ importers:
         version: 0.542.0(react@19.2.4)
       next:
         specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -144,7 +147,7 @@ importers:
         version: 3.5.0
       workflow:
         specifier: ^4.2.5
-        version: 4.2.5(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(magicast@0.5.2)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.3)
+        version: 4.2.5(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(magicast@0.5.2)(next@16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.3)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -2019,6 +2022,9 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/primitive@1.1.4':
+    resolution: {integrity: sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==}
+
   '@radix-ui/react-accordion@1.2.12':
     resolution: {integrity: sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==}
     peerDependencies:
@@ -2093,6 +2099,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-compose-refs@1.1.3':
+    resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-context@1.1.2':
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
     peerDependencies:
@@ -2104,6 +2119,15 @@ packages:
 
   '@radix-ui/react-context@1.1.3':
     resolution: {integrity: sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.4':
+    resolution: {integrity: sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2294,6 +2318,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-primitive@2.1.6':
+    resolution: {integrity: sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-progress@1.1.8':
     resolution: {integrity: sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==}
     peerDependencies:
@@ -2364,6 +2401,28 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-slot@1.3.0':
+    resolution: {integrity: sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-switch@1.3.1':
+    resolution: {integrity: sha512-55bQtCnOB0BohomSHi6qvQXpJEEqUGDm6hRrM0Bph5OXwhSegqkd8IqgBAQkM1IlgUlWZIxpxRcpOEfRIgimyw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-tabs@1.1.13':
     resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
     peerDependencies:
@@ -2408,8 +2467,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-controllable-state@1.2.3':
+    resolution: {integrity: sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-effect-event@0.0.2':
     resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.3':
+    resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2435,8 +2512,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-layout-effect@1.1.2':
+    resolution: {integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-previous@1.1.1':
     resolution: {integrity: sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-previous@1.1.2':
+    resolution: {integrity: sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2455,6 +2550,15 @@ packages:
 
   '@radix-ui/react-use-size@1.1.1':
     resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.2':
+    resolution: {integrity: sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -3144,9 +3248,6 @@ packages:
 
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
-
-  '@types/node@22.19.21':
-    resolution: {integrity: sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==}
 
   '@types/node@24.13.2':
     resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
@@ -6434,9 +6535,6 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
@@ -6954,7 +7052,7 @@ snapshots:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
@@ -6994,7 +7092,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.29.7
@@ -7094,12 +7192,12 @@ snapshots:
       - react
       - react-dom
 
-  '@clerk/nextjs@7.3.0(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@clerk/nextjs@7.3.0(next@16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@clerk/backend': 3.4.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@clerk/react': 6.5.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@clerk/shared': 4.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       server-only: 0.0.1
@@ -7436,10 +7534,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@flags-sdk/vercel@1.3.0(@aws-sdk/credential-provider-web-identity@3.972.13)(flags@4.0.6(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@flags-sdk/vercel@1.3.0(@aws-sdk/credential-provider-web-identity@3.972.13)(flags@4.0.6(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(next@16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
-      '@vercel/flags-core': 1.4.0(@aws-sdk/credential-provider-web-identity@3.972.13)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
-      flags: 4.0.6(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@vercel/flags-core': 1.4.0(@aws-sdk/credential-provider-web-identity@3.972.13)(next@16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      flags: 4.0.6(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-web-identity'
       - '@openfeature/server-sdk'
@@ -8251,6 +8349,8 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/primitive@1.1.4': {}
+
   '@radix-ui/react-accordion@1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -8325,6 +8425,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-compose-refs@1.1.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       react: 19.2.4
@@ -8332,6 +8438,12 @@ snapshots:
       '@types/react': 19.2.14
 
   '@radix-ui/react-context@1.1.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.4(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       react: 19.2.4
     optionalDependencies:
@@ -8525,6 +8637,15 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-primitive@2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-progress@1.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-context': 1.1.3(@types/react@19.2.14)(react@19.2.4)
@@ -8604,6 +8725,28 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-slot@1.3.0(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-switch@1.3.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -8654,9 +8797,24 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-controllable-state@1.2.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-effect-event@0.0.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
@@ -8674,7 +8832,19 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-previous@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-previous@1.1.2(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       react: 19.2.4
     optionalDependencies:
@@ -8690,6 +8860,13 @@ snapshots:
   '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-size@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
@@ -8889,7 +9066,7 @@ snapshots:
 
   '@sentry/core@10.49.0': {}
 
-  '@sentry/nextjs@10.49.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(supports-color@8.1.1)(webpack@5.103.0(@swc/core@1.15.3))':
+  '@sentry/nextjs@10.49.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(supports-color@8.1.1)(webpack@5.103.0(@swc/core@1.15.3))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -8902,7 +9079,7 @@ snapshots:
       '@sentry/react': 10.49.0(react@19.2.4)
       '@sentry/vercel-edge': 10.49.0
       '@sentry/webpack-plugin': 5.2.0(webpack@5.103.0(@swc/core@1.15.3))
-      next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       rollup: 4.60.2
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -9342,10 +9519,6 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@22.19.21':
-    dependencies:
-      undici-types: 6.21.0
-
   '@types/node@24.13.2':
     dependencies:
       undici-types: 7.18.2
@@ -9356,7 +9529,7 @@ snapshots:
 
   '@types/pg@8.15.6':
     dependencies:
-      '@types/node': 22.19.21
+      '@types/node': 24.13.2
       pg-protocol: 1.13.0
       pg-types: 2.2.0
 
@@ -9389,9 +9562,9 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+  '@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
     optionalDependencies:
-      next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
 
   '@vercel/cli-auth@0.0.1':
@@ -9401,13 +9574,13 @@ snapshots:
       xdg-app-paths: 5.1.0
       zod: 4.1.11
 
-  '@vercel/flags-core@1.4.0(@aws-sdk/credential-provider-web-identity@3.972.13)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@vercel/flags-core@1.4.0(@aws-sdk/credential-provider-web-identity@3.972.13)(next@16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@vercel/functions': 3.5.0(@aws-sdk/credential-provider-web-identity@3.972.13)
       jose: 5.2.1
       js-xxhash: 4.0.0
     optionalDependencies:
-      next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-web-identity'
 
@@ -9428,9 +9601,9 @@ snapshots:
       mixpart: 0.0.6
       picocolors: 1.1.1
 
-  '@vercel/speed-insights@2.0.0(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+  '@vercel/speed-insights@2.0.0(next@16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
     optionalDependencies:
-      next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
 
   '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
@@ -9679,7 +9852,7 @@ snapshots:
       - '@swc/helpers'
       - supports-color
 
-  '@workflow/next@4.0.6(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@workflow/next@4.0.6(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@swc/core': 1.15.3
       '@workflow/builders': 4.0.6(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
@@ -9688,7 +9861,7 @@ snapshots:
       semver: 7.7.4
       watchpack: 2.5.1
     optionalDependencies:
-      next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -10956,13 +11129,13 @@ snapshots:
       semver-regex: 4.0.5
       super-regex: 1.1.0
 
-  flags@4.0.6(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  flags@4.0.6(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@edge-runtime/cookies': 5.0.2
       jose: 5.10.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
-      next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
@@ -11273,7 +11446,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.19.21
+      '@types/node': 24.13.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -11877,7 +12050,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -11886,7 +12059,7 @@ snapshots:
       postcss: 8.5.10
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.4)
+      styled-jsx: 5.1.6(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.6
       '@next/swc-darwin-x64': 16.2.6
@@ -12803,7 +12976,7 @@ snapshots:
     dependencies:
       '@tokenizer/token': 0.3.0
 
-  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.4):
+  styled-jsx@5.1.6(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.4):
     dependencies:
       client-only: 0.0.1
       react: 19.2.4
@@ -13072,8 +13245,6 @@ snapshots:
 
   undici-types@5.26.5: {}
 
-  undici-types@6.21.0: {}
-
   undici-types@7.18.2: {}
 
   undici@7.28.0: {}
@@ -13328,14 +13499,14 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
-  workflow@4.2.5(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(magicast@0.5.2)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.3):
+  workflow@4.2.5(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(magicast@0.5.2)(next@16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.3):
     dependencies:
       '@workflow/astro': 4.0.5(@opentelemetry/api@1.9.1)
       '@workflow/cli': 4.2.5(@opentelemetry/api@1.9.1)
       '@workflow/core': 4.2.5(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@workflow/errors': 4.1.2
       '@workflow/nest': 0.0.5(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)
-      '@workflow/next': 4.0.6(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      '@workflow/next': 4.0.6(@opentelemetry/api@1.9.1)(next@16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@workflow/nitro': 4.0.6(@opentelemetry/api@1.9.1)
       '@workflow/nuxt': 4.0.6(@opentelemetry/api@1.9.1)(magicast@0.5.2)
       '@workflow/rollup': 4.0.5(@opentelemetry/api@1.9.1)

--- a/src/app/(app)/settings/notifications/components/NotificationPreferencesForm.tsx
+++ b/src/app/(app)/settings/notifications/components/NotificationPreferencesForm.tsx
@@ -7,7 +7,10 @@ import { requestJson } from '@/app/_shared/client-api';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
-import { getEmailNotificationCategoryCopy } from '@/shared/notifications/email-preferences';
+import {
+  emailNotificationPreferenceFormValuesSchema,
+  getEmailNotificationCategoryCopy,
+} from '@/shared/notifications/email-preferences';
 import { CheckCircle2, MailWarning } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useId, useState } from 'react';
@@ -16,12 +19,7 @@ import { z } from 'zod';
 
 const notificationPreferencesResponseSchema = z.object({
   message: z.string(),
-  preferences: z.object({
-    unsubscribeAllOptionalEmails: z.boolean(),
-    weeklySummary: z.boolean(),
-    dailyReminder: z.boolean(),
-    streakReminder: z.boolean(),
-  }),
+  preferences: emailNotificationPreferenceFormValuesSchema,
 });
 
 type NotificationPreferencesResponse = z.infer<
@@ -76,7 +74,8 @@ export function NotificationPreferencesForm({
   const [preferences, setPreferences] = useState(initialPreferences);
   const [isSaving, setIsSaving] = useState(false);
   const hasChanges = isDirty(preferences, savedPreferences);
-  const categoriesDisabled = preferences.unsubscribeAllOptionalEmails;
+  const categoriesDisabled =
+    preferences.unsubscribeAllOptionalEmails || isSaving;
 
   function updateField(
     field: keyof EmailNotificationPreferenceFormValues,
@@ -115,13 +114,7 @@ export function NotificationPreferencesForm({
   }
 
   return (
-    <form
-      className='space-y-6'
-      onSubmit={(event) => {
-        event.preventDefault();
-        void handleSave();
-      }}
-    >
+    <div className='space-y-6'>
       <section
         aria-labelledby={`${idPrefix}-unsubscribe-label`}
         className='rounded-lg border border-border bg-card p-5'
@@ -149,6 +142,7 @@ export function NotificationPreferencesForm({
           <Switch
             id={`${idPrefix}-unsubscribe`}
             checked={preferences.unsubscribeAllOptionalEmails}
+            disabled={isSaving}
             onCheckedChange={(checked) =>
               updateField('unsubscribeAllOptionalEmails', checked)
             }
@@ -214,10 +208,14 @@ export function NotificationPreferencesForm({
           <CheckCircle2 aria-hidden className='size-4' />
           Optional emails are off until you enable them.
         </div>
-        <Button type='submit' disabled={!hasChanges || isSaving}>
+        <Button
+          type='button'
+          disabled={!hasChanges || isSaving}
+          onClick={() => void handleSave()}
+        >
           {isSaving ? 'Saving...' : 'Save Preferences'}
         </Button>
       </div>
-    </form>
+    </div>
   );
 }

--- a/src/app/(app)/settings/notifications/components/NotificationPreferencesForm.tsx
+++ b/src/app/(app)/settings/notifications/components/NotificationPreferencesForm.tsx
@@ -74,8 +74,8 @@ export function NotificationPreferencesForm({
   const [preferences, setPreferences] = useState(initialPreferences);
   const [isSaving, setIsSaving] = useState(false);
   const hasChanges = isDirty(preferences, savedPreferences);
-  const categoriesDisabled =
-    preferences.unsubscribeAllOptionalEmails || isSaving;
+  const unsubscribeOverrideActive = preferences.unsubscribeAllOptionalEmails;
+  const categoriesDisabled = unsubscribeOverrideActive || isSaving;
 
   function updateField(
     field: keyof EmailNotificationPreferenceFormValues,
@@ -183,7 +183,7 @@ export function NotificationPreferencesForm({
                   >
                     {copy.description}
                   </p>
-                  {categoriesDisabled && (
+                  {unsubscribeOverrideActive && (
                     <p className='text-xs text-muted-foreground'>
                       Unsubscribe-all is currently overriding this preference.
                     </p>

--- a/src/app/(app)/settings/notifications/components/NotificationPreferencesForm.tsx
+++ b/src/app/(app)/settings/notifications/components/NotificationPreferencesForm.tsx
@@ -1,0 +1,223 @@
+'use client';
+
+import type { EmailNotificationPreferenceFormValues } from '@/shared/notifications/email-preferences';
+import type { EmailNotificationCategory } from '@/shared/types/db.types';
+
+import { requestJson } from '@/app/_shared/client-api';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { getEmailNotificationCategoryCopy } from '@/shared/notifications/email-preferences';
+import { CheckCircle2, MailWarning } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useId, useState } from 'react';
+import { toast } from 'sonner';
+import { z } from 'zod';
+
+const notificationPreferencesResponseSchema = z.object({
+  message: z.string(),
+  preferences: z.object({
+    unsubscribeAllOptionalEmails: z.boolean(),
+    weeklySummary: z.boolean(),
+    dailyReminder: z.boolean(),
+    streakReminder: z.boolean(),
+  }),
+});
+
+type NotificationPreferencesResponse = z.infer<
+  typeof notificationPreferencesResponseSchema
+>;
+
+type NotificationPreferencesFormProps = {
+  initialPreferences: EmailNotificationPreferenceFormValues;
+  categories: EmailNotificationCategory[];
+};
+
+function isDirty(
+  current: EmailNotificationPreferenceFormValues,
+  saved: EmailNotificationPreferenceFormValues,
+): boolean {
+  return (
+    current.unsubscribeAllOptionalEmails !==
+      saved.unsubscribeAllOptionalEmails ||
+    current.weeklySummary !== saved.weeklySummary ||
+    current.dailyReminder !== saved.dailyReminder ||
+    current.streakReminder !== saved.streakReminder
+  );
+}
+
+function fieldForCategory(
+  category: EmailNotificationCategory,
+): keyof Omit<
+  EmailNotificationPreferenceFormValues,
+  'unsubscribeAllOptionalEmails'
+> {
+  switch (category) {
+    case 'weekly_summary':
+      return 'weeklySummary';
+    case 'daily_reminder':
+      return 'dailyReminder';
+    case 'streak_reminder':
+      return 'streakReminder';
+    default: {
+      const _exhaustiveCheck: never = category;
+      return _exhaustiveCheck;
+    }
+  }
+}
+
+export function NotificationPreferencesForm({
+  initialPreferences,
+  categories,
+}: NotificationPreferencesFormProps) {
+  const router = useRouter();
+  const idPrefix = useId();
+  const [savedPreferences, setSavedPreferences] = useState(initialPreferences);
+  const [preferences, setPreferences] = useState(initialPreferences);
+  const [isSaving, setIsSaving] = useState(false);
+  const hasChanges = isDirty(preferences, savedPreferences);
+  const categoriesDisabled = preferences.unsubscribeAllOptionalEmails;
+
+  function updateField(
+    field: keyof EmailNotificationPreferenceFormValues,
+    checked: boolean,
+  ): void {
+    setPreferences((current) => ({ ...current, [field]: checked }));
+  }
+
+  async function handleSave(): Promise<void> {
+    if (!hasChanges || isSaving) return;
+
+    setIsSaving(true);
+    const result = await requestJson<NotificationPreferencesResponse>({
+      url: '/api/v1/user/preferences/notifications',
+      init: {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(preferences),
+      },
+      schema: notificationPreferencesResponseSchema,
+      fallbackMessage: 'Failed to save notification preferences',
+    });
+    setIsSaving(false);
+
+    if (result.kind === 'success') {
+      setSavedPreferences(result.data.preferences);
+      setPreferences(result.data.preferences);
+      toast.success('Notification preferences saved');
+      router.refresh();
+      return;
+    }
+
+    if (result.kind === 'error') {
+      toast.error(result.message);
+    }
+  }
+
+  return (
+    <form
+      className='space-y-6'
+      onSubmit={(event) => {
+        event.preventDefault();
+        void handleSave();
+      }}
+    >
+      <section
+        aria-labelledby={`${idPrefix}-unsubscribe-label`}
+        className='rounded-lg border border-border bg-card p-5'
+      >
+        <div className='flex items-start justify-between gap-4'>
+          <div className='space-y-2'>
+            <div className='flex items-center gap-2'>
+              <MailWarning
+                aria-hidden
+                className='size-4 text-muted-foreground'
+              />
+              <Label
+                id={`${idPrefix}-unsubscribe-label`}
+                htmlFor={`${idPrefix}-unsubscribe`}
+                className='text-base font-semibold'
+              >
+                Unsubscribe from optional emails
+              </Label>
+            </div>
+            <p className='text-sm text-muted-foreground'>
+              This overrides the category choices below without changing them.
+              Account, security, and billing emails still send when required.
+            </p>
+          </div>
+          <Switch
+            id={`${idPrefix}-unsubscribe`}
+            checked={preferences.unsubscribeAllOptionalEmails}
+            onCheckedChange={(checked) =>
+              updateField('unsubscribeAllOptionalEmails', checked)
+            }
+            aria-labelledby={`${idPrefix}-unsubscribe-label`}
+            aria-describedby={`${idPrefix}-unsubscribe-help`}
+          />
+        </div>
+        <p id={`${idPrefix}-unsubscribe-help`} className='sr-only'>
+          When enabled, all optional email categories are disabled.
+        </p>
+      </section>
+
+      <div className='grid gap-4'>
+        {categories.map((category) => {
+          const field = fieldForCategory(category);
+          const copy = getEmailNotificationCategoryCopy(category);
+          const inputId = `${idPrefix}-${category}`;
+          const descriptionId = `${inputId}-description`;
+
+          return (
+            <section
+              key={category}
+              aria-labelledby={`${inputId}-label`}
+              className='rounded-lg border border-border bg-card p-5'
+            >
+              <div className='flex items-start justify-between gap-4'>
+                <div className='space-y-2'>
+                  <Label
+                    id={`${inputId}-label`}
+                    htmlFor={inputId}
+                    className='text-base font-semibold'
+                  >
+                    {copy.label}
+                  </Label>
+                  <p
+                    id={descriptionId}
+                    className='text-sm text-muted-foreground'
+                  >
+                    {copy.description}
+                  </p>
+                  {categoriesDisabled && (
+                    <p className='text-xs text-muted-foreground'>
+                      Unsubscribe-all is currently overriding this preference.
+                    </p>
+                  )}
+                </div>
+                <Switch
+                  id={inputId}
+                  checked={preferences[field]}
+                  disabled={categoriesDisabled}
+                  onCheckedChange={(checked) => updateField(field, checked)}
+                  aria-labelledby={`${inputId}-label`}
+                  aria-describedby={descriptionId}
+                />
+              </div>
+            </section>
+          );
+        })}
+      </div>
+
+      <div className='flex flex-col gap-3 border-t border-border pt-5 sm:flex-row sm:items-center sm:justify-between'>
+        <div className='flex items-center gap-2 text-sm text-muted-foreground'>
+          <CheckCircle2 aria-hidden className='size-4' />
+          Optional emails are off until you enable them.
+        </div>
+        <Button type='submit' disabled={!hasChanges || isSaving}>
+          {isSaving ? 'Saving...' : 'Save Preferences'}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/(app)/settings/notifications/page.tsx
+++ b/src/app/(app)/settings/notifications/page.tsx
@@ -1,64 +1,64 @@
 import type { Metadata } from 'next';
 
-import { ComingSoonAlert } from '@/components/shared/ComingSoonAlert';
-import { LockedFeatureCard } from '@/components/ui/locked-feature-card';
+import { NotificationPreferencesForm } from '@/app/(app)/settings/notifications/components/NotificationPreferencesForm';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
 import { PageHeader } from '@/components/ui/page-header';
-import { BellRing, BookOpen, Clock, CreditCard } from 'lucide-react';
+import { ROUTES } from '@/features/navigation/routes';
+import { requestBoundary } from '@/lib/api/request-boundary';
+import {
+  EMAIL_NOTIFICATION_CATEGORIES,
+  getEmailNotificationPreferences,
+} from '@/lib/db/queries/user-preferences';
+import { emailNotificationPreferenceFormValuesFromPreferences } from '@/shared/notifications/email-preferences';
+import { redirect } from 'next/navigation';
 
 export const metadata: Metadata = {
   title: 'Notifications',
   description: 'Manage your notification preferences.',
 };
 
-const iconClass = 'text-primary size-8 shrink-0';
+export default async function NotificationsSettingsPage() {
+  const preferences = await requestBoundary.component(({ actor, db }) =>
+    getEmailNotificationPreferences(actor.id, db),
+  );
 
-const NOTIFICATION_CATEGORIES = [
-  {
-    icon: <Clock className={iconClass} aria-hidden />,
-    title: 'Learning reminders',
-    description:
-      'Daily and weekly nudges, progress summaries, and streak alerts when personalized notifications launch.',
-  },
-  {
-    icon: <BookOpen className={iconClass} aria-hidden />,
-    title: 'Plan updates',
-    description:
-      'Alerts when plans finish generating, new resources are ready, or you hit module milestones.',
-  },
-  {
-    icon: <CreditCard className={iconClass} aria-hidden />,
-    title: 'Account & billing',
-    description:
-      'Updates about subscription changes, usage limits, and account security events.',
-  },
-];
+  if (!preferences) {
+    redirect(
+      `${ROUTES.AUTH.SIGN_IN}?redirect_url=${encodeURIComponent(ROUTES.SETTINGS.NOTIFICATIONS)}`,
+    );
+  }
 
-export default function NotificationsSettingsPage() {
   return (
     <>
       <PageHeader
         title='Notifications'
         titleAs='h2'
-        subtitle='Manage how you stay informed about your learning progress and account activity'
+        subtitle='Choose which optional product emails Atlaris can send.'
       />
 
-      <ComingSoonAlert
-        title='Personalized alerts are on the way'
-        description="We're building notification preferences so you can choose how and when you receive updates about your learning and account."
-        icon={BellRing}
-        className='mb-6'
-      />
-
-      <div className='grid gap-6 md:grid-cols-2'>
-        {NOTIFICATION_CATEGORIES.map((category) => (
-          <LockedFeatureCard
-            key={category.title}
-            icon={category.icon}
-            title={category.title}
-            description={category.description}
+      <Card>
+        <CardHeader>
+          <CardTitle as='h3'>Email Preferences</CardTitle>
+          <CardDescription>
+            Weekly summaries, daily reminders, and streak reminders are optional
+            and stay off until you enable them.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <NotificationPreferencesForm
+            initialPreferences={emailNotificationPreferenceFormValuesFromPreferences(
+              preferences,
+            )}
+            categories={[...EMAIL_NOTIFICATION_CATEGORIES]}
           />
-        ))}
-      </div>
+        </CardContent>
+      </Card>
     </>
   );
 }

--- a/src/app/api/v1/user/preferences/notifications/route.ts
+++ b/src/app/api/v1/user/preferences/notifications/route.ts
@@ -1,5 +1,5 @@
 import { updateEmailNotificationPreferencesSchema } from '@/app/api/v1/user/preferences/notifications/validation';
-import { AppError, ValidationError } from '@/lib/api/errors';
+import { ValidationError } from '@/lib/api/errors';
 import { parseJsonBody } from '@/lib/api/parse-json-body';
 import { requestBoundary } from '@/lib/api/request-boundary';
 import { json } from '@/lib/api/response';
@@ -8,6 +8,7 @@ import {
   emailNotificationPreferenceFormValuesFromPreferences,
   emailNotificationPreferencesFromFormValues,
 } from '@/shared/notifications/email-preferences';
+import { z } from 'zod';
 
 export const PATCH = requestBoundary.route(
   { rateLimit: 'mutation' },
@@ -20,7 +21,7 @@ export const PATCH = requestBoundary.route(
     const parsed = updateEmailNotificationPreferencesSchema.safeParse(body);
 
     if (!parsed.success) {
-      const errors = parsed.error.flatten();
+      const errors = z.flattenError(parsed.error);
       throw new ValidationError('Invalid notification preferences', errors, {
         errors,
       });
@@ -31,14 +32,6 @@ export const PATCH = requestBoundary.route(
       emailNotificationPreferencesFromFormValues(parsed.data),
       db,
     );
-
-    if (!savedPreferences) {
-      throw new AppError('Failed to persist notification preferences.', {
-        status: 500,
-        code: 'NOTIFICATION_PREFERENCES_UPDATE_FAILED',
-        logMeta: { userId: actor.id },
-      });
-    }
 
     return json({
       message: 'Notification preferences updated',

--- a/src/app/api/v1/user/preferences/notifications/route.ts
+++ b/src/app/api/v1/user/preferences/notifications/route.ts
@@ -1,0 +1,49 @@
+import { updateEmailNotificationPreferencesSchema } from '@/app/api/v1/user/preferences/notifications/validation';
+import { AppError, ValidationError } from '@/lib/api/errors';
+import { parseJsonBody } from '@/lib/api/parse-json-body';
+import { requestBoundary } from '@/lib/api/request-boundary';
+import { json } from '@/lib/api/response';
+import { saveEmailNotificationPreferences } from '@/lib/db/queries/user-preferences';
+import {
+  emailNotificationPreferenceFormValuesFromPreferences,
+  emailNotificationPreferencesFromFormValues,
+} from '@/shared/notifications/email-preferences';
+
+export const PATCH = requestBoundary.route(
+  { rateLimit: 'mutation' },
+  async ({ req, actor, db }) => {
+    const body = await parseJsonBody(req, {
+      mode: 'required',
+      onMalformedJson: () =>
+        new ValidationError('Invalid JSON in request body'),
+    });
+    const parsed = updateEmailNotificationPreferencesSchema.safeParse(body);
+
+    if (!parsed.success) {
+      const errors = parsed.error.flatten();
+      throw new ValidationError('Invalid notification preferences', errors, {
+        errors,
+      });
+    }
+
+    const savedPreferences = await saveEmailNotificationPreferences(
+      actor.id,
+      emailNotificationPreferencesFromFormValues(parsed.data),
+      db,
+    );
+
+    if (!savedPreferences) {
+      throw new AppError('Failed to persist notification preferences.', {
+        status: 500,
+        code: 'NOTIFICATION_PREFERENCES_UPDATE_FAILED',
+        logMeta: { userId: actor.id },
+      });
+    }
+
+    return json({
+      message: 'Notification preferences updated',
+      preferences:
+        emailNotificationPreferenceFormValuesFromPreferences(savedPreferences),
+    });
+  },
+);

--- a/src/app/api/v1/user/preferences/notifications/validation.ts
+++ b/src/app/api/v1/user/preferences/notifications/validation.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const updateEmailNotificationPreferencesSchema = z.strictObject({
+  unsubscribeAllOptionalEmails: z.boolean(),
+  weeklySummary: z.boolean(),
+  dailyReminder: z.boolean(),
+  streakReminder: z.boolean(),
+});

--- a/src/app/api/v1/user/preferences/notifications/validation.ts
+++ b/src/app/api/v1/user/preferences/notifications/validation.ts
@@ -1,8 +1,4 @@
-import { z } from 'zod';
+import { emailNotificationPreferenceFormValuesSchema } from '@/shared/notifications/email-preferences';
 
-export const updateEmailNotificationPreferencesSchema = z.strictObject({
-  unsubscribeAllOptionalEmails: z.boolean(),
-  weeklySummary: z.boolean(),
-  dailyReminder: z.boolean(),
-  streakReminder: z.boolean(),
-});
+export const updateEmailNotificationPreferencesSchema =
+  emailNotificationPreferenceFormValuesSchema;

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import * as SwitchPrimitive from '@radix-ui/react-switch';
+import * as React from 'react';
+
+function Switch({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot='switch'
+      className={cn(
+        'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-input shadow-xs transition-colors outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary-dark',
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot='switch-thumb'
+        className={cn(
+          'pointer-events-none block size-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0',
+        )}
+      />
+    </SwitchPrimitive.Root>
+  );
+}
+
+export { Switch };

--- a/src/lib/db/queries/user-preferences.ts
+++ b/src/lib/db/queries/user-preferences.ts
@@ -1,8 +1,25 @@
 import type { PreferredAiModel } from '../../../../supabase/enums';
 import type { DbClient } from '@/lib/db/types';
+import type { EmailNotificationCategory } from '@/shared/types/db.types';
 
-import { userPreferences } from '@supabase/schema';
+import { emailNotificationCategory } from '../../../../supabase/enums';
+import {
+  prepareRlsTransactionContext,
+  reapplyJwtClaimsInTransaction,
+} from '@/lib/db/queries/helpers/rls-jwt-claims';
+import {
+  DEFAULT_EMAIL_NOTIFICATION_PREFERENCES,
+  type EmailNotificationPreferenceValues,
+} from '@/shared/notifications/email-preferences';
+import {
+  userEmailNotificationPreferences,
+  userEmailNotificationSettings,
+  userPreferences,
+} from '@supabase/schema';
 import { eq, sql } from 'drizzle-orm';
+
+export const EMAIL_NOTIFICATION_CATEGORIES =
+  emailNotificationCategory.enumValues;
 
 export type UserPreferenceValues = {
   preferredAiModel: PreferredAiModel | null;
@@ -27,6 +44,149 @@ export async function getUserPreferences(
     .where(eq(userPreferences.userId, userId));
 
   return row ?? DEFAULT_USER_PREFERENCES;
+}
+
+export async function getEmailNotificationPreferences(
+  userId: string,
+  dbClient: Pick<DbClient, 'select'>,
+): Promise<EmailNotificationPreferenceValues> {
+  const [settingsRow] = await dbClient
+    .select({
+      unsubscribeAllOptionalEmails:
+        userEmailNotificationSettings.unsubscribeAllOptionalEmails,
+    })
+    .from(userEmailNotificationSettings)
+    .where(eq(userEmailNotificationSettings.userId, userId));
+
+  const categoryRows = await dbClient
+    .select({
+      category: userEmailNotificationPreferences.category,
+      enabled: userEmailNotificationPreferences.enabled,
+    })
+    .from(userEmailNotificationPreferences)
+    .where(eq(userEmailNotificationPreferences.userId, userId));
+
+  const categories = {
+    ...DEFAULT_EMAIL_NOTIFICATION_PREFERENCES.categories,
+  };
+
+  for (const row of categoryRows) {
+    categories[row.category] = row.enabled;
+  }
+
+  return {
+    unsubscribeAllOptionalEmails:
+      settingsRow?.unsubscribeAllOptionalEmails ??
+      DEFAULT_EMAIL_NOTIFICATION_PREFERENCES.unsubscribeAllOptionalEmails,
+    categories,
+  };
+}
+
+export async function saveEmailNotificationPreferences(
+  userId: string,
+  values: EmailNotificationPreferenceValues,
+  dbClient: Pick<DbClient, 'execute' | 'transaction'>,
+): Promise<EmailNotificationPreferenceValues | undefined> {
+  const rlsCtx = await prepareRlsTransactionContext(dbClient);
+
+  return dbClient.transaction(async (tx) => {
+    await reapplyJwtClaimsInTransaction(tx, rlsCtx);
+
+    const currentRows = await tx
+      .select({
+        category: userEmailNotificationPreferences.category,
+        enabled: userEmailNotificationPreferences.enabled,
+        unsubscribedAt: userEmailNotificationPreferences.unsubscribedAt,
+      })
+      .from(userEmailNotificationPreferences)
+      .where(eq(userEmailNotificationPreferences.userId, userId));
+
+    const currentByCategory = new Map<
+      EmailNotificationCategory,
+      (typeof currentRows)[number]
+    >();
+
+    for (const row of currentRows) {
+      currentByCategory.set(row.category, row);
+    }
+
+    const [settingsRow] = await tx
+      .insert(userEmailNotificationSettings)
+      .values({
+        userId,
+        unsubscribeAllOptionalEmails: values.unsubscribeAllOptionalEmails,
+        updatedAt: sql<Date>`now()`,
+      })
+      .onConflictDoUpdate({
+        target: userEmailNotificationSettings.userId,
+        set: {
+          unsubscribeAllOptionalEmails: sql`excluded.unsubscribe_all_optional_emails`,
+          updatedAt: sql<Date>`now()`,
+        },
+      })
+      .returning({
+        unsubscribeAllOptionalEmails:
+          userEmailNotificationSettings.unsubscribeAllOptionalEmails,
+      });
+
+    if (!settingsRow) {
+      return undefined;
+    }
+
+    const categories = {
+      ...DEFAULT_EMAIL_NOTIFICATION_PREFERENCES.categories,
+    };
+
+    const categoryValues = EMAIL_NOTIFICATION_CATEGORIES.map((category) => {
+      const enabled = values.categories[category];
+      const current = currentByCategory.get(category);
+      const unsubscribedAt = enabled
+        ? null
+        : current?.enabled === true
+          ? sql<Date>`now()`
+          : (current?.unsubscribedAt ?? null);
+
+      return {
+        userId,
+        category,
+        enabled,
+        unsubscribedAt,
+        updatedAt: sql<Date>`now()`,
+      };
+    });
+
+    const categoryRows = await tx
+      .insert(userEmailNotificationPreferences)
+      .values(categoryValues)
+      .onConflictDoUpdate({
+        target: [
+          userEmailNotificationPreferences.userId,
+          userEmailNotificationPreferences.category,
+        ],
+        set: {
+          enabled: sql`excluded.enabled`,
+          unsubscribedAt: sql`excluded.unsubscribed_at`,
+          updatedAt: sql<Date>`now()`,
+        },
+      })
+      .returning({
+        category: userEmailNotificationPreferences.category,
+        enabled: userEmailNotificationPreferences.enabled,
+      });
+
+    if (categoryRows.length !== EMAIL_NOTIFICATION_CATEGORIES.length) {
+      return undefined;
+    }
+
+    for (const row of categoryRows) {
+      categories[row.category] = row.enabled;
+    }
+
+    return {
+      unsubscribeAllOptionalEmails: settingsRow.unsubscribeAllOptionalEmails,
+      categories,
+    };
+  });
 }
 
 export async function upsertUserPreferredAiModel(

--- a/src/lib/db/queries/user-preferences.ts
+++ b/src/lib/db/queries/user-preferences.ts
@@ -1,8 +1,7 @@
-import type { PreferredAiModel } from '../../../../supabase/enums';
 import type { DbClient } from '@/lib/db/types';
 import type { EmailNotificationCategory } from '@/shared/types/db.types';
+import type { PreferredAiModel } from '@supabase/enums';
 
-import { emailNotificationCategory } from '../../../../supabase/enums';
 import {
   prepareRlsTransactionContext,
   reapplyJwtClaimsInTransaction,
@@ -11,6 +10,7 @@ import {
   DEFAULT_EMAIL_NOTIFICATION_PREFERENCES,
   type EmailNotificationPreferenceValues,
 } from '@/shared/notifications/email-preferences';
+import { emailNotificationCategory } from '@supabase/enums';
 import {
   userEmailNotificationPreferences,
   userEmailNotificationSettings,
@@ -86,7 +86,7 @@ export async function saveEmailNotificationPreferences(
   userId: string,
   values: EmailNotificationPreferenceValues,
   dbClient: Pick<DbClient, 'execute' | 'transaction'>,
-): Promise<EmailNotificationPreferenceValues | undefined> {
+): Promise<EmailNotificationPreferenceValues> {
   const rlsCtx = await prepareRlsTransactionContext(dbClient);
 
   return dbClient.transaction(async (tx) => {
@@ -130,7 +130,7 @@ export async function saveEmailNotificationPreferences(
       });
 
     if (!settingsRow) {
-      return undefined;
+      throw new Error('Failed to persist email notification settings row.');
     }
 
     const categories = {
@@ -175,7 +175,7 @@ export async function saveEmailNotificationPreferences(
       });
 
     if (categoryRows.length !== EMAIL_NOTIFICATION_CATEGORIES.length) {
-      return undefined;
+      throw new Error('Failed to persist email notification category rows.');
     }
 
     for (const row of categoryRows) {

--- a/src/shared/notifications/email-preferences.ts
+++ b/src/shared/notifications/email-preferences.ts
@@ -1,0 +1,97 @@
+import type { EmailNotificationCategory } from '@/shared/types/db.types';
+
+export type EmailNotificationCategoryPreferences = Record<
+  EmailNotificationCategory,
+  boolean
+>;
+
+export type EmailNotificationPreferenceValues = {
+  unsubscribeAllOptionalEmails: boolean;
+  categories: EmailNotificationCategoryPreferences;
+};
+
+export type EmailNotificationPreferenceFormValues = {
+  unsubscribeAllOptionalEmails: boolean;
+  weeklySummary: boolean;
+  dailyReminder: boolean;
+  streakReminder: boolean;
+};
+
+export type EmailNotificationCategoryCopy = {
+  label: string;
+  description: string;
+};
+
+export const DEFAULT_EMAIL_NOTIFICATION_PREFERENCES: EmailNotificationPreferenceValues =
+  {
+    unsubscribeAllOptionalEmails: false,
+    categories: {
+      weekly_summary: false,
+      daily_reminder: false,
+      streak_reminder: false,
+    },
+  };
+
+export function resolveEffectiveEmailPreferences(
+  values: EmailNotificationPreferenceValues,
+): EmailNotificationCategoryPreferences {
+  const enabled = !values.unsubscribeAllOptionalEmails;
+
+  return {
+    weekly_summary: enabled && values.categories.weekly_summary,
+    daily_reminder: enabled && values.categories.daily_reminder,
+    streak_reminder: enabled && values.categories.streak_reminder,
+  };
+}
+
+export function emailNotificationPreferenceFormValuesFromPreferences(
+  values: EmailNotificationPreferenceValues,
+): EmailNotificationPreferenceFormValues {
+  return {
+    unsubscribeAllOptionalEmails: values.unsubscribeAllOptionalEmails,
+    weeklySummary: values.categories.weekly_summary,
+    dailyReminder: values.categories.daily_reminder,
+    streakReminder: values.categories.streak_reminder,
+  };
+}
+
+export function emailNotificationPreferencesFromFormValues(
+  values: EmailNotificationPreferenceFormValues,
+): EmailNotificationPreferenceValues {
+  return {
+    unsubscribeAllOptionalEmails: values.unsubscribeAllOptionalEmails,
+    categories: {
+      weekly_summary: values.weeklySummary,
+      daily_reminder: values.dailyReminder,
+      streak_reminder: values.streakReminder,
+    },
+  };
+}
+
+export function getEmailNotificationCategoryCopy(
+  category: EmailNotificationCategory,
+): EmailNotificationCategoryCopy {
+  switch (category) {
+    case 'weekly_summary':
+      return {
+        label: 'Weekly summary emails',
+        description:
+          'A weekly progress recap with completed work and suggested next steps.',
+      };
+    case 'daily_reminder':
+      return {
+        label: 'Daily reminder emails',
+        description:
+          'A daily prompt to return to active plans and keep momentum.',
+      };
+    case 'streak_reminder':
+      return {
+        label: 'Streak reminder emails',
+        description: 'A reminder when a learning streak is close to slipping.',
+      };
+    default: {
+      const _exhaustiveCheck: never = category;
+      return _exhaustiveCheck;
+    }
+  }
+}

--- a/src/shared/notifications/email-preferences.ts
+++ b/src/shared/notifications/email-preferences.ts
@@ -1,5 +1,7 @@
 import type { EmailNotificationCategory } from '@/shared/types/db.types';
 
+import { z } from 'zod';
+
 export type EmailNotificationCategoryPreferences = Record<
   EmailNotificationCategory,
   boolean
@@ -10,12 +12,16 @@ export type EmailNotificationPreferenceValues = {
   categories: EmailNotificationCategoryPreferences;
 };
 
-export type EmailNotificationPreferenceFormValues = {
-  unsubscribeAllOptionalEmails: boolean;
-  weeklySummary: boolean;
-  dailyReminder: boolean;
-  streakReminder: boolean;
-};
+export const emailNotificationPreferenceFormValuesSchema = z.strictObject({
+  unsubscribeAllOptionalEmails: z.boolean(),
+  weeklySummary: z.boolean(),
+  dailyReminder: z.boolean(),
+  streakReminder: z.boolean(),
+});
+
+export type EmailNotificationPreferenceFormValues = z.infer<
+  typeof emailNotificationPreferenceFormValuesSchema
+>;
 
 export type EmailNotificationCategoryCopy = {
   label: string;

--- a/src/shared/types/db.types.ts
+++ b/src/shared/types/db.types.ts
@@ -18,6 +18,8 @@ export type ProgressStatus =
   DbEnumsModule['progressStatus']['enumValues'][number];
 export type GenerationStatus =
   DbEnumsModule['generationStatus']['enumValues'][number];
+export type EmailNotificationCategory =
+  DbEnumsModule['emailNotificationCategory']['enumValues'][number];
 
 export type LearningPlan = InferSelectModel<DbSchemaModule['learningPlans']>;
 

--- a/tests/integration/api/user-notification-preferences.spec.ts
+++ b/tests/integration/api/user-notification-preferences.spec.ts
@@ -1,0 +1,155 @@
+import { assertLocalIntegrationDatabaseUrl } from '../../helpers/assert-local-database-url';
+import { clearTestUser, setTestUser } from '../../helpers/auth';
+import { ensureUser } from '../../helpers/db/users';
+import { PATCH } from '@/app/api/v1/user/preferences/notifications/route';
+import { USER_RATE_LIMIT_CONFIGS } from '@/lib/api/user-rate-limit';
+import { getEmailNotificationPreferences } from '@/lib/db/queries/user-preferences';
+import { db } from '@supabase/service-role';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+assertLocalIntegrationDatabaseUrl();
+
+function expectJsonObject(value: unknown): Record<string, unknown> {
+  expect(value).toBeTypeOf('object');
+  expect(value).not.toBeNull();
+  return value as Record<string, unknown>;
+}
+
+function patchRequest(body: unknown): Request {
+  return new Request('http://localhost/api/v1/user/preferences/notifications', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+describe('PATCH /api/v1/user/preferences/notifications', () => {
+  const testAuthUserId = `notification-preferences-user-${Date.now()}`;
+  let userId: string;
+
+  beforeAll(async () => {
+    userId = await ensureUser({
+      authUserId: testAuthUserId,
+      email: `${testAuthUserId}@example.com`,
+    });
+  });
+
+  afterAll(() => {
+    clearTestUser();
+  });
+
+  it('saves authenticated user notification preferences', async () => {
+    setTestUser(testAuthUserId);
+
+    const response = await PATCH(
+      patchRequest({
+        unsubscribeAllOptionalEmails: false,
+        weeklySummary: true,
+        dailyReminder: false,
+        streakReminder: true,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('X-RateLimit-Limit')).toBe(
+      String(USER_RATE_LIMIT_CONFIGS.mutation.maxRequests),
+    );
+    const data = expectJsonObject(await response.json());
+    expect(data.message).toBe('Notification preferences updated');
+    expect(data.preferences).toEqual({
+      unsubscribeAllOptionalEmails: false,
+      weeklySummary: true,
+      dailyReminder: false,
+      streakReminder: true,
+    });
+    await expect(getEmailNotificationPreferences(userId, db)).resolves.toEqual({
+      unsubscribeAllOptionalEmails: false,
+      categories: {
+        weekly_summary: true,
+        daily_reminder: false,
+        streak_reminder: true,
+      },
+    });
+  });
+
+  it('keeps category preferences while unsubscribe-all masks effective delivery', async () => {
+    setTestUser(testAuthUserId);
+
+    const response = await PATCH(
+      patchRequest({
+        unsubscribeAllOptionalEmails: true,
+        weeklySummary: true,
+        dailyReminder: true,
+        streakReminder: true,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const data = expectJsonObject(await response.json());
+    expect(data.preferences).toEqual({
+      unsubscribeAllOptionalEmails: true,
+      weeklySummary: true,
+      dailyReminder: true,
+      streakReminder: true,
+    });
+    await expect(getEmailNotificationPreferences(userId, db)).resolves.toEqual({
+      unsubscribeAllOptionalEmails: true,
+      categories: {
+        weekly_summary: true,
+        daily_reminder: true,
+        streak_reminder: true,
+      },
+    });
+  });
+
+  it('rejects invalid payloads with canonical 400 errors', async () => {
+    setTestUser(testAuthUserId);
+
+    for (const body of [
+      {},
+      {
+        unsubscribeAllOptionalEmails: false,
+        weeklySummary: true,
+        dailyReminder: false,
+        streakReminder: false,
+        extraField: true,
+      },
+      {
+        unsubscribeAllOptionalEmails: false,
+        weeklySummary: 'yes',
+        dailyReminder: false,
+        streakReminder: false,
+      },
+    ]) {
+      const response = await PATCH(patchRequest(body));
+      expect(response.status).toBe(400);
+      const data = expectJsonObject(await response.json());
+      expect(data.error).toBe('Invalid notification preferences');
+    }
+  });
+
+  it('rejects malformed JSON', async () => {
+    setTestUser(testAuthUserId);
+
+    const response = await PATCH(patchRequest('{ not json'));
+
+    expect(response.status).toBe(400);
+    const data = expectJsonObject(await response.json());
+    expect(data.error).toBe('Invalid JSON in request body');
+  });
+
+  it('returns 401 for unauthenticated requests', async () => {
+    clearTestUser();
+
+    const response = await PATCH(
+      patchRequest({
+        unsubscribeAllOptionalEmails: false,
+        weeklySummary: true,
+        dailyReminder: false,
+        streakReminder: false,
+      }),
+    );
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/tests/integration/api/user-notification-preferences.spec.ts
+++ b/tests/integration/api/user-notification-preferences.spec.ts
@@ -5,7 +5,7 @@ import { PATCH } from '@/app/api/v1/user/preferences/notifications/route';
 import { USER_RATE_LIMIT_CONFIGS } from '@/lib/api/user-rate-limit';
 import { getEmailNotificationPreferences } from '@/lib/db/queries/user-preferences';
 import { db } from '@supabase/service-role';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
 
 assertLocalIntegrationDatabaseUrl();
 
@@ -27,7 +27,7 @@ describe('PATCH /api/v1/user/preferences/notifications', () => {
   const testAuthUserId = `notification-preferences-user-${Date.now()}`;
   let userId: string;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     userId = await ensureUser({
       authUserId: testAuthUserId,
       email: `${testAuthUserId}@example.com`,

--- a/tests/integration/db/user-preferences.spec.ts
+++ b/tests/integration/db/user-preferences.spec.ts
@@ -1,5 +1,10 @@
 import { ensureUser } from '../../helpers/db/users';
-import { getUserPreferences } from '@/lib/db/queries/user-preferences';
+import {
+  getEmailNotificationPreferences,
+  getUserPreferences,
+  saveEmailNotificationPreferences,
+} from '@/lib/db/queries/user-preferences';
+import { resolveEffectiveEmailPreferences } from '@/shared/notifications/email-preferences';
 import {
   userEmailNotificationPreferences,
   userEmailNotificationSettings,
@@ -44,6 +49,52 @@ describe('user preference persistence', () => {
       enabled: false,
       unsubscribedAt: null,
     });
+  });
+
+  it('round trips email notification preferences with unsubscribe-all masking', async () => {
+    const userId = await ensureUser({
+      authUserId: 'notification_round_trip',
+      email: 'notification-round-trip@example.com',
+    });
+
+    await expect(getEmailNotificationPreferences(userId, db)).resolves.toEqual({
+      unsubscribeAllOptionalEmails: false,
+      categories: {
+        weekly_summary: false,
+        daily_reminder: false,
+        streak_reminder: false,
+      },
+    });
+
+    const savedPreferences = await saveEmailNotificationPreferences(
+      userId,
+      {
+        unsubscribeAllOptionalEmails: true,
+        categories: {
+          weekly_summary: true,
+          daily_reminder: true,
+          streak_reminder: false,
+        },
+      },
+      db,
+    );
+
+    expect(savedPreferences).toEqual({
+      unsubscribeAllOptionalEmails: true,
+      categories: {
+        weekly_summary: true,
+        daily_reminder: true,
+        streak_reminder: false,
+      },
+    });
+    expect(resolveEffectiveEmailPreferences(savedPreferences!)).toEqual({
+      weekly_summary: false,
+      daily_reminder: false,
+      streak_reminder: false,
+    });
+    await expect(getEmailNotificationPreferences(userId, db)).resolves.toEqual(
+      savedPreferences,
+    );
   });
 
   it('cascades preference rows when a user is deleted', async () => {

--- a/tests/unit/db/user-preferences.queries.spec.ts
+++ b/tests/unit/db/user-preferences.queries.spec.ts
@@ -156,6 +156,56 @@ describe('user preference queries', () => {
     });
   });
 
+  it('throws when email notification category writes are incomplete', async () => {
+    function insertReturning(rows: unknown[]) {
+      return {
+        values: vi.fn(() => ({
+          onConflictDoUpdate: vi.fn(() => ({
+            returning: vi.fn().mockResolvedValue(rows),
+          })),
+        })),
+      };
+    }
+
+    const tx = {
+      select: vi.fn(() => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      })),
+      insert: vi
+        .fn()
+        .mockReturnValueOnce(
+          insertReturning([{ unsubscribeAllOptionalEmails: false }]),
+        )
+        .mockReturnValueOnce(
+          insertReturning([{ category: 'weekly_summary', enabled: true }]),
+        ),
+      execute: vi.fn(),
+    };
+    const dbClient = makeDbClient({
+      execute: vi.fn().mockResolvedValue([]) as unknown as DbClient['execute'],
+      transaction: vi.fn((run) =>
+        run(tx),
+      ) as unknown as DbClient['transaction'],
+    });
+
+    await expect(
+      saveEmailNotificationPreferences(
+        'user-1',
+        {
+          unsubscribeAllOptionalEmails: false,
+          categories: {
+            weekly_summary: true,
+            daily_reminder: false,
+            streak_reminder: false,
+          },
+        },
+        dbClient,
+      ),
+    ).rejects.toThrow('Failed to persist email notification category rows.');
+  });
+
   it('upserts preferred AI model on the user preference row', async () => {
     const returning = vi.fn().mockResolvedValue([
       {

--- a/tests/unit/db/user-preferences.queries.spec.ts
+++ b/tests/unit/db/user-preferences.queries.spec.ts
@@ -2,7 +2,9 @@ import type { DbClient } from '@/lib/db/types';
 
 import { makeDbClient } from '../../fixtures/db-mocks';
 import {
+  getEmailNotificationPreferences,
   getUserPreferences,
+  saveEmailNotificationPreferences,
   upsertUserAnalyticsTimezone,
   upsertUserPreferredAiModel,
 } from '@/lib/db/queries/user-preferences';
@@ -21,6 +23,136 @@ describe('user preference queries', () => {
     await expect(getUserPreferences('user-1', dbClient)).resolves.toEqual({
       preferredAiModel: null,
       analyticsTimezone: 'UTC',
+    });
+  });
+
+  it('returns default email notification preferences when no rows exist', async () => {
+    const where = vi.fn().mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    const from = vi.fn().mockReturnValue({ where });
+    const select = vi.fn().mockReturnValue({ from });
+    const dbClient = makeDbClient({
+      select: select as unknown as DbClient['select'],
+    });
+
+    await expect(
+      getEmailNotificationPreferences('user-1', dbClient),
+    ).resolves.toEqual({
+      unsubscribeAllOptionalEmails: false,
+      categories: {
+        weekly_summary: false,
+        daily_reminder: false,
+        streak_reminder: false,
+      },
+    });
+  });
+
+  it('saves email notification preferences transactionally', async () => {
+    const insertedValues: unknown[] = [];
+    const currentUnsubscribedAt = new Date('2026-07-03T12:00:00.000Z');
+
+    function insertReturning(rows: unknown[]) {
+      return {
+        values: vi.fn((payload: unknown) => {
+          insertedValues.push(payload);
+          return {
+            onConflictDoUpdate: vi.fn(() => ({
+              returning: vi.fn().mockResolvedValue(rows),
+            })),
+          };
+        }),
+      };
+    }
+
+    const tx = {
+      select: vi.fn(() => ({
+        from: () => ({
+          where: () =>
+            Promise.resolve([
+              {
+                category: 'weekly_summary',
+                enabled: true,
+                unsubscribedAt: null,
+              },
+              {
+                category: 'streak_reminder',
+                enabled: false,
+                unsubscribedAt: currentUnsubscribedAt,
+              },
+            ]),
+        }),
+      })),
+      insert: vi
+        .fn()
+        .mockReturnValueOnce(
+          insertReturning([{ unsubscribeAllOptionalEmails: true }]),
+        )
+        .mockReturnValueOnce(
+          insertReturning([
+            { category: 'weekly_summary', enabled: false },
+            { category: 'daily_reminder', enabled: true },
+            { category: 'streak_reminder', enabled: false },
+          ]),
+        ),
+      execute: vi.fn(),
+    };
+    const transaction = vi.fn((run) => run(tx));
+    const dbClient = makeDbClient({
+      execute: vi.fn().mockResolvedValue([]) as unknown as DbClient['execute'],
+      transaction: transaction as unknown as DbClient['transaction'],
+    });
+
+    await expect(
+      saveEmailNotificationPreferences(
+        'user-1',
+        {
+          unsubscribeAllOptionalEmails: true,
+          categories: {
+            weekly_summary: false,
+            daily_reminder: true,
+            streak_reminder: false,
+          },
+        },
+        dbClient,
+      ),
+    ).resolves.toEqual({
+      unsubscribeAllOptionalEmails: true,
+      categories: {
+        weekly_summary: false,
+        daily_reminder: true,
+        streak_reminder: false,
+      },
+    });
+
+    expect(transaction).toHaveBeenCalledOnce();
+    expect(insertedValues).toHaveLength(2);
+    expect(insertedValues[0]).toMatchObject({
+      userId: 'user-1',
+      unsubscribeAllOptionalEmails: true,
+    });
+    const categoryValues = insertedValues[1] as Array<{
+      userId: string;
+      category: string;
+      enabled: boolean;
+      unsubscribedAt: unknown;
+    }>;
+    expect(categoryValues).toHaveLength(3);
+    expect(categoryValues[0]).toMatchObject({
+      userId: 'user-1',
+      category: 'weekly_summary',
+      enabled: false,
+    });
+    expect(categoryValues[0]?.unsubscribedAt).not.toBeNull();
+    expect(categoryValues[1]).toMatchObject({
+      userId: 'user-1',
+      category: 'daily_reminder',
+      enabled: true,
+      unsubscribedAt: null,
+    });
+    expect(categoryValues[2]).toMatchObject({
+      userId: 'user-1',
+      category: 'streak_reminder',
+      enabled: false,
+      unsubscribedAt: currentUnsubscribedAt,
     });
   });
 

--- a/tests/unit/settings/notifications/NotificationPreferencesForm.spec.tsx
+++ b/tests/unit/settings/notifications/NotificationPreferencesForm.spec.tsx
@@ -1,0 +1,202 @@
+import type { EmailNotificationPreferenceFormValues } from '@/shared/notifications/email-preferences';
+import type { EmailNotificationCategory } from '@/shared/types/db.types';
+
+import { NotificationPreferencesForm } from '@/app/(app)/settings/notifications/components/NotificationPreferencesForm';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { toast } from 'sonner';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import '../../../mocks/unit/sonner.unit';
+
+const refreshMock = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: refreshMock }),
+}));
+
+const CATEGORIES: EmailNotificationCategory[] = [
+  'weekly_summary',
+  'daily_reminder',
+  'streak_reminder',
+];
+
+const DEFAULT_PREFERENCES: EmailNotificationPreferenceFormValues = {
+  unsubscribeAllOptionalEmails: false,
+  weeklySummary: false,
+  dailyReminder: false,
+  streakReminder: false,
+};
+
+function mockJsonResponse(
+  body: unknown,
+  options?: { ok?: boolean; status?: number },
+) {
+  return {
+    ok: options?.ok ?? true,
+    status: options?.status ?? 200,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: vi.fn().mockResolvedValue(body),
+    text: vi.fn().mockResolvedValue(JSON.stringify(body)),
+  };
+}
+
+function renderForm(
+  initialPreferences: EmailNotificationPreferenceFormValues = DEFAULT_PREFERENCES,
+) {
+  return render(
+    <NotificationPreferencesForm
+      initialPreferences={initialPreferences}
+      categories={CATEGORIES}
+    />,
+  );
+}
+
+describe('NotificationPreferencesForm', () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+    refreshMock.mockClear();
+    vi.mocked(toast.error).mockClear();
+    vi.mocked(toast.success).mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders default-off preferences with save disabled', () => {
+    renderForm();
+
+    expect(
+      screen.getByRole('switch', { name: /weekly summary emails/i }),
+    ).toHaveAttribute('aria-checked', 'false');
+    expect(
+      screen.getByRole('switch', { name: /daily reminder emails/i }),
+    ).toHaveAttribute('aria-checked', 'false');
+    expect(
+      screen.getByRole('switch', { name: /streak reminder emails/i }),
+    ).toHaveAttribute('aria-checked', 'false');
+    expect(
+      screen.getByRole('button', { name: /save preferences/i }),
+    ).toBeDisabled();
+  });
+
+  it('saves changed category preferences', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockJsonResponse({
+        message: 'Notification preferences updated',
+        preferences: {
+          ...DEFAULT_PREFERENCES,
+          weeklySummary: true,
+        },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderForm();
+
+    await user.click(
+      screen.getByRole('switch', { name: /weekly summary emails/i }),
+    );
+    await user.click(screen.getByRole('button', { name: /save preferences/i }));
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith(
+        'Notification preferences saved',
+      );
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/user/preferences/notifications',
+      expect.objectContaining({
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...DEFAULT_PREFERENCES,
+          weeklySummary: true,
+        }),
+      }),
+    );
+    expect(refreshMock).toHaveBeenCalledOnce();
+    expect(
+      screen.getByRole('button', { name: /save preferences/i }),
+    ).toBeDisabled();
+  });
+
+  it('unsubscribe-all disables category switches without clearing their values', async () => {
+    const initialPreferences = {
+      ...DEFAULT_PREFERENCES,
+      weeklySummary: true,
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockJsonResponse({
+        message: 'Notification preferences updated',
+        preferences: {
+          ...initialPreferences,
+          unsubscribeAllOptionalEmails: true,
+        },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderForm(initialPreferences);
+
+    await user.click(
+      screen.getByRole('switch', {
+        name: /unsubscribe from optional emails/i,
+      }),
+    );
+
+    const weeklySwitch = screen.getByRole('switch', {
+      name: /weekly summary emails/i,
+    });
+    expect(weeklySwitch).toBeDisabled();
+    expect(weeklySwitch).toHaveAttribute('aria-checked', 'true');
+
+    await user.click(screen.getByRole('button', { name: /save preferences/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    expect(JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string)).toEqual({
+      ...initialPreferences,
+      unsubscribeAllOptionalEmails: true,
+    });
+  });
+
+  it('keeps local changes and shows an error when save fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        mockJsonResponse(
+          {
+            error: 'Nope',
+            code: 'BAD_REQUEST',
+          },
+          { ok: false, status: 400 },
+        ),
+      ),
+    );
+
+    renderForm();
+
+    await user.click(
+      screen.getByRole('switch', { name: /daily reminder emails/i }),
+    );
+    await user.click(screen.getByRole('button', { name: /save preferences/i }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Nope');
+    });
+    expect(
+      screen.getByRole('switch', { name: /daily reminder emails/i }),
+    ).toHaveAttribute('aria-checked', 'true');
+    expect(
+      screen.getByRole('button', { name: /save preferences/i }),
+    ).toBeEnabled();
+  });
+});

--- a/tests/unit/settings/notifications/NotificationPreferencesForm.spec.tsx
+++ b/tests/unit/settings/notifications/NotificationPreferencesForm.spec.tsx
@@ -168,6 +168,54 @@ describe('NotificationPreferencesForm', () => {
     });
   });
 
+  it('disables all switches while saving', async () => {
+    let resolveFetch: (response: ReturnType<typeof mockJsonResponse>) => void;
+    const fetchPromise = new Promise<ReturnType<typeof mockJsonResponse>>(
+      (resolve) => {
+        resolveFetch = resolve;
+      },
+    );
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(fetchPromise));
+
+    renderForm();
+
+    await user.click(
+      screen.getByRole('switch', { name: /weekly summary emails/i }),
+    );
+    await user.click(screen.getByRole('button', { name: /save preferences/i }));
+
+    expect(
+      screen.getByRole('switch', {
+        name: /unsubscribe from optional emails/i,
+      }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole('switch', { name: /weekly summary emails/i }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole('switch', { name: /daily reminder emails/i }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole('switch', { name: /streak reminder emails/i }),
+    ).toBeDisabled();
+
+    resolveFetch!(
+      mockJsonResponse({
+        message: 'Notification preferences updated',
+        preferences: {
+          ...DEFAULT_PREFERENCES,
+          weeklySummary: true,
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith(
+        'Notification preferences saved',
+      );
+    });
+  });
+
   it('keeps local changes and shows an error when save fails', async () => {
     vi.stubGlobal(
       'fetch',

--- a/tests/unit/settings/notifications/NotificationPreferencesForm.spec.tsx
+++ b/tests/unit/settings/notifications/NotificationPreferencesForm.spec.tsx
@@ -198,6 +198,9 @@ describe('NotificationPreferencesForm', () => {
     expect(
       screen.getByRole('switch', { name: /streak reminder emails/i }),
     ).toBeDisabled();
+    expect(
+      screen.queryByText(/unsubscribe-all is currently overriding/i),
+    ).not.toBeInTheDocument();
 
     resolveFetch!(
       mockJsonResponse({

--- a/tests/unit/shared/notifications/email-preferences.spec.ts
+++ b/tests/unit/shared/notifications/email-preferences.spec.ts
@@ -1,0 +1,61 @@
+import {
+  emailNotificationPreferenceFormValuesFromPreferences,
+  emailNotificationPreferencesFromFormValues,
+  getEmailNotificationCategoryCopy,
+  resolveEffectiveEmailPreferences,
+} from '@/shared/notifications/email-preferences';
+import { describe, expect, it } from 'vitest';
+
+describe('email notification preference helpers', () => {
+  it('keeps category choices but masks effective delivery when unsubscribe-all is enabled', () => {
+    const preferences = {
+      unsubscribeAllOptionalEmails: true,
+      categories: {
+        weekly_summary: true,
+        daily_reminder: true,
+        streak_reminder: false,
+      },
+    };
+
+    expect(resolveEffectiveEmailPreferences(preferences)).toEqual({
+      weekly_summary: false,
+      daily_reminder: false,
+      streak_reminder: false,
+    });
+  });
+
+  it('round trips form values and category preferences', () => {
+    const formValues = {
+      unsubscribeAllOptionalEmails: false,
+      weeklySummary: true,
+      dailyReminder: false,
+      streakReminder: true,
+    };
+
+    const preferences = emailNotificationPreferencesFromFormValues(formValues);
+
+    expect(preferences).toEqual({
+      unsubscribeAllOptionalEmails: false,
+      categories: {
+        weekly_summary: true,
+        daily_reminder: false,
+        streak_reminder: true,
+      },
+    });
+    expect(
+      emailNotificationPreferenceFormValuesFromPreferences(preferences),
+    ).toEqual(formValues);
+  });
+
+  it('has copy for each email notification category', () => {
+    expect(getEmailNotificationCategoryCopy('weekly_summary').label).toBe(
+      'Weekly summary emails',
+    );
+    expect(getEmailNotificationCategoryCopy('daily_reminder').label).toBe(
+      'Daily reminder emails',
+    );
+    expect(getEmailNotificationCategoryCopy('streak_reminder').label).toBe(
+      'Streak reminder emails',
+    );
+  });
+});

--- a/tests/unit/shared/notifications/email-preferences.spec.ts
+++ b/tests/unit/shared/notifications/email-preferences.spec.ts
@@ -1,4 +1,5 @@
 import {
+  emailNotificationPreferenceFormValuesSchema,
   emailNotificationPreferenceFormValuesFromPreferences,
   emailNotificationPreferencesFromFormValues,
   getEmailNotificationCategoryCopy,
@@ -45,6 +46,25 @@ describe('email notification preference helpers', () => {
     expect(
       emailNotificationPreferenceFormValuesFromPreferences(preferences),
     ).toEqual(formValues);
+  });
+
+  it('validates the strict form value contract', () => {
+    const formValues = {
+      unsubscribeAllOptionalEmails: false,
+      weeklySummary: true,
+      dailyReminder: false,
+      streakReminder: true,
+    };
+
+    expect(
+      emailNotificationPreferenceFormValuesSchema.parse(formValues),
+    ).toEqual(formValues);
+    expect(
+      emailNotificationPreferenceFormValuesSchema.safeParse({
+        ...formValues,
+        extraField: true,
+      }).success,
+    ).toBe(false);
   });
 
   it('has copy for each email notification category', () => {


### PR DESCRIPTION
## Summary
- replaces the notifications coming-soon page with authenticated optional email preference controls
- adds user-scoped email notification preference load/save helpers plus the PATCH user preferences sub-route
- adds the switch primitive/dependency and focused unit/integration coverage for defaults, validation, save behavior, and unsubscribe-all masking

## Verification
- SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit tests/unit/shared/notifications/email-preferences.spec.ts tests/unit/db/user-preferences.queries.spec.ts tests/unit/settings/notifications/NotificationPreferencesForm.spec.tsx
- pnpm check:type
- pnpm check:lint
- npx -y react-doctor@latest . --verbose --scope changed --base origin/develop
- pnpm audit --prod --json (reports 2 existing low webpack advisories via @sentry/nextjs, not introduced by this branch)

## Not run
- DB/API integration, RLS, and Playwright smoke suites were not run locally because OrbStack/test containers are not running locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches user-scoped preference persistence and a new authenticated mutation route; behavior is well-tested but incorrect masking could affect future email sends.
> 
> **Overview**
> Replaces the notifications **coming-soon** UI with a working **Email Preferences** experience: users can toggle optional categories (weekly summary, daily reminder, streak reminder), use a global **unsubscribe from optional emails** override that masks delivery without wiping stored category toggles, and **Save** via `PATCH /api/v1/user/preferences/notifications`.
> 
> Adds shared Zod/form mapping in `email-preferences`, transactional load/save against `userEmailNotificationSettings` and `userEmailNotificationPreferences` (including `unsubscribedAt` when a category is turned off), a Radix-based `Switch` component, and unit/integration tests for API validation, persistence, and form behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9aeb69fed0aa6f1176a90f37bd34c0de5520075e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->