### PR TITLE
fix(a11y): hide achievements preview from screen readers

### DIFF
--- a/src/app/(app)/analytics/achievements/page.tsx
+++ b/src/app/(app)/analytics/achievements/page.tsx
@@ -60,17 +60,14 @@ export default function AchievementsPage() {
       />
 
       <section
-        aria-labelledby='upcoming-milestones-heading'
+        aria-labelledby='achievements-coming-soon-heading'
         className={cn(
           'relative mx-auto max-w-3xl overflow-hidden px-5 py-7 sm:px-7',
           ledgerGlassSurface,
         )}
       >
-        <div className='pointer-events-none opacity-40'>
-          <h2
-            id='upcoming-milestones-heading'
-            className='text-base font-medium text-foreground'
-          >
+        <div className='pointer-events-none opacity-40' aria-hidden='true'>
+          <h2 className='text-base font-medium text-foreground'>
             Upcoming milestones
           </h2>
           <ul className='mt-4 grid gap-x-6 gap-y-4 sm:grid-cols-2'>
@@ -102,7 +99,12 @@ export default function AchievementsPage() {
             'border-transparent shadow-none',
           )}
         >
-          <p className='text-base font-medium text-foreground'>Coming soon</p>
+          <p
+            id='achievements-coming-soon-heading'
+            className='text-base font-medium text-foreground'
+          >
+            Coming soon
+          </p>
           <p className='mt-1 max-w-xs text-sm text-muted-foreground'>
             Achievement tracking isn&apos;t available yet. These milestones are
             a preview of what&apos;s ahead.


### PR DESCRIPTION
## Summary
- Marks the faded upcoming-milestones preview `aria-hidden="true"` so assistive tech does not announce unavailable badge content.
- Labels the section from the Coming soon overlay heading instead of the hidden preview heading.

Bugbot autofix for preview milestones exposed to screen readers. Direct push to `feat/ui-updates` is blocked by the development ruleset requiring status check `All Checks Passed (PR)` on the new commit SHA.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markup-only accessibility change on a static analytics page with no behavior or data impact.
> 
> **Overview**
> **Achievements “coming soon”** section accessibility is tightened so assistive tech matches what sighted users see.
> 
> The faded **Upcoming milestones** preview (decorative list behind the overlay) is now **`aria-hidden="true"`**, so screen readers no longer read unavailable badge names and descriptions. The section’s accessible name is wired to the overlay’s **Coming soon** text via `aria-labelledby` / `id` on that heading instead of the hidden preview `h2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0ac1ba763453791de81075bdb7befc12152305b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->