### PR TITLE
fix(deps): bump brace-expansion to 5.0.9

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ overrides:
   piscina: ^4.9.3
   postcss: ^8.5.18
   uuid: ^11.1.1
-  brace-expansion: ^5.0.8
+  brace-expansion: ^5.0.9
   sharp: ^0.35.0
   '@babel/core': ^7.29.6
   '@opentelemetry/core': ^2.8.0
@@ -3854,8 +3854,8 @@ packages:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   browserslist@4.28.2:
@@ -10390,7 +10390,7 @@ snapshots:
       widest-line: 5.0.0
       wrap-ansi: 9.0.2
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -12068,7 +12068,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minipass@7.1.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
-  - brace-expansion@5.0.8
+  - brace-expansion@5.0.9
   - "@next/env@16.2.11"
   - "@next/swc-darwin-arm64@16.2.11"
   - "@next/swc-darwin-x64@16.2.11"
@@ -48,7 +48,7 @@ overrides:
   piscina: ^4.9.3
   postcss: ^8.5.18
   uuid: ^11.1.1
-  brace-expansion: ^5.0.8
+  brace-expansion: ^5.0.9
   sharp: ^0.35.0
   "@babel/core": ^7.29.6
   "@opentelemetry/core": ^2.8.0


### PR DESCRIPTION
## Summary
- bump the repository-wide `brace-expansion` override to patched 5.0.9
- update the release-age exception and lockfile without unrelated resolver churn

## Security verification
- reproduced GHSA-rgw5-rvv9-x895 against 5.0.8
- `CI=true pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm why brace-expansion --depth 100` resolves only 5.0.9
- `pnpm audit --prod --audit-level=high` passes (no high/critical findings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile and workspace override only; patch-level transitive dependency fix with no product logic changes.
> 
> **Overview**
> **Security dependency bump** for `brace-expansion` **5.0.8 → 5.0.9** across the monorepo.
> 
> Updates the `pnpm-workspace.yaml` **override** (`brace-expansion: ^5.0.9`) and the **`minimumReleaseAgeExclude`** entry so the newer release can install under the workspace release-age policy. The **lockfile** is refreshed so resolved packages (including `minimatch`’s dependency on `brace-expansion`) point at **5.0.9** only.
> 
> No application or runtime code changes—install/audit resolution only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 459151161bfbc0446e1dac7442a445a79e12d01b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->