### PR TITLE
fix(pricing): keep checkout params until auth resolves

### DIFF
--- a/src/app/(marketing)/pricing/components/ClerkPricingTable.tsx
+++ b/src/app/(marketing)/pricing/components/ClerkPricingTable.tsx
@@ -85,7 +85,7 @@ export function ClerkPricingTable({
   newSubscriptionRedirectUrl,
 }: ClerkPricingTableProps) {
   const { billing, loaded } = useClerk();
-  const { userId } = useAuth();
+  const { isLoaded, userId } = useAuth();
   const [plans, setPlans] = useState<PricingPlan[]>([]);
   const [period, setPeriod] = useState<BillingPeriod>('month');
 
@@ -97,22 +97,7 @@ export function ClerkPricingTable({
       .getPlans()
       .then((result) => {
         if (cancelled) return;
-        const nextPlans = result.data.map(normalizePlan);
-        const url = new URL(window.location.href);
-        const requestedPlan = nextPlans.find(
-          (plan) => plan.id === url.searchParams.get(CHECKOUT_PLAN_PARAM),
-        );
-        const requestedPeriod = url.searchParams.get(CHECKOUT_PERIOD_PARAM);
-
-        if (requestedPlan && requestedPeriod === 'annual') {
-          setPeriod(planHasAnnual(requestedPlan) ? 'annual' : 'month');
-        }
-        if (requestedPlan || requestedPeriod) {
-          url.searchParams.delete(CHECKOUT_PLAN_PARAM);
-          url.searchParams.delete(CHECKOUT_PERIOD_PARAM);
-          window.history.replaceState(window.history.state, '', url);
-        }
-        setPlans(nextPlans);
+        setPlans(result.data.map(normalizePlan));
       })
       .catch((error: unknown) => {
         if (cancelled) return;
@@ -127,6 +112,31 @@ export function ClerkPricingTable({
     };
   }, [billing, loaded]);
 
+  useEffect(() => {
+    if (!isLoaded || !userId || plans.length === 0) return;
+
+    const url = new URL(window.location.href);
+    const requestedPlanId = url.searchParams.get(CHECKOUT_PLAN_PARAM);
+    const requestedPeriod = url.searchParams.get(CHECKOUT_PERIOD_PARAM);
+    if (!requestedPlanId && !requestedPeriod) return;
+
+    const requestedPlan = plans.find((plan) => plan.id === requestedPlanId);
+    if (
+      requestedPlan &&
+      (requestedPeriod === 'month' || requestedPeriod === 'annual')
+    ) {
+      setPeriod(
+        requestedPeriod === 'annual' && planHasAnnual(requestedPlan)
+          ? 'annual'
+          : 'month',
+      );
+    }
+
+    url.searchParams.delete(CHECKOUT_PLAN_PARAM);
+    url.searchParams.delete(CHECKOUT_PERIOD_PARAM);
+    window.history.replaceState(window.history.state, '', url);
+  }, [isLoaded, plans, userId]);
+
   return (
     <PricingCards
       onPeriodChange={setPeriod}
@@ -134,6 +144,18 @@ export function ClerkPricingTable({
       plans={plans}
       renderAction={(plan, planPeriod) => {
         const label = PLAN_CTA_LABEL_BY_SLUG[plan.slug] || 'Choose plan';
+
+        if (!isLoaded) {
+          return (
+            <button
+              className={pricingCardStyles.checkoutButton}
+              disabled
+              type='button'
+            >
+              {label}
+            </button>
+          );
+        }
 
         if (!plan.fee?.amount) {
           return userId ? (

--- a/src/app/(marketing)/pricing/components/ClerkPricingTable.tsx
+++ b/src/app/(marketing)/pricing/components/ClerkPricingTable.tsx
@@ -113,7 +113,7 @@ export function ClerkPricingTable({
   }, [billing, loaded]);
 
   useEffect(() => {
-    if (!isLoaded || !userId || plans.length === 0) return;
+    if (plans.length === 0) return;
 
     const url = new URL(window.location.href);
     const requestedPlanId = url.searchParams.get(CHECKOUT_PLAN_PARAM);
@@ -131,6 +131,9 @@ export function ClerkPricingTable({
           : 'month',
       );
     }
+
+    // Keep params while signed out so reload/sign-in can preserve intent.
+    if (!isLoaded || !userId) return;
 
     url.searchParams.delete(CHECKOUT_PLAN_PARAM);
     url.searchParams.delete(CHECKOUT_PERIOD_PARAM);

--- a/tests/unit/app/pricing/ClerkPricingTable.spec.tsx
+++ b/tests/unit/app/pricing/ClerkPricingTable.spec.tsx
@@ -231,6 +231,78 @@ describe('ClerkPricingTable', () => {
     );
   });
 
+  it('keeps checkout return params in the URL while signed out', async () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/pricing?checkoutPlan=plan_starter&checkoutPeriod=annual',
+    );
+    mocks.useAuth.mockReturnValue({ isLoaded: true, userId: null });
+    mocks.getPlans.mockResolvedValue({
+      data: [
+        {
+          annualFee: { amount: 9600, amountFormatted: '96.00' },
+          annualMonthlyFee: { amount: 800, amountFormatted: '8.00' },
+          fee: { amount: 1000, amountFormatted: '10.00' },
+          features: [],
+          hasBaseFee: true,
+          id: 'plan_starter',
+          slug: 'starter_plan',
+        },
+      ],
+    });
+
+    const { ClerkPricingTable } =
+      await import('@/app/(marketing)/pricing/components/ClerkPricingTable');
+
+    render(
+      <ClerkPricingTable
+        appearance={{}}
+        newSubscriptionRedirectUrl='/settings#billing'
+      />,
+    );
+
+    expect(await screen.findByTestId('sign-in-checkout')).toBeVisible();
+    expect(window.location.search).toBe(
+      '?checkoutPlan=plan_starter&checkoutPeriod=annual',
+    );
+  });
+
+  it('waits for auth to load before showing signed-out checkout actions', async () => {
+    mocks.useAuth.mockReturnValue({ isLoaded: false, userId: null });
+    mocks.getPlans.mockResolvedValue({
+      data: [
+        {
+          annualFee: { amount: 9600, amountFormatted: '96.00' },
+          annualMonthlyFee: { amount: 800, amountFormatted: '8.00' },
+          fee: { amount: 1000, amountFormatted: '10.00' },
+          features: [],
+          hasBaseFee: true,
+          id: 'plan_starter',
+          slug: 'starter_plan',
+        },
+      ],
+    });
+
+    const { ClerkPricingTable } =
+      await import('@/app/(marketing)/pricing/components/ClerkPricingTable');
+
+    render(
+      <ClerkPricingTable
+        appearance={{}}
+        newSubscriptionRedirectUrl='/settings#billing'
+      />,
+    );
+
+    expect(
+      await screen.findByRole('button', { name: 'Choose Starter' }),
+    ).toBeDisabled();
+    expect(screen.queryByTestId('sign-in-checkout')).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('checkout-plan_starter'),
+    ).not.toBeInTheDocument();
+  });
+
   it('restores a validated annual checkout selection after authentication', async () => {
     window.history.replaceState(
       {},

--- a/tests/unit/app/pricing/ClerkPricingTable.spec.tsx
+++ b/tests/unit/app/pricing/ClerkPricingTable.spec.tsx
@@ -262,7 +262,15 @@ describe('ClerkPricingTable', () => {
       />,
     );
 
-    expect(await screen.findByTestId('sign-in-checkout')).toBeVisible();
+    expect(await screen.findByTestId('sign-in-checkout')).toHaveAttribute(
+      'data-redirect',
+      '/pricing?checkoutPlan=plan_starter&checkoutPeriod=annual',
+    );
+    expect(screen.getByRole('button', { name: 'Yearly' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    expect(screen.getByText('$8')).toBeVisible();
     expect(window.location.search).toBe(
       '?checkoutPlan=plan_starter&checkoutPeriod=annual',
     );


### PR DESCRIPTION
## Summary
- Keep `checkoutPlan`/`checkoutPeriod` in the URL until the visitor is signed in, so yearly/monthly intent survives reload before auth.
- Wait for Clerk `useAuth().isLoaded` before choosing SignIn vs Checkout CTAs.

## Test plan
- [x] `ClerkPricingTable` unit tests (including signed-out param retention and auth-loading CTA guard)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to marketing pricing UI and checkout deep-link behavior; no auth, billing API, or data-layer changes beyond URL/CTA timing.
> 
> **Overview**
> Fixes pricing checkout intent being lost for visitors who are not signed in yet.
> 
> **`checkoutPlan` / `checkoutPeriod` handling** is moved out of the plans fetch effect into a dedicated effect. The table still applies those query params to the monthly/yearly toggle once plans load, but it **only strips them from the URL after Clerk auth has finished loading and a `userId` exists**. While signed out (or before auth resolves), the params stay on `/pricing` so reloads and sign-in redirects keep the chosen plan and billing period.
> 
> **Plan CTAs** now wait on `useAuth().isLoaded`: until then, each card shows a **disabled** button styled like checkout instead of rendering `SignInButton` or `CheckoutButton`, avoiding a flash of the wrong action.
> 
> Unit tests cover signed-out URL retention and the auth-loading CTA guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 561a8db12bd5037e6cc04711f1fb41797aca6008. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->