### PR TITLE
fix/pr 428 review followups

### DIFF
--- a/.github/workflows/plan-cleanup-scheduler.yml
+++ b/.github/workflows/plan-cleanup-scheduler.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   cleanup:
     name: Trigger production plan cleanup
+    if: github.event_name == 'workflow_dispatch' || vars.PLAN_CLEANUP_ENABLED == 'true'
     runs-on: ubuntu-latest
     # Environment secret MAINTENANCE_WORKER_TOKEN lives here (not a repo secret).
     # Branch policy allows main only; schedules run from the default branch.

--- a/docs/architecture/email-notification-delivery-runbook.md
+++ b/docs/architecture/email-notification-delivery-runbook.md
@@ -68,7 +68,7 @@ Only one email scheduler may be active. The GitHub workflow `.github/workflows/e
 
 ## Inspect a run
 
-1. In Vercel, inspect the Cron invocation for `GET /api/cron/notifications/email` and record the response's `runId` and `workflowRunId`.
+1. In Vercel, inspect the Cron invocation for `GET /api/cron/notifications/email?runKind=daily` or `?runKind=weekly` and record the response's `runId` and `workflowRunId`.
 2. Inspect the Workflow SDK run by `workflowRunId` to find the current durable step or retry.
 3. Inspect the matching Sentry monitor. A check-in begins when the workflow claims the run and closes only on `completed`, `failed`, or `needs_review`.
 4. Inspect the service-role delivery run and ledger without selecting recipient addresses or provider payloads:

--- a/docs/development/deploy.md
+++ b/docs/development/deploy.md
@@ -58,6 +58,7 @@ After deploying a release that includes new Supabase migrations:
    - `WORKER_HEALTH_TOKEN` for `GET /api/health/worker` operator metrics
    - `RETENTION_CLEANUP_ENABLED=true` and/or `PLAN_CLEANUP_ENABLED=true` plus `MAINTENANCE_WORKER_TOKEN` only when enabling maintenance routes
 4. Verify plan cleanup scheduler and alerting when `PLAN_CLEANUP_ENABLED=true`:
+   - Set the GitHub Actions repository variable `PLAN_CLEANUP_ENABLED=true`; scheduled workflow runs are skipped until this variable is enabled, while manual dispatch remains available for checks.
    - Set the same `MAINTENANCE_WORKER_TOKEN` value in Vercel Production and the GitHub Actions `Production – atlaris` environment secret.
    - Confirm `.github/workflows/plan-cleanup-scheduler.yml` runs every 15 minutes and returns `200` with `ok: true`.
    - Confirm Sentry monitor `plan-cleanup-maintenance` receives successful check-ins; GitHub workflow failures identify `401`, `503`, and `500` responses.
@@ -93,7 +94,7 @@ The email scheduler must have exactly one active owner. This release removes the
 
 1. Run the migration workflow's `expand` phase before deploying code that starts email workflows. Its explicit safe list applies both `20260710151930_create_email_notification_delivery_runs` and the future-dated delivery ledger without opening the contract gate.
 2. Set a new `CRON_SECRET` in the target Vercel environment. Keep it distinct from `MAINTENANCE_WORKER_TOKEN`.
-3. Deploy the application with `vercel.json`; confirm Vercel lists only `0 14 * * *` and `30 14 * * 1` for `/api/cron/notifications/email`.
+3. Deploy the application with `vercel.json`; confirm Vercel lists only `0 14 * * *` for `/api/cron/notifications/email?runKind=daily` and `30 14 * * 1` for `/api/cron/notifications/email?runKind=weekly`.
 4. Leave the `email-notification-delivery` Vercel Flag disabled and verify both authenticated cron paths return the intentional `disabled` outcome without creating a run.
 5. Enable a safe opted-in account, trigger one manual logical run, and inspect its database run, Workflow SDK run, Sentry monitor, and delivery ledger before enabling broader delivery.
 

--- a/scripts/db/run-phased-migrations.sh
+++ b/scripts/db/run-phased-migrations.sh
@@ -7,6 +7,7 @@ readonly DROP_VERSION='20260706222017'
 readonly CONTRACT_CONFIRMATION_VALUE='post-deploy-health-verified'
 readonly -a EXPAND_MIGRATIONS=(
   supabase/migrations/0036_add_learning_activity_events.sql
+  supabase/migrations/20260804160000_revoke_task_progress_delete.sql
   supabase/migrations/0037_add_user_analytics_timezone.sql
   supabase/migrations/20260703181947_create_user_preferences_foundation.sql
   supabase/migrations/20260706201202_create_clerk_billing_webhook_events.sql

--- a/src/app/api/cron/notifications/email/route.ts
+++ b/src/app/api/cron/notifications/email/route.ts
@@ -27,6 +27,16 @@ function readBearerToken(request: Request): string | null {
   return match?.[1]?.trim() || null;
 }
 
+function resolveRunKind(request: Request) {
+  const runKindParam = new URL(request.url).searchParams.get('runKind');
+  if (runKindParam === 'daily' || runKindParam === 'weekly') {
+    return runKindParam;
+  }
+
+  const schedule = request.headers.get('x-vercel-cron-schedule');
+  return schedule ? resolveEmailNotificationDeliveryRunKind(schedule) : null;
+}
+
 export type EmailNotificationDeliveryCronRouteDeps = {
   readonly resolveCronSecret?: () => string | undefined;
   readonly resolveDeliveryEnabled?: () => Promise<boolean>;
@@ -78,10 +88,7 @@ export function createEmailNotificationDeliveryCronRoute(
       return jsonError('Unauthorized cron trigger.', { status: 401 });
     }
 
-    const schedule = request.headers.get('x-vercel-cron-schedule');
-    const runKind = schedule
-      ? resolveEmailNotificationDeliveryRunKind(schedule)
-      : null;
+    const runKind = resolveRunKind(request);
     if (!runKind) {
       return jsonError('Unknown email notification cron schedule.', {
         status: 400,

--- a/src/features/notifications/email/delivery-service.ts
+++ b/src/features/notifications/email/delivery-service.ts
@@ -561,6 +561,7 @@ export async function runEmailNotificationDelivery(
   const { recipients, nextCursor } = await listEmailDeliveryRecipients({
     batchSize,
     cursorUserId: request.cursorUserId,
+    categories: request.categories,
     dbClient: db,
   });
   counts.nextCursor = nextCursor;

--- a/src/lib/db/queries/email-delivery-recipients.ts
+++ b/src/lib/db/queries/email-delivery-recipients.ts
@@ -1,7 +1,12 @@
 import type { DbClient } from '@/lib/db/types';
+import type { EmailNotificationCategory } from '@/shared/types/db.types';
 
-import { users } from '@supabase/schema';
-import { and, gt, isNotNull, ne, sql } from 'drizzle-orm';
+import {
+  userEmailNotificationPreferences,
+  userEmailNotificationSettings,
+  users,
+} from '@supabase/schema';
+import { and, eq, gt, isNotNull, ne, sql } from 'drizzle-orm';
 
 export type EmailDeliveryRecipient = {
   userId: string;
@@ -14,12 +19,37 @@ export type EmailDeliveryRecipient = {
 export async function listEmailDeliveryRecipients(args: {
   batchSize: number;
   cursorUserId?: string | null;
+  categories: readonly EmailNotificationCategory[];
   dbClient: Pick<DbClient, 'select'>;
 }): Promise<{
   recipients: EmailDeliveryRecipient[];
   nextCursor: string | null;
 }> {
   const batchSize = Math.max(1, Math.min(args.batchSize, 200));
+  const categoryFilter =
+    args.categories.length === 0
+      ? sql`false`
+      : sql`exists (
+          select 1
+          from ${userEmailNotificationPreferences}
+          where ${userEmailNotificationPreferences.userId} = ${users.id}
+            and ${eq(userEmailNotificationPreferences.enabled, true)}
+            and ${userEmailNotificationPreferences.category} in (${sql.join(
+              args.categories.map(
+                (category) => sql`${category}::email_notification_category`,
+              ),
+              sql`, `,
+            )})
+        )`;
+  const unsubscribeFilter = sql`not exists (
+    select 1
+    from ${userEmailNotificationSettings}
+    where ${userEmailNotificationSettings.userId} = ${users.id}
+      and ${eq(
+        userEmailNotificationSettings.unsubscribeAllOptionalEmails,
+        true,
+      )}
+  )`;
   const rows = await args.dbClient
     .select({
       userId: users.id,
@@ -30,6 +60,8 @@ export async function listEmailDeliveryRecipients(args: {
       and(
         isNotNull(users.email),
         ne(users.email, ''),
+        categoryFilter,
+        unsubscribeFilter,
         args.cursorUserId ? gt(users.id, args.cursorUserId) : sql`true`,
       ),
     )

--- a/src/lib/db/queries/email-notification-deliveries.ts
+++ b/src/lib/db/queries/email-notification-deliveries.ts
@@ -48,6 +48,13 @@ function claimSnapshotPredicates(existing: {
   ] as const;
 }
 
+function shouldUseRecomputedRequest(failureClass: string | null): boolean {
+  return (
+    failureClass === 'provider_configuration' ||
+    failureClass === 'provider_recipient_invalid'
+  );
+}
+
 export type EmailNotificationDeliveryLedgerSummary = {
   readonly sent: number;
   readonly skipped: number;
@@ -164,8 +171,10 @@ async function readCurrentClaimResult(
 /**
  * Atomically claim a delivery row for send. Terminal sent/skipped/manual_review
  * is final. Failed rows and expired pending leases can be reclaimed only with
- * their persisted request. Fresh pending leases return in_flight. Ambiguous
- * pending older than the provider window becomes manual_review.
+ * their persisted request, except definitively rejected configuration or
+ * recipient rows, which accept the recomputed request during recovery. Fresh
+ * pending leases return in_flight. Ambiguous pending older than the provider
+ * window becomes manual_review.
  */
 export async function claimEmailNotificationDelivery(
   args: {
@@ -231,6 +240,7 @@ export async function claimEmailNotificationDelivery(
       claimToken: emailNotificationDeliveries.claimToken,
       claimExpiresAt: emailNotificationDeliveries.claimExpiresAt,
       providerRequest: emailNotificationDeliveries.providerRequest,
+      failureClass: emailNotificationDeliveries.failureClass,
       updatedAt: emailNotificationDeliveries.updatedAt,
       createdAt: emailNotificationDeliveries.createdAt,
     })
@@ -257,7 +267,13 @@ export async function claimEmailNotificationDelivery(
 
   if (existing.status === 'failed') {
     const previousRequest = asProviderRequest(existing.providerRequest);
-    if (!previousRequest) {
+    const useRecomputedRequest = shouldUseRecomputedRequest(
+      existing.failureClass,
+    );
+    const requestForRetry = useRecomputedRequest
+      ? args.providerRequest
+      : previousRequest;
+    if (!requestForRetry) {
       throw new Error('Failed delivery missing provider request');
     }
 
@@ -269,7 +285,7 @@ export async function claimEmailNotificationDelivery(
         providerMessageId: null,
         claimToken,
         claimExpiresAt,
-        providerRequest: previousRequest,
+        providerRequest: requestForRetry,
         attemptCount: sql`${emailNotificationDeliveries.attemptCount} + 1`,
         updatedAt: now,
       })
@@ -296,7 +312,7 @@ export async function claimEmailNotificationDelivery(
         deliveryId: reclaimed[0].id,
         claimToken: reclaimed[0].claimToken,
         providerRequest: stored,
-        reusedProviderRequest: true,
+        reusedProviderRequest: !useRecomputedRequest,
       };
     }
 

--- a/src/lib/db/queries/plan-list.ts
+++ b/src/lib/db/queries/plan-list.ts
@@ -184,6 +184,7 @@ function planListRowsSql(params: {
         m.plan_id,
         count(t.id)::int as total_tasks,
         count(t.id) filter (where tp.status = 'completed')::int as completed_tasks,
+        count(t.id) filter (where tp.status in ('in_progress', 'completed'))::int as started_tasks,
         max(tp.updated_at) as latest_progress_at
       from modules m
       inner join filtered_user_plans up on up.id = m.plan_id
@@ -211,7 +212,7 @@ function planListRowsSql(params: {
             and coalesce(tm.total_tasks, 0) > 0
             and tm.completed_tasks >= tm.total_tasks then 'completed'
           when coalesce(mc.module_count, 0) > 0
-            and coalesce(tm.completed_tasks, 0) = 0 then 'not_started'
+            and coalesce(tm.started_tasks, 0) = 0 then 'not_started'
           when coalesce(mc.module_count, 0) > 0
             and coalesce(
               greatest(up.updated_at, tm.latest_progress_at),

--- a/supabase/migrations/20260804160000_revoke_task_progress_delete.sql
+++ b/supabase/migrations/20260804160000_revoke_task_progress_delete.sql
@@ -1,0 +1,1 @@
+REVOKE DELETE ON "task_progress" FROM authenticated;

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1783723210003,
       "tag": "20260810120100_restore_clerk_webhook_claim_retention",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1785859200000,
+      "tag": "20260804160000_revoke_task_progress_delete",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/integration/db/email-delivery-recipients.spec.ts
+++ b/tests/integration/db/email-delivery-recipients.spec.ts
@@ -1,0 +1,62 @@
+import { listEmailDeliveryRecipients } from '@/lib/db/queries/email-delivery-recipients';
+import {
+  userEmailNotificationPreferences,
+  userEmailNotificationSettings,
+} from '@supabase/schema';
+import { db } from '@supabase/service-role';
+import { ensureUser } from '@tests/helpers/db/users';
+import { buildTestAuthUserId, buildTestEmail } from '@tests/helpers/testIds';
+import { describe, expect, it } from 'vitest';
+
+describe('email delivery recipient query', () => {
+  it('filters by enabled categories and unsubscribe-all before pagination', async () => {
+    const enabledAuthUserId = buildTestAuthUserId('email-recipient-enabled');
+    const disabledAuthUserId = buildTestAuthUserId('email-recipient-disabled');
+    const unsubscribedAuthUserId = buildTestAuthUserId(
+      'email-recipient-unsubscribed',
+    );
+    const [enabledUserId, disabledUserId, unsubscribedUserId] =
+      await Promise.all([
+        ensureUser({
+          authUserId: enabledAuthUserId,
+          email: buildTestEmail(enabledAuthUserId),
+        }),
+        ensureUser({
+          authUserId: disabledAuthUserId,
+          email: buildTestEmail(disabledAuthUserId),
+        }),
+        ensureUser({
+          authUserId: unsubscribedAuthUserId,
+          email: buildTestEmail(unsubscribedAuthUserId),
+        }),
+      ]);
+
+    await db.insert(userEmailNotificationPreferences).values([
+      { userId: enabledUserId, category: 'daily_reminder', enabled: true },
+      { userId: disabledUserId, category: 'daily_reminder', enabled: false },
+      {
+        userId: unsubscribedUserId,
+        category: 'daily_reminder',
+        enabled: true,
+      },
+    ]);
+    await db.insert(userEmailNotificationSettings).values({
+      userId: unsubscribedUserId,
+      unsubscribeAllOptionalEmails: true,
+    });
+
+    const result = await listEmailDeliveryRecipients({
+      batchSize: 1,
+      categories: ['daily_reminder'],
+      dbClient: db,
+    });
+
+    expect(result.recipients).toEqual([
+      {
+        userId: enabledUserId,
+        email: buildTestEmail(enabledAuthUserId),
+      },
+    ]);
+    expect(result.nextCursor).toBeNull();
+  });
+});

--- a/tests/integration/db/email-notification-deliveries.spec.ts
+++ b/tests/integration/db/email-notification-deliveries.spec.ts
@@ -207,7 +207,7 @@ describe('email notification deliveries ledger', () => {
     expect(retried).toMatchObject({ outcome: 'claimed' });
   });
 
-  it('reuses the original provider request and domain idempotency key for failed rows', async () => {
+  it('accepts a recomputed provider request for definitively rejected rows', async () => {
     const authUserId = buildTestAuthUserId('email-ledger-failed');
     const userId = await ensureUser({
       authUserId,
@@ -239,15 +239,16 @@ describe('email notification deliveries ledger', () => {
       db,
     );
 
+    const recomputedRequest = providerRequest({
+      subject: 'Recomputed subject',
+      idempotencyKey: 'recomputed:daily_reminder:2026-07-10',
+    });
     const second = await claimEmailNotificationDelivery(
       {
         userId,
         category: 'daily_reminder',
         deliveryKey: '2026-07-10',
-        providerRequest: providerRequest({
-          subject: 'Recomputed subject',
-          idempotencyKey: 'recomputed:daily_reminder:2026-07-10',
-        }),
+        providerRequest: recomputedRequest,
       },
       db,
     );
@@ -256,8 +257,8 @@ describe('email notification deliveries ledger', () => {
     if (second.outcome !== 'claimed') return;
     expect(second.deliveryId).toBe(first.deliveryId);
     expect(second.claimToken).not.toBe(first.claimToken);
-    expect(second.providerRequest).toEqual(originalRequest);
-    expect(second.reusedProviderRequest).toBe(true);
+    expect(second.providerRequest).toEqual(recomputedRequest);
+    expect(second.reusedProviderRequest).toBe(false);
 
     await markEmailNotificationDeliveryFailed(
       {
@@ -268,23 +269,24 @@ describe('email notification deliveries ledger', () => {
       db,
     );
 
+    const latestRequest = providerRequest({
+      subject: 'Another recomputed subject',
+      idempotencyKey: 'another:daily_reminder:2026-07-10',
+    });
     const third = await claimEmailNotificationDelivery(
       {
         userId,
         category: 'daily_reminder',
         deliveryKey: '2026-07-10',
-        providerRequest: providerRequest({
-          subject: 'Another recomputed subject',
-          idempotencyKey: 'another:daily_reminder:2026-07-10',
-        }),
+        providerRequest: latestRequest,
       },
       db,
     );
 
     expect(third.outcome).toBe('claimed');
     if (third.outcome !== 'claimed') return;
-    expect(third.providerRequest).toEqual(originalRequest);
-    expect(third.reusedProviderRequest).toBe(true);
+    expect(third.providerRequest).toEqual(latestRequest);
+    expect(third.reusedProviderRequest).toBe(false);
 
     await expect(
       markEmailNotificationDeliverySent(
@@ -351,7 +353,7 @@ describe('email notification deliveries ledger', () => {
       {
         deliveryId: first.deliveryId,
         claimToken: first.claimToken,
-        failureClass: 'provider_configuration',
+        failureClass: 'provider_rate_limited',
       },
       db,
     );

--- a/tests/integration/db/plan-list-page.spec.ts
+++ b/tests/integration/db/plan-list-page.spec.ts
@@ -394,6 +394,34 @@ describe('aggregate plans page query', () => {
     ]);
   });
 
+  it('treats in-progress task rows as started plans', async () => {
+    const userId = await createUser('in-progress-plan-status');
+    const plan = await createTestPlan({
+      userId,
+      topic: 'Started plan',
+      generationStatus: 'ready',
+    });
+    const module = await createTestModule({ planId: plan.id });
+    const task = await createTestTask({ moduleId: module.id });
+
+    await db.insert(taskProgress).values({
+      taskId: task.id,
+      userId,
+      status: 'in_progress',
+    });
+
+    const page = await getPlansPageForRead({
+      userId,
+      dbClient: db,
+      query: query({ status: 'all' }),
+      referenceTimestamp: REFERENCE_TIMESTAMP,
+    });
+
+    expect(page.items).toEqual([
+      expect.objectContaining({ id: plan.id, status: 'active' }),
+    ]);
+  });
+
   it('keeps non-ready plans with modules out of the not-started bucket', async () => {
     const userId = await createUser('non-ready-modules');
     const generatingPlan = await createTestPlan({

--- a/tests/results/integration/08-04-2026-results.md
+++ b/tests/results/integration/08-04-2026-results.md
@@ -17,3 +17,7 @@
 - Command: `NODE_ENV=test pnpm vitest run --config vitest.config.ts --project integration tests/integration/db/retention-cleanup-function.spec.ts --no-file-parallelism`
 - Result: passed — 1 test file, 1 test.
 - Scope: verifies the final cleanup function continues pruning expired Clerk webhook claims after the contract-only repair migration is applied.
+
+- Command: `NODE_ENV=test pnpm vitest run --config vitest.config.ts --project integration tests/integration/db/email-delivery-recipients.spec.ts tests/integration/db/email-notification-deliveries.spec.ts tests/integration/db/plan-list-page.spec.ts`
+- Result: passed — 3 test files, 20 tests.
+- Scope: category- and unsubscribe-filtered recipient pagination, provider-request recovery, and in-progress plan status aggregation.

--- a/tests/results/security/08-04-2026-results.md
+++ b/tests/results/security/08-04-2026-results.md
@@ -3,3 +3,7 @@
 - Command: `NODE_ENV=test pnpm vitest run --config vitest.config.ts --project security tests/security/rls.policies.spec.ts`
 - Result: passed — 1 test file, 31 tests.
 - Scope: service-owned Clerk webhook claim table is unreadable and unwritable through `anon` and `authenticated` RLS clients; the service-role row remains intact.
+
+- Command: `NODE_ENV=test pnpm vitest run --config vitest.config.ts --project security tests/security/rls.policies.spec.ts`
+- Result: passed — 1 test file, 31 tests.
+- Scope: authenticated `task_progress` DELETE remains revoked after the later hardening migration.

--- a/tests/results/unit/08-04-2026-results.md
+++ b/tests/results/unit/08-04-2026-results.md
@@ -23,3 +23,7 @@
 - Command: `SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit tests/unit/architecture/db-migration-workflows.spec.ts tests/unit/features/billing/clerk-billing/reconciliation.spec.ts --no-file-parallelism`
 - Result: passed — 2 test files, 22 tests.
 - Scope: contract-only cleanup repair ordering and retryable missing-local-user webhook behavior.
+
+- Command: `SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit tests/unit/api/email-notification-cron-route.spec.ts tests/unit/features/notifications/email/delivery-service.spec.ts`
+- Result: passed — 2 test files, 28 tests.
+- Scope: cron run-kind query routing and category-aware email recipient pagination handoff.

--- a/tests/unit/api/email-notification-cron-route.spec.ts
+++ b/tests/unit/api/email-notification-cron-route.spec.ts
@@ -183,6 +183,34 @@ describe('email notification delivery cron route', () => {
     });
   });
 
+  it('maps the Vercel cron URL run kind when the schedule header is absent', async () => {
+    resolveDeliveryEnabled.mockResolvedValue(true);
+    startWorkflow.mockResolvedValue({
+      outcome: 'started',
+      runId: 'run-query',
+      workflowRunId: 'workflow-query',
+    });
+    const GET = createEmailNotificationDeliveryCronRoute({
+      resolveCronSecret: () => 'cron-secret',
+      resolveDeliveryEnabled,
+      startWorkflow,
+      now: () => new Date('2026-07-10T14:01:00.000Z'),
+    });
+
+    const response = await GET(
+      new Request(`${URL}?runKind=daily`, {
+        headers: { authorization: 'Bearer cron-secret' },
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(startWorkflow).toHaveBeenCalledWith({
+      runKind: 'daily',
+      schedulerDateUtc: '2026-07-10',
+      action: 'start',
+    });
+  });
+
   it('returns an existing weekly run without treating it as a new workflow', async () => {
     resolveDeliveryEnabled.mockResolvedValue(true);
     startWorkflow.mockResolvedValue({

--- a/tests/unit/features/notifications/email/delivery-service.spec.ts
+++ b/tests/unit/features/notifications/email/delivery-service.spec.ts
@@ -139,6 +139,7 @@ describe('runEmailNotificationDelivery', () => {
     expect(listRecipients).toHaveBeenCalledWith({
       batchSize: 50,
       cursorUserId: '00000000-0000-0000-0000-000000000000',
+      categories: ['streak_reminder'],
       dbClient: expect.anything(),
     });
     expect(result.nextCursor).toBe('u1');

--- a/vercel.json
+++ b/vercel.json
@@ -2,11 +2,11 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "crons": [
     {
-      "path": "/api/cron/notifications/email",
+      "path": "/api/cron/notifications/email?runKind=daily",
       "schedule": "0 14 * * *"
     },
     {
-      "path": "/api/cron/notifications/email",
+      "path": "/api/cron/notifications/email?runKind=weekly",
       "schedule": "30 14 * * 1"
     }
   ]


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production email cron routing, recipient selection, and delivery ledger retry semantics; incorrect behavior could skip or mis-target sends, though changes are covered by integration and unit tests.
> 
> **Overview**
> Follow-up fixes for email scheduling, delivery pagination, plan list accuracy, and maintenance gating.
> 
> **Email notifications:** Vercel cron paths now include `?runKind=daily` / `?runKind=weekly`, and the cron route resolves run kind from that query param when the schedule header is missing. Recipient pagination filters in SQL for users with an enabled category and without **unsubscribe all**, passing run `categories` through from the delivery service. Failed ledger rows with `provider_configuration` or `provider_recipient_invalid` may **reclaim with a recomputed** provider request instead of always reusing the stored payload.
> 
> **Plans & security:** Plan list **not_started** treats any `in_progress` or `completed` task as started (not only completed). A migration **revokes authenticated `DELETE` on `task_progress`**, registered in the phased expand list.
> 
> **Ops:** Scheduled plan-cleanup GitHub workflow runs only when repo variable `PLAN_CLEANUP_ENABLED=true`; manual dispatch unchanged. Deploy and email runbooks updated for the new cron URLs and cleanup variable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aef117d425db9718e7909575db72002141dab38e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->