### PR TITLE
fix(settings): clear model save state after failure

### DIFF
--- a/src/app/(app)/settings/ai/components/useModelPreferenceSave.ts
+++ b/src/app/(app)/settings/ai/components/useModelPreferenceSave.ts
@@ -94,9 +94,9 @@ export function useModelPreferenceSave({
       });
       setSaveStatus('error');
       scheduleStatusReset();
+    } finally {
+      setIsSaving(false);
     }
-
-    setIsSaving(false);
   };
 
   const saveSelectedModel = async (): Promise<void> => {

--- a/tests/unit/components/ModelSelector.spec.tsx
+++ b/tests/unit/components/ModelSelector.spec.tsx
@@ -256,12 +256,16 @@ describe('ModelSelector', () => {
     );
 
     await selectFirstFreeModel(user);
-    await user.click(screen.getByRole('button', { name: /save preferences/i }));
+    const saveButton = screen.getByRole('button', {
+      name: /save preferences/i,
+    });
+    await user.click(saveButton);
 
     await waitFor(() => {
       expect(
         screen.getByText(/failed to save preferences/i),
       ).toBeInTheDocument();
+      expect(saveButton).not.toBeDisabled();
     });
   });
 });


### PR DESCRIPTION
## Summary
- clear the model preference saving flag in `finally`
- verify Save Preferences is re-enabled after a failed save

## Stack note
Replaces PR #438 as the active stack layer. GitHub marked #438 merged when PR #429 was rebased to contain its head commit, which locks #438 in the prior stack.

## Verification
- `SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit tests/unit/components/ModelSelector.spec.tsx`
- pre-push `pnpm check:lint` and `pnpm check:type`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small hook lifecycle change in settings UI with a targeted unit test; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **Save Preferences** staying disabled after a failed model preference save in AI settings.
> 
> `useModelPreferenceSave` now calls **`setIsSaving(false)` in a `finally` block** so the saving flag always clears when `runSave` finishes, including on rejected `onSave` calls. That re-enables the save button (and related controls gated on `isSaving`) while the error message still shows.
> 
> The **ModelSelector** unit test for a failed save now asserts the save button is **not disabled** once the failure UI appears.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b4893ed13eee9df3e167f7a22fd1bb59d7d4cbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->