### PR TITLE
fix(plans): use animation duration for empty state

### DIFF
--- a/src/app/(app)/plans/components/EmptyPlansList.tsx
+++ b/src/app/(app)/plans/components/EmptyPlansList.tsx
@@ -30,7 +30,7 @@ export function EmptyPlansList({
       icon={Icon}
       title={title}
       description={description}
-      className='flex min-h-72 animate-in flex-col items-center justify-center rounded-xl border border-dashed border-border bg-panel/40 px-6 py-12 text-center duration-500 fill-mode-both fade-in motion-reduce:animate-none'
+      className='flex min-h-72 animate-in flex-col items-center justify-center rounded-xl border border-dashed border-border bg-panel/40 px-6 py-12 text-center animation-duration-500 fill-mode-both fade-in motion-reduce:animate-none'
       action={
         <Button asChild>
           <Link href='/plans/new'>


### PR DESCRIPTION
Applies `c447fe02` to `develop` for #428.

Replaces `duration-500` with `animation-duration-500` so the empty-list enter animation keeps its 500ms duration without setting transition duration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class change on an empty-state UI component with no logic, data, or auth impact.
> 
> **Overview**
> Updates the plans list **empty state** styling so its enter animation keeps a **500ms** timing without affecting CSS **transitions**.
> 
> On `RouteEmptyState` in `EmptyPlansList`, replaces the `duration-500` utility with **`animation-duration-500`** alongside the existing `animate-in` / `fade-in` classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c447fe022b176c14190d2b486b1a49d8175c9a5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->