### PR TITLE
fix(pricing): pass planPeriod for signed-out yearly checkout

### DIFF
--- a/src/app/(marketing)/_shared/AfterHoursClerkPricing.tsx
+++ b/src/app/(marketing)/_shared/AfterHoursClerkPricing.tsx
@@ -267,6 +267,16 @@ function sameCheckoutMounts(
 }
 
 /**
+ * Resolves Clerk checkout period from the visible billing tab.
+ */
+function checkoutPlanPeriod(
+  period: BillingPeriod,
+  plan: ClerkPlanSnapshot,
+): BillingPeriod {
+  return period === 'annual' && planHasAnnual(plan) ? 'annual' : 'month';
+}
+
+/**
  * Clerk PricingTable with After Hours card chrome, monthly/yearly tabs,
  * and feature-list fallback when Clerk plans have empty features.
  */
@@ -274,7 +284,8 @@ export function AfterHoursClerkPricing({
   appearance,
   newSubscriptionRedirectUrl,
 }: AfterHoursClerkPricingProps) {
-  const { billing, loaded } = useClerk();
+  const clerk = useClerk();
+  const { billing, loaded } = clerk;
   const { isLoaded, userId } = useAuth();
   const rootRef = useRef<HTMLDivElement>(null);
   const [plans, setPlans] = useState<ClerkPlanSnapshot[]>([]);
@@ -307,13 +318,9 @@ export function AfterHoursClerkPricing({
       syncCardFees(root, plans, period);
       syncCardCtaLabels(root, plans);
 
-      if (!isLoaded || !userId) {
-        root
-          .querySelectorAll<HTMLElement>('[data-atlaris-checkout]')
-          .forEach((node) => node.remove());
-        setCheckoutMounts([]);
-        return;
-      }
+      // Wait for auth to settle so signed-out visitors still get period-aware CTAs
+      // (CheckoutButton requires a userId; unsigned uses __internal_openCheckout).
+      if (!isLoaded) return;
 
       const nextMounts = reconcileCheckoutMounts(root, plans);
       setCheckoutMounts((current) =>
@@ -327,7 +334,7 @@ export function AfterHoursClerkPricing({
     observer.observe(root, { childList: true, subtree: true });
 
     return () => observer.disconnect();
-  }, [isLoaded, period, plans, userId]);
+  }, [isLoaded, period, plans]);
 
   useEffect(() => {
     const root = rootRef.current;
@@ -446,28 +453,42 @@ export function AfterHoursClerkPricing({
           appearance={appearance}
           newSubscriptionRedirectUrl={newSubscriptionRedirectUrl}
         />
-        {userId
-          ? checkoutMounts.map(({ label, plan, target }) =>
-              createPortal(
-                <CheckoutButton
-                  checkoutProps={{ appearance }}
-                  newSubscriptionRedirectUrl={newSubscriptionRedirectUrl}
-                  planId={plan.id}
-                  planPeriod={
-                    period === 'annual' && planHasAnnual(plan)
-                      ? 'annual'
-                      : 'month'
-                  }
-                  key={plan.id}
-                >
-                  <button className={styles.checkoutButton} type='button'>
-                    {label}
-                  </button>
-                </CheckoutButton>,
-                target,
-              ),
-            )
-          : null}
+        {checkoutMounts.map(({ label, plan, target }) => {
+          const planPeriod = checkoutPlanPeriod(period, plan);
+
+          return createPortal(
+            userId ? (
+              <CheckoutButton
+                checkoutProps={{ appearance }}
+                newSubscriptionRedirectUrl={newSubscriptionRedirectUrl}
+                planId={plan.id}
+                planPeriod={planPeriod}
+                key={plan.id}
+              >
+                <button className={styles.checkoutButton} type='button'>
+                  {label}
+                </button>
+              </CheckoutButton>
+            ) : (
+              <button
+                className={styles.checkoutButton}
+                type='button'
+                key={plan.id}
+                onClick={() => {
+                  clerk.__internal_openCheckout({
+                    appearance,
+                    newSubscriptionRedirectUrl,
+                    planId: plan.id,
+                    planPeriod,
+                  });
+                }}
+              >
+                {label}
+              </button>
+            ),
+            target,
+          );
+        })}
       </div>
     </div>
   );

--- a/tests/unit/app/pricing/AfterHoursClerkPricing.spec.tsx
+++ b/tests/unit/app/pricing/AfterHoursClerkPricing.spec.tsx
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   getPlans: vi.fn(),
+  openCheckout: vi.fn(),
+  useAuth: vi.fn(),
   useClerk: vi.fn(),
 }));
 
@@ -28,7 +30,7 @@ vi.mock('@clerk/nextjs', () => ({
       </article>
     </div>
   ),
-  useAuth: () => ({ isLoaded: true, userId: 'user_123' }),
+  useAuth: mocks.useAuth,
   useClerk: mocks.useClerk,
 }));
 
@@ -48,16 +50,33 @@ vi.mock('@clerk/nextjs/experimental', () => ({
   ),
 }));
 
+const starterPlan = {
+  annualFee: { amount: 9600, amountFormatted: '96.00' },
+  annualMonthlyFee: { amount: 800, amountFormatted: '8.00' },
+  fee: { amount: 1000, amountFormatted: '10.00' },
+  features: [],
+  hasBaseFee: true,
+  id: 'plan_starter',
+  slug: 'starter_plan',
+};
+
 describe('AfterHoursClerkPricing', () => {
   beforeEach(() => {
+    mocks.getPlans.mockReset();
+    mocks.openCheckout.mockReset();
+    mocks.useAuth.mockReturnValue({ isLoaded: true, userId: 'user_123' });
     mocks.useClerk.mockReturnValue({
+      __internal_openCheckout: mocks.openCheckout,
       billing: { getPlans: mocks.getPlans },
       loaded: true,
     });
   });
 
   it('still renders when Clerk Billing is unavailable', async () => {
-    mocks.useClerk.mockReturnValue({ loaded: true });
+    mocks.useClerk.mockReturnValue({
+      __internal_openCheckout: mocks.openCheckout,
+      loaded: true,
+    });
 
     const { AfterHoursClerkPricing } =
       await import('@/app/(marketing)/_shared/AfterHoursClerkPricing');
@@ -73,19 +92,7 @@ describe('AfterHoursClerkPricing', () => {
   });
 
   it('fills empty Clerk feature lists and sends the selected period to Clerk checkout', async () => {
-    mocks.getPlans.mockResolvedValue({
-      data: [
-        {
-          annualFee: { amount: 9600, amountFormatted: '96.00' },
-          annualMonthlyFee: { amount: 800, amountFormatted: '8.00' },
-          fee: { amount: 1000, amountFormatted: '10.00' },
-          features: [],
-          hasBaseFee: true,
-          id: 'plan_starter',
-          slug: 'starter_plan',
-        },
-      ],
-    });
+    mocks.getPlans.mockResolvedValue({ data: [starterPlan] });
 
     const { AfterHoursClerkPricing } =
       await import('@/app/(marketing)/_shared/AfterHoursClerkPricing');
@@ -112,5 +119,43 @@ describe('AfterHoursClerkPricing', () => {
       'annual',
     );
     expect(screen.getByText('$8')).toBeVisible();
+  });
+
+  it('opens signed-out checkout with the selected yearly period', async () => {
+    mocks.useAuth.mockReturnValue({ isLoaded: true, userId: null });
+    mocks.getPlans.mockResolvedValue({ data: [starterPlan] });
+
+    const { AfterHoursClerkPricing } =
+      await import('@/app/(marketing)/_shared/AfterHoursClerkPricing');
+    const user = userEvent.setup();
+
+    render(
+      <AfterHoursClerkPricing
+        appearance={{ elements: { rootBox: 'w-full' } }}
+        newSubscriptionRedirectUrl='/settings#billing'
+      />,
+    );
+
+    expect(await screen.findByText('Priority queue access')).toBeVisible();
+
+    await user.click(screen.getByRole('tab', { name: 'Yearly' }));
+    expect(screen.getByText('$8')).toBeVisible();
+
+    const checkoutMount = document.querySelector(
+      '[data-atlaris-checkout="plan_starter"]',
+    );
+    expect(checkoutMount).toBeInstanceOf(HTMLElement);
+    await user.click(
+      within(checkoutMount as HTMLElement).getByRole('button', {
+        name: 'Choose Starter',
+      }),
+    );
+
+    expect(mocks.openCheckout).toHaveBeenCalledWith({
+      appearance: { elements: { rootBox: 'w-full' } },
+      newSubscriptionRedirectUrl: '/settings#billing',
+      planId: 'plan_starter',
+      planPeriod: 'annual',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Signed-out Yearly tab showed annual prices but Clerk native CTAs ignored `planPeriod`.
- Mount period-aware unsigned checkout via `__internal_openCheckout` (CheckoutButton stays signed-in only).

## Test plan
- [x] Unit: signed-out Yearly click opens checkout with `planPeriod: 'annual'`
- [x] Unit: signed-in period wiring still passes

Cloud-agent delivery into `feat/ui-updates` (branch rules blocked direct push).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches marketing checkout wiring via Clerk’s internal `__internal_openCheckout` API, which could break on SDK upgrades, but scope is limited to signed-out pricing CTAs with test coverage.
> 
> **Overview**
> Fixes a mismatch where **signed-out** visitors on the **Yearly** tab saw annual prices but checkout could still use the monthly period.
> 
> **AfterHoursClerkPricing** now keeps period-aware checkout mounts once auth has loaded (instead of stripping mounts when `userId` is missing). Signed-in users still use **`CheckoutButton`** with a shared **`checkoutPlanPeriod`** helper; signed-out users get portal-mounted CTAs that call **`clerk.__internal_openCheckout`** with the same `planId`, `planPeriod`, appearance, and redirect URL.
> 
> Adds a unit test that a signed-out Yearly CTA opens checkout with **`planPeriod: 'annual'`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6ea1b371d61a58e32e208f73f1aeff487ad31a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->