### PR TITLE
fix(settings): free hash anchors from Clerk and restore section scroll

### DIFF
--- a/src/app/(app)/settings/[...user-profile]/page.tsx
+++ b/src/app/(app)/settings/[...user-profile]/page.tsx
@@ -1,0 +1,8 @@
+import type { ReactElement } from 'react';
+
+import { SettingsLedgerPage } from '@/app/(app)/settings/components/SettingsLedgerPage';
+
+/** Renders Clerk's path-routed profile subpages within the settings ledger. */
+export default async function SettingsUserProfilePage(): Promise<ReactElement> {
+  return <SettingsLedgerPage />;
+}

--- a/src/app/(app)/settings/components/SettingsLedgerPage.tsx
+++ b/src/app/(app)/settings/components/SettingsLedgerPage.tsx
@@ -16,6 +16,7 @@ import { SettingsScrollTarget } from '@/app/(app)/settings/components/SettingsSc
 import { IntegrationRows } from '@/app/(app)/settings/integrations/components/IntegrationRows';
 import { NotificationsSection } from '@/app/(app)/settings/notifications/components/NotificationsSection';
 import { ProfileForm } from '@/app/(app)/settings/profile/components/ProfileForm';
+import { SETTINGS_SECTIONS } from '@/app/(app)/settings/settings-section-ids';
 import { shouldUseClerkUi } from '@/lib/auth/local-identity';
 import { getSupportedLocale } from '@/lib/i18n/locale';
 import { UserProfile } from '@clerk/nextjs';
@@ -39,7 +40,7 @@ export async function SettingsLedgerPage(): Promise<ReactElement> {
 
       <SettingsLedgerPanel>
         <LedgerSectionBlock
-          id='profile'
+          id={SETTINGS_SECTIONS.profile}
           label='Profile'
           description='How you appear across Atlaris.'
         >
@@ -47,7 +48,7 @@ export async function SettingsLedgerPage(): Promise<ReactElement> {
         </LedgerSectionBlock>
 
         <LedgerSectionBlock
-          id='billing'
+          id={SETTINGS_SECTIONS.billing}
           label='Plan & billing'
           description='Subscription, renewal, and payment details.'
         >
@@ -69,7 +70,7 @@ export async function SettingsLedgerPage(): Promise<ReactElement> {
         </LedgerSectionBlock>
 
         <LedgerSectionBlock
-          id='usage'
+          id={SETTINGS_SECTIONS.usage}
           label='Usage'
           description='Monthly quota across your workspace.'
         >
@@ -79,7 +80,7 @@ export async function SettingsLedgerPage(): Promise<ReactElement> {
         </LedgerSectionBlock>
 
         <LedgerSectionBlock
-          id='ai'
+          id={SETTINGS_SECTIONS.ai}
           label='AI model'
           description='The model that drafts your plans and lessons.'
         >
@@ -89,7 +90,7 @@ export async function SettingsLedgerPage(): Promise<ReactElement> {
         </LedgerSectionBlock>
 
         <LedgerSectionBlock
-          id='integrations'
+          id={SETTINGS_SECTIONS.integrations}
           label='Integrations'
           description='Connect Atlaris to the rest of your stack.'
         >
@@ -97,7 +98,7 @@ export async function SettingsLedgerPage(): Promise<ReactElement> {
         </LedgerSectionBlock>
 
         <LedgerSectionBlock
-          id='notifications'
+          id={SETTINGS_SECTIONS.notifications}
           label='Notifications'
           description='What Atlaris is allowed to email you about.'
         >

--- a/src/app/(app)/settings/components/SettingsLedgerPage.tsx
+++ b/src/app/(app)/settings/components/SettingsLedgerPage.tsx
@@ -12,6 +12,7 @@ import {
   LedgerSectionBlock,
   SettingsLedgerPanel,
 } from '@/app/(app)/settings/components/LedgerPrimitives';
+import { SettingsScrollTarget } from '@/app/(app)/settings/components/SettingsScrollTarget';
 import { IntegrationRows } from '@/app/(app)/settings/integrations/components/IntegrationRows';
 import { NotificationsSection } from '@/app/(app)/settings/notifications/components/NotificationsSection';
 import { ProfileForm } from '@/app/(app)/settings/profile/components/ProfileForm';
@@ -27,6 +28,8 @@ export async function SettingsLedgerPage(): Promise<ReactElement> {
 
   return (
     <>
+      <SettingsScrollTarget />
+
       <header className='relative mb-6'>
         <h1>Settings</h1>
         <p className='mt-1 text-sm text-muted-foreground'>
@@ -54,7 +57,6 @@ export async function SettingsLedgerPage(): Promise<ReactElement> {
           {showClerkBilling ? (
             <div className='py-3.5 last:pb-0'>
               <UserProfile
-                routing='hash'
                 appearance={{
                   elements: {
                     rootBox: 'w-full',

--- a/src/app/(app)/settings/components/SettingsScrollTarget.tsx
+++ b/src/app/(app)/settings/components/SettingsScrollTarget.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { useEffect, type ReactElement } from 'react';
+
+const SETTINGS_SECTION_IDS = [
+  'profile',
+  'billing',
+  'usage',
+  'ai',
+  'integrations',
+  'notifications',
+] as const;
+
+type SettingsSectionId = (typeof SETTINGS_SECTION_IDS)[number];
+
+function parseSectionHash(hash: string): SettingsSectionId | undefined {
+  const sectionId = hash.replace(/^#/, '');
+  return SETTINGS_SECTION_IDS.includes(sectionId as SettingsSectionId)
+    ? (sectionId as SettingsSectionId)
+    : undefined;
+}
+
+function scrollToSection(sectionId: SettingsSectionId): void {
+  document.getElementById(sectionId)?.scrollIntoView({
+    behavior: 'smooth',
+    block: 'start',
+  });
+}
+
+export function SettingsScrollTarget(): ReactElement | null {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    const scrollFromHash = (): void => {
+      const sectionId = parseSectionHash(window.location.hash);
+      if (sectionId) {
+        scrollToSection(sectionId);
+      }
+    };
+
+    scrollFromHash();
+
+    const retryTimeouts = [100, 500].map((delay) =>
+      window.setTimeout(scrollFromHash, delay),
+    );
+
+    window.addEventListener('hashchange', scrollFromHash);
+
+    return () => {
+      for (const timeoutId of retryTimeouts) {
+        window.clearTimeout(timeoutId);
+      }
+      window.removeEventListener('hashchange', scrollFromHash);
+    };
+  }, [pathname]);
+
+  return null;
+}

--- a/src/app/(app)/settings/components/SettingsScrollTarget.tsx
+++ b/src/app/(app)/settings/components/SettingsScrollTarget.tsx
@@ -1,18 +1,11 @@
 'use client';
 
+import {
+  SETTINGS_SECTION_IDS,
+  type SettingsSectionId,
+} from '@/app/(app)/settings/settings-section-ids';
 import { usePathname } from 'next/navigation';
 import { useEffect, type ReactElement } from 'react';
-
-const SETTINGS_SECTION_IDS = [
-  'profile',
-  'billing',
-  'usage',
-  'ai',
-  'integrations',
-  'notifications',
-] as const;
-
-type SettingsSectionId = (typeof SETTINGS_SECTION_IDS)[number];
 
 function parseSectionHash(hash: string): SettingsSectionId | undefined {
   const sectionId = hash.replace(/^#/, '');

--- a/src/app/(app)/settings/settings-section-ids.ts
+++ b/src/app/(app)/settings/settings-section-ids.ts
@@ -1,0 +1,12 @@
+export const SETTINGS_SECTIONS = {
+  profile: 'profile',
+  billing: 'billing',
+  usage: 'usage',
+  ai: 'ai',
+  integrations: 'integrations',
+  notifications: 'notifications',
+} as const;
+
+export const SETTINGS_SECTION_IDS = Object.values(SETTINGS_SECTIONS);
+
+export type SettingsSectionId = (typeof SETTINGS_SECTION_IDS)[number];

--- a/tests/unit/app/settings/page.spec.tsx
+++ b/tests/unit/app/settings/page.spec.tsx
@@ -18,6 +18,13 @@ async function renderSettingsPage(): Promise<void> {
   render(await SettingsPage());
 }
 
+async function renderSettingsUserProfilePage(): Promise<void> {
+  vi.resetModules();
+  const { default: SettingsUserProfilePage } =
+    await import('@/app/(app)/settings/[...user-profile]/page');
+  render(await SettingsUserProfilePage());
+}
+
 describe('SettingsPage', () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -30,6 +37,13 @@ describe('SettingsPage', () => {
 
   it('renders the unified settings ledger', async () => {
     await renderSettingsPage();
+
+    expect(screen.getByTestId('settings-ledger-page')).toBeVisible();
+    expect(mocks.settingsLedgerPageMock).toHaveBeenCalledWith({});
+  });
+
+  it('renders the unified settings ledger for Clerk profile subpaths', async () => {
+    await renderSettingsUserProfilePage();
 
     expect(screen.getByTestId('settings-ledger-page')).toBeVisible();
     expect(mocks.settingsLedgerPageMock).toHaveBeenCalledWith({});


### PR DESCRIPTION
## Summary

Follow-up fix for settings hash deep links after #398.

- Remove `UserProfile` `routing='hash'` so Clerk no longer overwrites section anchors like `#billing`
- Restore `SettingsScrollTarget` to scroll to hashed sections on load, hashchange, and client navigations

## Verification

- `pnpm check:lint`
- `pnpm check:type`
- `npx react-doctor@latest --scope changed`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized settings UX and routing changes; no auth, billing logic, or data-layer changes beyond Clerk embed routing behavior.
> 
> **Overview**
> Restores **settings URL hashes** (e.g. `#billing`) so deep links and post–sign-in redirects scroll to the right ledger section again, instead of Clerk’s embedded `UserProfile` owning the fragment.
> 
> **Clerk** no longer uses `routing='hash'` on `UserProfile`, and a new **`settings/[...user-profile]`** route still renders the same unified ledger for Clerk profile subpaths. Section DOM ids are centralized in **`settings-section-ids`**, and **`SettingsScrollTarget`** scrolls to known section hashes on load, `hashchange`, and pathname changes (with short retries for late-mounted content).
> 
> A unit test asserts Clerk profile subpaths render the same ledger page as `/settings`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a86cd8bf25cad032ef0a6e13008597f2b429435c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->