### PR TITLE
fix/security hardening gates

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ System design, pipelines, and operational runbooks.
 | File | Description |
 |------|-------------|
 | [auth-and-data-layer.md](./architecture/auth-and-data-layer.md) | Auth, authorization, RLS / tenant isolation |
-| [clerk-billing-architecture.md](./architecture/clerk-billing-architecture.md) | Clerk Billing webhooks, projection, quotas, checkout sync |
+| [clerk-billing-architecture.md](./architecture/clerk-billing-architecture.md) | Clerk Billing and identity webhooks, projections, quotas, checkout sync |
 | [email-notification-delivery-runbook.md](./architecture/email-notification-delivery-runbook.md) | Email notification scheduler runbook |
 | [internal-worker-routes.md](./architecture/internal-worker-routes.md) | Internal `/api/internal/` workers and token auth |
 | [plan-cleanup-runbook.md](./architecture/plan-cleanup-runbook.md) | Stuck-plan and orphaned-attempt maintenance |

--- a/docs/architecture/auth-and-data-layer.md
+++ b/docs/architecture/auth-and-data-layer.md
@@ -102,7 +102,7 @@ getEffectiveAuthUserId()
 └── Production → Clerk auth() / currentUser() → Clerk user id
 ```
 
-The `DEV_AUTH_USER_ID` override is **impossible in production** — it's gated by `NODE_ENV` which is a process-level environment variable, not a request parameter.
+The `DEV_AUTH_USER_ID` override is unavailable to a valid hosted runtime: the import-time hosted guard requires `NODE_ENV=production` and rejects both `DEV_AUTH_USER_ID` and `VITEST_WORKER_ID`. `NODE_ENV` alone is not the security boundary because Vitest's marker independently enables test behavior.
 
 For security-sensitive flows (OAuth callbacks), use `getAuthUserId()` instead — it always reads the real session, ignoring dev overrides.
 
@@ -170,6 +170,8 @@ throw new MissingRequestDbContextError(); // No fallback — fail hard
 2. **Double-layered access control.** Application queries filter by `user.id` AND Postgres RLS policies enforce the same filter at the database level. Even if app code has a bug, the database blocks cross-tenant access.
 
 3. **Dev overrides cannot leak to production.** `DEV_AUTH_USER_ID` is gated by `NODE_ENV` (process-level). Clerk Billing local fixtures run through an explicit script and do not bypass the production webhook signature check.
+
+   On first authenticated use, the app stores only Clerk's exact verified primary email and Clerk update timestamp. If the local row is tombstoned after a signed `user.deleted` event, authentication fails closed; an event cannot silently revive it.
 
 4. **Service-role usage is restricted.** Do not import `@supabase/service-role` from `src/app/api/**`, `src/lib/api/**`, or `src/lib/integrations/**` (enforce via architecture review and Oxlint).
 

--- a/docs/architecture/clerk-billing-architecture.md
+++ b/docs/architecture/clerk-billing-architecture.md
@@ -1,24 +1,25 @@
-# Clerk Billing Architecture
+# Clerk Billing & Identity Architecture
 
 **Audience:** Developers working on entitlements, pricing checkout, quotas, or billing webhooks.  
 **Last Updated:** August 2026
 
-Atlaris keeps a **single entitlement source**: Postgres `users` subscription columns projected from Clerk Billing webhooks and reconciliation. Do **not** gate features with Clerk `auth().has({ plan })` alongside DB tiers.
+Atlaris keeps a **single entitlement source**: Postgres `users` subscription columns projected from Clerk Billing webhooks and reconciliation. The same signed Clerk endpoint also maintains a minimal identity projection for the current, verified primary email. Do **not** gate features with Clerk `auth().has({ plan })` alongside DB tiers.
 
 Local fixture mode, env checklists, and manual checkout verification live in [environment.md](../development/environment.md#clerk-development-checkout-fixture-vs-real-payment-flow). This page covers the runtime architecture.
 
 ## Flow overview
 
 ```text
-Clerk Checkout / Dashboard
+Clerk Checkout / Dashboard / user lifecycle
         │
         ▼  Svix-signed events
 POST /api/v1/clerk/billing/webhook
         │
         ├── insert clerk_webhook_events (idempotent on svix-id)
-        ├── map event → ClerkBillingProjectionSource
-        ├── optional refresh: clerkClient.billing.getUserBillingSubscription
-        └── UPDATE users (tier, status, period_end, cancel_at_period_end)
+        ├── map billing event → ClerkBillingProjectionSource
+        ├── optional billing refresh: clerkClient.billing.getUserBillingSubscription
+        ├── map user event → ClerkUserProjectionSource
+        └── UPDATE users (entitlements or verified primary email/tombstone)
                 │
                 ├── GET /api/v1/user/subscription  → Settings #billing / #usage
                 └── quota boundaries (plans, regenerations, lesson generations)
@@ -44,8 +45,10 @@ Prefix matching in `src/features/billing/clerk-billing/projection.ts`:
 | `subscriptionItem.` | Single subscription item |
 | `subscription.` | All items on the subscription |
 | `paymentAttempt.` | Items plus payment attempt status |
+| `user.created`, `user.updated` | Current exact verified primary email and Clerk update watermark |
+| `user.deleted` | Clear email and permanently tombstone the local identity projection |
 
-Other types are ignored (`status: 'ignored'`). Subscribe the Clerk endpoint to `subscription.*`, `subscriptionItem.*`, and `paymentAttempt.*`.
+Other types are ignored (`status: 'ignored'`). Subscribe the Clerk endpoint to `subscription.*`, `subscriptionItem.*`, `paymentAttempt.*`, `user.created`, `user.updated`, and `user.deleted`.
 
 ### Idempotency
 
@@ -61,6 +64,9 @@ Lookup: `users.auth_user_id` = Clerk payer user id (`user_...`).
 | `subscription_status` | `active` \| `canceled` \| `past_due` \| `trialing` |
 | `subscription_period_end` | Period end timestamp |
 | `cancel_at_period_end` | Boolean |
+| `email` | Exact Clerk primary email only while it is verified; otherwise `NULL` |
+| `clerk_user_updated_at` | Provider timestamp used to ignore stale lifecycle events |
+| `clerk_deleted_at` | Permanent local tombstone for a Clerk `user.deleted` event |
 
 Plan slug → tier mapping lives in `src/features/billing/clerk-billing/plan-mapping.ts`:
 
@@ -73,6 +79,35 @@ Plan slug → tier mapping lives in `src/features/billing/clerk-billing/plan-map
 Free and starter may share a Clerk plan id; amount (`0` vs paid) plus slug disambiguate. Projection rules (highest paid tier, past-due retention, canceled-but-in-period, terminal downgrade to free) are implemented in `projectClerkBillingSource` — read that function before changing entitlement semantics.
 
 Webhook applies refresh from Clerk Billing API (`refreshFromClerk: true`) before writing. Local fixtures call `applyClerkBillingSource` **without** refresh or webhook idempotency insert.
+
+### Identity projection
+
+The identity projection is intentionally narrow. `user.created` and `user.updated` use only Clerk's **exact** primary email when its verification status is `verified`; there is no fallback to another address. A missing or unverified primary address stores `NULL`. The provider's `updated_at` timestamp prevents stale deliveries from replacing newer data. A `user.deleted` event clears the email and sets `clerk_deleted_at`; later lifecycle updates cannot resurrect that row.
+
+The event ledger acknowledges lifecycle events for users that do not yet have an Atlaris row as `skipped_no_user`. On the first authenticated use, Atlaris provisions the current Clerk identity instead. A unique-email conflict never transfers an address between local users; the transaction rolls back and Clerk retries the delivery.
+
+For a deliberate one-shot repair after enabling lifecycle subscriptions, the command is dry-run by default:
+
+```bash
+# Local preview / apply
+pnpm clerk:user:reconcile
+pnpm clerk:user:reconcile -- --apply
+
+# Hosted preview / apply (both explicit gates are required to mutate)
+pnpm clerk:user:reconcile -- --allow-non-local true
+pnpm clerk:user:reconcile -- --apply --allow-non-local true
+```
+
+It pages local `auth_user_id` values, obtains the current Clerk user, applies the same verified-primary projection, tombstones Clerk 404s, and exits nonzero if transient retrieval failures remain. Before an apply run, verify that `CLERK_SECRET_KEY` and `POSTGRES_URL` belong to the same target environment and review the dry-run `wouldTombstone` count. It is not a scheduler.
+
+### Lifecycle cutover
+
+1. Apply `20260811100100_add_clerk_user_identity_projection` in the migration workflow's expand phase.
+2. Deploy the application release that handles the lifecycle events.
+3. In the matching Clerk Dashboard instance, add `user.created`, `user.updated`, and `user.deleted` to the existing signed endpoint subscription.
+4. Run the one-shot dry-run, inspect `wouldUpdate` and `wouldTombstone`, then use the explicit apply command only after the counts are expected.
+
+Do not configure the lifecycle events against a different Clerk instance than the deployment's `CLERK_SECRET_KEY`; a mismatch makes current users appear deleted to the reconciliation command.
 
 ## Checkout return sync
 
@@ -122,6 +157,7 @@ Metered reservation core: `src/features/billing/metered-reservation.ts`. Boundar
 | Command | Purpose |
 | ------- | ------- |
 | `pnpm billing:clerk:fixture -- --user-id <auth_user_id> --plan pro` | Apply projection for a local user (localhost Postgres only unless `--allow-non-local true`) |
+| `pnpm clerk:user:reconcile -- --apply` | One-shot lifecycle projection repair; run only with the intended target environment credentials |
 | `pnpm dev:local:starter` | Start DB, seed, fixture starter, `pnpm dev` |
 | `pnpm dev:local:pro` | Same for pro |
 

--- a/docs/architecture/email-notification-delivery-runbook.md
+++ b/docs/architecture/email-notification-delivery-runbook.md
@@ -85,6 +85,26 @@ WHERE id = '<run-id>';
 
 The run record is an operational checkpoint. `email_notification_deliveries` remains the source of truth for individual sends and idempotency.
 
+## Payload minimization and inventory
+
+Resolved `sent` and `skipped` ledger rows retain their compact idempotency tombstone but must have `provider_request = NULL`. Pending, retryable failed, and `manual_review` rows retain their request because retry/review correctness still depends on it. There is no age-based email-ledger cleanup policy yet.
+
+Inspect only aggregate state while setting that policy; do not select recipient addresses, content, headers, tokens, or `provider_request`:
+
+```sql
+SELECT
+  status,
+  count(*) AS total_rows,
+  count(*) FILTER (WHERE provider_request IS NOT NULL) AS rows_with_provider_request,
+  min(created_at) AS oldest_created_at,
+  min(updated_at) AS oldest_updated_at
+FROM email_notification_deliveries
+GROUP BY status
+ORDER BY status;
+```
+
+If a `sent` or `skipped` row has a payload, stop before validating the invariant and resolve the row under the approved operator policy. Do not delete its tombstone.
+
 ## Trigger a safe manual run
 
 Use the manual recovery route with `MAINTENANCE_WORKER_TOKEN`, never `CRON_SECRET`. It accepts only a code-owned run kind, UTC date, and explicit action.
@@ -110,6 +130,8 @@ For a weekly run, use a Monday UTC date and `"runKind":"weekly"`. A `start` requ
 ## Handle `needs_review`
 
 `needs_review` means the run observed an isolated recipient error or an ambiguous provider/idempotency outcome. It is intentionally terminal and does not automatically resend.
+
+If an expired pending claim has a different current recipient, the ledger enters `manual_review` and retains the original request. Do not replace or resend it automatically: determine whether the provider may have accepted the original delivery first.
 
 1. Inspect the affected ledger rows and resolve the underlying data or provider state.
 2. Confirm no unresolved `manual_review` ledger rows remain for the logical run.

--- a/docs/architecture/internal-worker-routes.md
+++ b/docs/architecture/internal-worker-routes.md
@@ -43,7 +43,7 @@ The Vercel Cron email route accepts only `Authorization: Bearer $CRON_SECRET`; i
 ### Production vs non-production
 
 - **Production:** enabled routes require a worker token or return `503`. Disabled routes return `503` before token validation.
-- **Non-production:** enabled routes without a token allow unauthenticated access (local/staging convenience only).
+- **Local non-production:** enabled routes without a token allow unauthenticated access. Hosted Preview and Staging deployments use the production runtime profile and therefore require worker tokens.
 
 ## Middleware
 

--- a/docs/architecture/plan-generation-architecture.md
+++ b/docs/architecture/plan-generation-architecture.md
@@ -192,7 +192,7 @@ This path is **not** the streamed plan creator. It fills structured lesson conte
 3. Build batch prompts from `src/features/lesson-content/module-lesson-prompts.ts`.
 4. Inside quota boundary: resolve provider (`resolveModelForTier` unless tests inject a provider), call `generateModuleLessonBatchWithInstrumentation`, parse stream via `parseModuleLessonBatchFromStream`.
 5. **Persist** in one transaction path: `commitModuleLessonBatchSuccess` writes per-task `lesson_content`, sets module to `ready`, records AI usage metadata, increments `usage_metrics.lesson_modules_generated` for the calendar month (via `src/features/billing/metered-reservation.ts` / `usage-metrics.ts`).
-6. On parser/provider failure after claim: `commitModuleLessonGenerationFailure` sets module `failed` with a truncated error string; quota work returns `revert` so the meter reservation is compensated.
+6. On parser/provider failure after claim: `commitModuleLessonGenerationFailure` sets the module to `failed` with `lesson_generation_error` left `NULL`; raw diagnostic details stay in server logs. Quota work returns `revert` so the meter reservation is compensated.
 
 ### API response shape
 

--- a/docs/architecture/retention-cleanup-runbook.md
+++ b/docs/architecture/retention-cleanup-runbook.md
@@ -9,7 +9,7 @@ Expired OAuth state tokens, old Clerk webhook idempotency rows, and old terminal
 
 - `private.cleanup_retained_db_rows()`
 
-Supabase Cron schedules the function daily through migration `20260522223908_schedule_retention_cleanup.sql`. Raw `ai_usage_events` rows are intentionally excluded until a monthly aggregation model exists.
+Supabase Cron schedules the function daily through migration `20260522223908_schedule_retention_cleanup.sql`. Raw `ai_usage_events` rows are intentionally excluded until a monthly aggregation model exists. Email delivery runs and ledger tombstones are also excluded: their retry, manual-review, and idempotency retention policy has not yet been approved.
 
 ## Required Environment
 
@@ -27,6 +27,7 @@ Supabase Cron schedules the function daily through migration `20260522223908_sch
 | `clerk_webhook_events`  | Delete rows older than 45 days                               |
 | `job_queue`             | Delete terminal `completed`/`failed` rows older than 30 days |
 | `ai_usage_events`       | Not deleted by this endpoint                                 |
+| `email_notification_delivery_runs` / `email_notification_deliveries` | Not deleted by this endpoint; see the email delivery runbook for payload minimization and non-sensitive inventory |
 
 ## Scheduled Cleanup
 

--- a/docs/database/schema-overview.md
+++ b/docs/database/schema-overview.md
@@ -47,7 +47,8 @@ Defined in `supabase/enums.ts` (plus delivery status enums on delivery table mod
 
 - **Primary keys:** UUID on all user-facing tables
 - **User identity:** `users.auth_user_id` is unique and maps the Clerk auth identity to the internal `users.id`
-- **Email uniqueness:** `users.email` is unique
+- **Email uniqueness:** `users.email` is nullable and unique when present; it stores only Clerk's verified primary address
+- **Clerk identity projection:** `users.clerk_user_updated_at` rejects stale lifecycle updates; `users.clerk_deleted_at` tombstones a signed Clerk deletion without cascading user data
 - **Ownership integrity:** foreign keys generally cascade on delete
 - **Ordering integrity:** `unique(plan_id, order)` on modules and `unique(module_id, order)` on tasks
 - **Preferences:** `user_preferences.user_id` and `user_email_notification_settings.user_id` are 1:1 with `users`; category prefs use `unique(user_id, category)`

--- a/docs/development/deploy.md
+++ b/docs/development/deploy.md
@@ -53,16 +53,31 @@ After deploying a release that includes new Supabase migrations:
 
 1. Before deploying code that needs new schema, manually dispatch the environment workflow's `expand` phase (`staging-db-migrations.yaml` from `develop`, `production-db-migrations.yaml` from `main`).
 2. After rollout health and any migration-specific archive checks pass, dispatch `contract` with confirmation `post-deploy-health-verified`. Do not run `supabase db push --include-all` directly; the confirmed contract phase owns out-of-order/destructive application.
-3. Set worker tokens in the target environment for enabled internal routes:
+3. After the expand workflow, attest that authenticated users cannot delete task progress:
+
+```sql
+SELECT version::text
+FROM supabase_migrations.schema_migrations
+WHERE version::text = '20260804160000';
+
+SELECT
+  has_table_privilege('authenticated', 'public.task_progress', 'SELECT') AS can_select,
+  has_table_privilege('authenticated', 'public.task_progress', 'INSERT') AS can_insert,
+  has_table_privilege('authenticated', 'public.task_progress', 'UPDATE') AS can_update,
+  has_table_privilege('authenticated', 'public.task_progress', 'DELETE') AS can_delete;
+```
+
+The expected result is migration version `20260804160000`, `can_select`, `can_insert`, and `can_update` true, and `can_delete` false.
+4. Set worker tokens in the target environment for enabled internal routes:
    - `REGENERATION_WORKER_TOKEN` for regeneration drains
    - `WORKER_HEALTH_TOKEN` for `GET /api/health/worker` operator metrics
    - `RETENTION_CLEANUP_ENABLED=true` and/or `PLAN_CLEANUP_ENABLED=true` plus `MAINTENANCE_WORKER_TOKEN` only when enabling maintenance routes
-4. Verify plan cleanup scheduler and alerting when `PLAN_CLEANUP_ENABLED=true`:
+5. Verify plan cleanup scheduler and alerting when `PLAN_CLEANUP_ENABLED=true`:
    - Set the GitHub Actions repository variable `PLAN_CLEANUP_ENABLED=true`; scheduled workflow runs are skipped until this variable is enabled, while manual dispatch remains available for checks.
    - Set the same `MAINTENANCE_WORKER_TOKEN` value in Vercel Production and the GitHub Actions `Production – atlaris` environment secret.
    - Confirm `.github/workflows/plan-cleanup-scheduler.yml` runs every 15 minutes and returns `200` with `ok: true`.
    - Confirm Sentry monitor `plan-cleanup-maintenance` receives successful check-ins; GitHub workflow failures identify `401`, `503`, and `500` responses.
-5. Verify scheduled retention cleanup after migration `20260522223908_schedule_retention_cleanup.sql`:
+6. Verify scheduled retention cleanup after migration `20260522223908_schedule_retention_cleanup.sql`:
 
 ```sql
 SELECT jobid, jobname, schedule, active
@@ -72,13 +87,14 @@ WHERE jobname = 'retention-cleanup';
 
 If the migration applied but no cron job exists, enable `pg_cron` in Supabase and register the job manually (see retention runbook).
 
-6. Enable module lesson generation when the hosted environment should serve it:
+7. Enable module lesson generation when the hosted environment should serve it:
    - Set `LESSON_GENERATION_ENABLED=true` in production/staging. When unset outside development, the flag defaults to **off** and `POST /api/v1/plans/:planId/modules/:moduleId/lesson-content/generate` returns HTTP `503` with `disabled`.
    - After deploy, verify from an authenticated session that lesson generation does not return `503 disabled` for an unlocked module. See `docs/architecture/plan-generation-architecture.md` (module lesson generation) and `docs/development/environment.md` (`LESSON_GENERATION_ENABLED`).
-7. Enable opted-in email notification delivery only after the env and ledger are ready:
+8. Enable opted-in email notification delivery only after the env and ledger are ready:
    - Confirm `APP_URL` is the canonical https origin for that environment (required for unsubscribe and deeplink URLs; production throws if unset).
    - Configure `RESEND_API_KEY`, `RESEND_FROM`, and `EMAIL_UNSUBSCRIBE_TOKEN_SECRET` (see `emailEnv` in `docs/development/environment.md`).
-   - Apply the email notification deliveries ledger migration, then enable the Vercel Flag `email-notification-delivery` after a smoke pass. The flag is fail-closed / default disabled.
+   - Apply the email notification deliveries ledger migration and `20260811100200_enforce_resolved_email_delivery_payload_minimization`, then run the non-PII inventory in the email delivery runbook. Do not validate the new check until the inventory reports no historical violations or remediation is approved.
+   - Enable the Vercel Flag `email-notification-delivery` after a smoke pass. The flag is fail-closed / default disabled.
    - Confirm Vercel Cron and `CRON_SECRET` are configured for production; keep `MAINTENANCE_WORKER_TOKEN` for manual recovery only. See `docs/architecture/internal-worker-routes.md`.
 
 See also:
@@ -92,10 +108,14 @@ See also:
 
 The email scheduler must have exactly one active owner. This release removes the GitHub email scheduler and adds the two Vercel Cron entries together.
 
-1. Run the migration workflow's `expand` phase before deploying code that starts email workflows. Its explicit safe list applies both `20260710151930_create_email_notification_delivery_runs` and the future-dated delivery ledger without opening the contract gate.
+1. Run the migration workflow's `expand` phase before deploying code that starts email workflows. Its explicit safe list applies `20260710151930_create_email_notification_delivery_runs`, the delivery ledger, and `20260811100200_enforce_resolved_email_delivery_payload_minimization` without opening the contract gate.
 2. Set a new `CRON_SECRET` in the target Vercel environment. Keep it distinct from `MAINTENANCE_WORKER_TOKEN`.
 3. Deploy the application with `vercel.json`; confirm Vercel lists only `0 14 * * *` for `/api/cron/notifications/email?runKind=daily` and `30 14 * * 1` for `/api/cron/notifications/email?runKind=weekly`.
 4. Leave the `email-notification-delivery` Vercel Flag disabled and verify both authenticated cron paths return the intentional `disabled` outcome without creating a run.
 5. Enable a safe opted-in account, trigger one manual logical run, and inspect its database run, Workflow SDK run, Sentry monitor, and delivery ledger before enabling broader delivery.
 
 See [`docs/architecture/email-notification-delivery-runbook.md`](../architecture/email-notification-delivery-runbook.md) for duplicate, failure, and `needs_review` recovery.
+
+## Module lesson-generation error cleanup cutover
+
+Deploy the release that keeps lesson-generation failure diagnostics in logs only before running `20260811100000_clear_module_lesson_generation_errors` in the confirmed contract phase. Wait for all older application instances to drain first; otherwise an older binary could write a raw diagnostic back after the cleanup.

--- a/docs/development/environment.md
+++ b/docs/development/environment.md
@@ -8,6 +8,10 @@ Guidelines for environment variables and logging in this project.
 
 **All env access must go through `@/lib/config/env`.** Do **not** read `process.env` directly outside that module.
 
+### Hosted runtime profile
+
+Every Vercel Preview, Staging, and Production deployment must run with `NODE_ENV=production`. Startup refuses a hosted process with missing, blank, development, or test `NODE_ENV`, or with `VITEST_WORKER_ID`, `DEV_AUTH_USER_ID`, or enabled `LOCAL_PRODUCT_TESTING`. These capability markers remain valid for local development and tests only.
+
 ### Grouped Configs
 
 Prefer the exported grouped configs instead of raw keys:
@@ -70,9 +74,9 @@ Key auth-related server variables include:
 | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
 | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Clerk browser-safe publishable key                                                                                                                                                                                                                              | Yes                                         |
 | `CLERK_SECRET_KEY`                  | Clerk server secret key                                                                                                                                                                                                                                         | Yes                                         |
-| `CLERK_WEBHOOK_SIGNING_SECRET`      | Clerk/Svix signing secret for `POST /api/v1/clerk/billing/webhook`                                                                                                                                                                                              | Yes when Clerk Billing webhooks are enabled |
+| `CLERK_WEBHOOK_SIGNING_SECRET`      | Clerk/Svix signing secret for `POST /api/v1/clerk/billing/webhook` (Billing and user lifecycle events)                                                                                                                                                        | Yes when Clerk webhooks are enabled |
 | `LOCAL_PRODUCT_TESTING`             | Enables the local product-testing workflow (must be off in hosted deploys). Do not combine with Clerk UI checkout — see [Clerk development checkout](#clerk-development-checkout-fixture-vs-real-payment-flow).                                                 | No                                          |
-| `DEV_AUTH_USER_ID`                  | Optional dev/test auth override (`users.auth_user_id`); use bootstrap seed id for local DB. Required with `LOCAL_PRODUCT_TESTING=true`; must be empty for real Clerk checkout.                                                                                  | No                                          |
+| `DEV_AUTH_USER_ID`                  | Optional dev/test auth override (`users.auth_user_id`); use bootstrap seed id for local DB. Required with `LOCAL_PRODUCT_TESTING=true`; must be empty for real Clerk checkout and every hosted deployment.                                                       | No                                          |
 | `DEV_AUTH_USER_EMAIL`               | Optional dev/test display email                                                                                                                                                                                                                                 | No                                          |
 | `DEV_AUTH_USER_NAME`                | Optional dev/test display name                                                                                                                                                                                                                                  | No                                          |
 | `LESSON_GENERATION_ENABLED`         | `true`/`false`/`1`/`0`; when unset, defaults to **on** in development and **off** in other `NODE_ENV` values (see `lessonContentEnv`). Set `true` in hosted production/staging when module lesson generation should be live — see `docs/development/deploy.md`. | No (yes for hosted lesson generation)       |
@@ -169,7 +173,7 @@ Startup fails in development when Clerk UI would be enabled while `DEV_AUTH_USER
   - `pro_plan` → `pro`
 - Do not use a generic `pro` Clerk plan slug.
 - Dashboard plan features/limits should match `src/shared/constants/tier-limits.ts` (link the source; do not copy values into docs where drift is likely).
-- Webhook endpoint: `{APP_URL}/api/v1/clerk/billing/webhook`, subscribed to `subscription.*`, `subscriptionItem.*`, and `paymentAttempt.*`.
+- Webhook endpoint: `{APP_URL}/api/v1/clerk/billing/webhook`, subscribed to `subscription.*`, `subscriptionItem.*`, `paymentAttempt.*`, `user.created`, `user.updated`, and `user.deleted`.
 - `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`, and `CLERK_WEBHOOK_SIGNING_SECRET` must all belong to that same Development instance. Presence of an encrypted Vercel variable is not proof the value matches the endpoint.
 - Prefer hosted Preview/staging for real checkout. Localhost needs a public tunnel to the webhook path ([Clerk webhook debugging](https://clerk.com/docs/guides/development/webhooks/debugging)).
 - Clerk’s shared development payment gateway uses Stripe test cards ([Stripe testing](https://docs.stripe.com/testing)). **No app-owned Stripe account, Stripe API keys, Stripe products, or Stripe prices are required.**

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "db:dev:stop": "supabase stop",
     "db:dev:seed": "tsx scripts/db/seed-local-supabase.ts",
     "billing:clerk:fixture": "tsx scripts/db/apply-clerk-billing-fixture.ts",
+    "clerk:user:reconcile": "tsx scripts/db/reconcile-clerk-users.ts",
     "db:dev:reset": "supabase db reset",
     "test": "tsx scripts/tests/run-phases.ts test:unit:changed test:integration:changed",
     "test:unit": "SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit tests/unit",

--- a/scripts/db/reconcile-clerk-users.ts
+++ b/scripts/db/reconcile-clerk-users.ts
@@ -1,0 +1,136 @@
+import {
+  getPostgresHostname,
+  isLocalPostgresHostname,
+} from './local-postgres-host';
+import { reconcileClerkUserIdentities } from '@/features/auth/clerk-user-projection';
+import { createLogger } from '@/lib/logging/logger';
+import { clerkClient as getClerkClient } from '@clerk/nextjs/server';
+import { db as serviceRoleDb } from '@supabase/service-role';
+import { existsSync } from 'node:fs';
+
+type ReconciliationArgs = {
+  apply: boolean;
+  allowNonLocal: boolean;
+};
+
+function usage(): never {
+  console.error(
+    [
+      'Usage:',
+      '  pnpm clerk:user:reconcile',
+      '  pnpm clerk:user:reconcile -- --apply',
+      '  pnpm clerk:user:reconcile -- --allow-non-local true',
+      '  pnpm clerk:user:reconcile -- --apply --allow-non-local true',
+      '',
+      'The default is dry-run. Non-local targets require --allow-non-local true.',
+    ].join('\n'),
+  );
+  process.exit(1);
+}
+
+function parseArgs(argv: string[]): ReconciliationArgs {
+  const args: ReconciliationArgs = { apply: false, allowNonLocal: false };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--apply' && !args.apply) {
+      args.apply = true;
+      continue;
+    }
+    if (
+      arg === '--allow-non-local' &&
+      !args.allowNonLocal &&
+      argv[index + 1] === 'true'
+    ) {
+      args.allowNonLocal = true;
+      index += 1;
+      continue;
+    }
+    usage();
+  }
+
+  return args;
+}
+
+function resolveDatabaseUrl(): string {
+  const value = process.env.POSTGRES_URL?.trim();
+  if (!value) {
+    throw new Error('POSTGRES_URL is required to reconcile Clerk users.');
+  }
+  return value;
+}
+
+function assertTargetDatabase(
+  connectionUrl: string,
+  allowNonLocal: boolean,
+): string {
+  const hostname = getPostgresHostname(connectionUrl);
+  if (hostname === null) {
+    throw new Error(
+      'Invalid POSTGRES_URL: could not parse hostname (expected a postgresql:// URL).',
+    );
+  }
+  if (!isLocalPostgresHostname(hostname) && !allowNonLocal) {
+    throw new Error(
+      `Refusing to reconcile non-local database (host: ${hostname}). Pass "--allow-non-local true" after verifying the target credentials.`,
+    );
+  }
+  return hostname;
+}
+
+async function main(): Promise<void> {
+  if (!process.env.CI && existsSync('.env.local')) {
+    process.loadEnvFile('.env.local');
+  }
+
+  const args = parseArgs(process.argv.slice(2));
+  const hostname = assertTargetDatabase(
+    resolveDatabaseUrl(),
+    args.allowNonLocal,
+  );
+  const mode = args.apply ? 'APPLY' : 'DRY RUN';
+  console.log(`[clerk:user:reconcile] ${mode}; database host: ${hostname}`);
+
+  const clerkClient = await getClerkClient();
+  const logger = createLogger({ script: 'reconcile-clerk-users', mode });
+  const total = {
+    checked: 0,
+    updated: 0,
+    tombstoned: 0,
+    wouldUpdate: 0,
+    wouldTombstone: 0,
+    skipped: 0,
+    ignored: 0,
+    failed: 0,
+  };
+  let cursor: string | undefined;
+
+  do {
+    const page = await reconcileClerkUserIdentities({
+      apply: args.apply,
+      clerkClient,
+      db: serviceRoleDb,
+      logger,
+      startingAfterAuthUserId: cursor,
+    });
+    total.checked += page.checked;
+    total.updated += page.updated;
+    total.tombstoned += page.tombstoned;
+    total.wouldUpdate += page.wouldUpdate;
+    total.wouldTombstone += page.wouldTombstone;
+    total.skipped += page.skipped;
+    total.ignored += page.ignored;
+    total.failed += page.failed;
+    cursor = page.nextCursor ?? undefined;
+  } while (cursor);
+
+  console.log(JSON.stringify({ mode, ...total }, null, 2));
+  if (total.failed > 0) {
+    process.exitCode = 1;
+  }
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/db/run-phased-migrations.sh
+++ b/scripts/db/run-phased-migrations.sh
@@ -15,6 +15,8 @@ readonly -a EXPAND_MIGRATIONS=(
   supabase/migrations/20260710151930_create_email_notification_delivery_runs.sql
   supabase/migrations/20260809190000_create_email_notification_deliveries.sql
   supabase/migrations/20260810120000_create_clerk_webhook_event_claims.sql
+  supabase/migrations/20260811100100_add_clerk_user_identity_projection.sql
+  supabase/migrations/20260811100200_enforce_resolved_email_delivery_payload_minimization.sql
 )
 
 declare -A APPLIED_VERSIONS=()

--- a/src/app/(app)/plans/[id]/modules/[moduleId]/components/GenerationStatePanel.tsx
+++ b/src/app/(app)/plans/[id]/modules/[moduleId]/components/GenerationStatePanel.tsx
@@ -77,8 +77,8 @@ function GenerationDescription({
         </>
       ) : lessonGeneration.status === 'failed' ? (
         <p className='text-sm text-muted-foreground'>
-          {lessonGeneration.error ??
-            'Generation failed. Retry to create fresh lesson content for this module.'}
+          Generation failed. Retry to create fresh lesson content for this
+          module.
         </p>
       ) : (
         <p className='text-sm text-muted-foreground'>

--- a/src/app/(app)/settings/profile/components/ProfileForm.tsx
+++ b/src/app/(app)/settings/profile/components/ProfileForm.tsx
@@ -292,7 +292,9 @@ export function ProfileForm({ locale }: ProfileFormProps): ReactElement {
       </LedgerRow>
 
       <LedgerRow label='Email' hint='Managed by your sign-in provider.'>
-        <span className='text-foreground'>{state.profile.email}</span>
+        <span className='text-foreground'>
+          {state.profile.email ?? 'Unavailable'}
+        </span>
       </LedgerRow>
 
       <LedgerRow label='Member since'>

--- a/src/app/(app)/settings/profile/components/profile-client.ts
+++ b/src/app/(app)/settings/profile/components/profile-client.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 const profileSchema = z.object({
   id: z.string(),
   name: z.string().nullable(),
-  email: z.string(),
+  email: z.string().nullable(),
   subscriptionTier: z.string(),
   subscriptionStatus: z.string().nullable(),
   createdAt: z.string(),

--- a/src/app/api/v1/plans/[planId]/modules/[moduleId]/lesson-content/generate/handler.ts
+++ b/src/app/api/v1/plans/[planId]/modules/[moduleId]/lesson-content/generate/handler.ts
@@ -14,6 +14,8 @@ import { logger } from '@/lib/logging/logger';
 import { ModuleLessonGenerationApiResponseSchema } from '@/shared/schemas/lesson-content.schemas';
 
 type StartModuleLessonGeneration = typeof startModuleLessonGeneration;
+const LESSON_GENERATION_FAILURE_MESSAGE =
+  'Lesson generation failed. Please try again.';
 
 /**
  * Factory for the module lesson content generate POST handler.
@@ -102,7 +104,7 @@ function mapModuleLessonGenerationResult(
           state: 'provider_failure',
           planId,
           moduleId,
-          message: result.message,
+          message: LESSON_GENERATION_FAILURE_MESSAGE,
         }),
         { status: 502 },
       );

--- a/src/features/auth/clerk-user-projection.ts
+++ b/src/features/auth/clerk-user-projection.ts
@@ -1,0 +1,404 @@
+import type { DbTransaction } from '@/lib/db/types';
+import type { Logger } from '@/lib/logging/logger';
+import type { WebhookEvent } from '@clerk/nextjs/webhooks';
+
+import { users } from '@supabase/schema';
+import { and, asc, eq, gt, isNull, lte, or } from 'drizzle-orm';
+
+type UserProjectionDb = Pick<DbTransaction, 'select' | 'update'>;
+
+type ClerkUserEmailAddress = {
+  id: string;
+  email: string;
+  verificationStatus: string | null;
+};
+
+type ClerkWebhookUser = {
+  id: string;
+  updated_at: number;
+  primary_email_address_id: string | null;
+  email_addresses: readonly {
+    id: string;
+    email_address: string;
+    verification: { status?: string } | null;
+  }[];
+};
+
+export type ClerkBackendUser = {
+  id: string;
+  updatedAt: number;
+  primaryEmailAddressId: string | null;
+  emailAddresses: readonly {
+    id: string;
+    emailAddress: string;
+    verification: { status?: string } | null;
+  }[];
+};
+
+export type ClerkUserProjectionSource =
+  | {
+      readonly kind: 'upsert';
+      readonly type: 'user.created' | 'user.updated';
+      readonly authUserId: string;
+      readonly email: string | null;
+      readonly clerkUserUpdatedAt: Date;
+    }
+  | {
+      readonly kind: 'deleted';
+      readonly type: 'user.deleted';
+      readonly authUserId: string;
+      readonly clerkDeletedAt: Date;
+    };
+
+export type ClerkUserProjectionApplyResult =
+  | 'updated'
+  | 'skipped_no_user'
+  | 'skipped_deleted_user'
+  | 'ignored';
+
+export type ClerkUserIdentityClient = {
+  users: {
+    getUser(authUserId: string): Promise<ClerkBackendUser>;
+  };
+};
+
+type LocalUserProjection = {
+  id: string;
+  authUserId: string;
+  clerkUserUpdatedAt: Date | null;
+  clerkDeletedAt: Date | null;
+};
+
+function verifiedPrimaryEmail(
+  primaryEmailAddressId: string | null,
+  emailAddresses: readonly ClerkUserEmailAddress[],
+): string | null {
+  if (!primaryEmailAddressId) {
+    return null;
+  }
+
+  const primaryEmail = emailAddresses.find(
+    (email) => email.id === primaryEmailAddressId,
+  );
+  return primaryEmail?.verificationStatus === 'verified' &&
+    primaryEmail.email !== ''
+    ? primaryEmail.email
+    : null;
+}
+
+function dateFromClerkTimestamp(timestamp: number): Date {
+  const date = new Date(timestamp);
+  if (!Number.isFinite(timestamp) || Number.isNaN(date.getTime())) {
+    throw new Error('Clerk user event has an invalid updated_at timestamp');
+  }
+  return date;
+}
+
+function webhookEmailAddresses(
+  emailAddresses: ClerkWebhookUser['email_addresses'],
+): ClerkUserEmailAddress[] {
+  return emailAddresses.map((email) => ({
+    id: email.id,
+    email: email.email_address,
+    verificationStatus: email.verification?.status ?? null,
+  }));
+}
+
+function backendEmailAddresses(
+  emailAddresses: ClerkBackendUser['emailAddresses'],
+): ClerkUserEmailAddress[] {
+  return emailAddresses.map((email) => ({
+    id: email.id,
+    email: email.emailAddress,
+    verificationStatus: email.verification?.status ?? null,
+  }));
+}
+
+export function clerkUserProjectionSourceFromWebhook(
+  event: WebhookEvent,
+  receivedAt = new Date(),
+): ClerkUserProjectionSource | null {
+  if (event.type === 'user.created' || event.type === 'user.updated') {
+    const user = event.data as ClerkWebhookUser;
+    return {
+      kind: 'upsert',
+      type: event.type,
+      authUserId: user.id,
+      email: verifiedPrimaryEmail(
+        user.primary_email_address_id,
+        webhookEmailAddresses(user.email_addresses),
+      ),
+      clerkUserUpdatedAt: dateFromClerkTimestamp(user.updated_at),
+    };
+  }
+
+  if (event.type === 'user.deleted') {
+    const authUserId = event.data.id;
+    return typeof authUserId === 'string' && authUserId !== ''
+      ? {
+          kind: 'deleted',
+          type: event.type,
+          authUserId,
+          clerkDeletedAt: receivedAt,
+        }
+      : null;
+  }
+
+  return null;
+}
+
+export function clerkUserProjectionSourceFromBackendUser(
+  user: ClerkBackendUser,
+): ClerkUserProjectionSource {
+  return {
+    kind: 'upsert',
+    type: 'user.updated',
+    authUserId: user.id,
+    email: verifiedPrimaryEmail(
+      user.primaryEmailAddressId,
+      backendEmailAddresses(user.emailAddresses),
+    ),
+    clerkUserUpdatedAt: dateFromClerkTimestamp(user.updatedAt),
+  };
+}
+
+export function clerkUserDeletionProjectionSource(
+  authUserId: string,
+  clerkDeletedAt = new Date(),
+): ClerkUserProjectionSource {
+  if (authUserId.trim() === '') {
+    throw new Error('Cannot tombstone a Clerk user without an id');
+  }
+  return {
+    kind: 'deleted',
+    type: 'user.deleted',
+    authUserId,
+    clerkDeletedAt,
+  };
+}
+
+function projectedApplyResult(
+  source: ClerkUserProjectionSource,
+  user: LocalUserProjection,
+): ClerkUserProjectionApplyResult {
+  if (source.kind === 'deleted') {
+    return user.clerkDeletedAt === null ? 'updated' : 'skipped_deleted_user';
+  }
+
+  if (user.clerkDeletedAt !== null) {
+    return 'skipped_deleted_user';
+  }
+
+  if (
+    user.clerkUserUpdatedAt !== null &&
+    source.clerkUserUpdatedAt.getTime() < user.clerkUserUpdatedAt.getTime()
+  ) {
+    return 'ignored';
+  }
+
+  return 'updated';
+}
+
+export async function applyClerkUserProjectionSource(
+  source: ClerkUserProjectionSource,
+  deps: { db: UserProjectionDb; logger: Pick<Logger, 'info' | 'warn'> },
+): Promise<ClerkUserProjectionApplyResult> {
+  const [user] = await deps.db
+    .select({
+      id: users.id,
+      authUserId: users.authUserId,
+      clerkUserUpdatedAt: users.clerkUserUpdatedAt,
+      clerkDeletedAt: users.clerkDeletedAt,
+    })
+    .from(users)
+    .where(eq(users.authUserId, source.authUserId))
+    .limit(1);
+
+  if (!user) {
+    deps.logger.info(
+      { authUserId: source.authUserId, type: source.type },
+      'No local user found for Clerk identity event; skipping projection',
+    );
+    return 'skipped_no_user';
+  }
+
+  if (source.kind === 'deleted') {
+    const [updated] = await deps.db
+      .update(users)
+      .set({
+        email: null,
+        clerkDeletedAt: source.clerkDeletedAt,
+        updatedAt: new Date(),
+      })
+      .where(and(eq(users.id, user.id), isNull(users.clerkDeletedAt)))
+      .returning({ id: users.id });
+
+    if (!updated) {
+      return 'skipped_deleted_user';
+    }
+
+    deps.logger.info(
+      { authUserId: user.authUserId, type: source.type, userId: user.id },
+      'Clerk user deletion tombstone applied',
+    );
+    return 'updated';
+  }
+
+  const projectedResult = projectedApplyResult(source, user);
+  if (projectedResult === 'skipped_deleted_user') {
+    deps.logger.warn(
+      { authUserId: user.authUserId, type: source.type, userId: user.id },
+      'Ignored Clerk identity update for tombstoned local user',
+    );
+    return 'skipped_deleted_user';
+  }
+
+  if (projectedResult === 'ignored') {
+    return 'ignored';
+  }
+
+  const [updated] = await deps.db
+    .update(users)
+    .set({
+      email: source.email,
+      clerkUserUpdatedAt: source.clerkUserUpdatedAt,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(users.id, user.id),
+        isNull(users.clerkDeletedAt),
+        or(
+          isNull(users.clerkUserUpdatedAt),
+          lte(users.clerkUserUpdatedAt, source.clerkUserUpdatedAt),
+        ),
+      ),
+    )
+    .returning({ id: users.id });
+
+  if (!updated) {
+    return 'ignored';
+  }
+
+  deps.logger.info(
+    { authUserId: user.authUserId, type: source.type, userId: user.id },
+    'Clerk user identity projection applied',
+  );
+  return 'updated';
+}
+
+function isClerkNotFound(error: unknown): boolean {
+  return (
+    error !== null &&
+    typeof error === 'object' &&
+    'status' in error &&
+    (error as { status?: unknown }).status === 404
+  );
+}
+
+export type ClerkUserIdentityReconciliationResult = {
+  checked: number;
+  updated: number;
+  tombstoned: number;
+  wouldUpdate: number;
+  wouldTombstone: number;
+  skipped: number;
+  ignored: number;
+  failed: number;
+  nextCursor: string | null;
+};
+
+export async function reconcileClerkUserIdentities({
+  apply,
+  clerkClient,
+  db,
+  limit = 100,
+  logger,
+  startingAfterAuthUserId,
+}: {
+  apply: boolean;
+  clerkClient: ClerkUserIdentityClient;
+  db: UserProjectionDb;
+  limit?: number;
+  logger: Pick<Logger, 'error' | 'info' | 'warn'>;
+  startingAfterAuthUserId?: string;
+}): Promise<ClerkUserIdentityReconciliationResult> {
+  const batchLimit = Math.max(1, Math.min(Math.trunc(limit), 100));
+  const localUsers = startingAfterAuthUserId
+    ? await db
+        .select({
+          id: users.id,
+          authUserId: users.authUserId,
+          clerkUserUpdatedAt: users.clerkUserUpdatedAt,
+          clerkDeletedAt: users.clerkDeletedAt,
+        })
+        .from(users)
+        .where(gt(users.authUserId, startingAfterAuthUserId))
+        .orderBy(asc(users.authUserId))
+        .limit(batchLimit + 1)
+    : await db
+        .select({
+          id: users.id,
+          authUserId: users.authUserId,
+          clerkUserUpdatedAt: users.clerkUserUpdatedAt,
+          clerkDeletedAt: users.clerkDeletedAt,
+        })
+        .from(users)
+        .orderBy(asc(users.authUserId))
+        .limit(batchLimit + 1);
+  const batch = localUsers.slice(0, batchLimit);
+  const totals: ClerkUserIdentityReconciliationResult = {
+    checked: 0,
+    updated: 0,
+    tombstoned: 0,
+    wouldUpdate: 0,
+    wouldTombstone: 0,
+    skipped: 0,
+    ignored: 0,
+    failed: 0,
+    nextCursor:
+      localUsers.length > batchLimit
+        ? (batch.at(-1)?.authUserId ?? null)
+        : null,
+  };
+
+  for (const localUser of batch) {
+    totals.checked += 1;
+    try {
+      let source: ClerkUserProjectionSource;
+      try {
+        source = clerkUserProjectionSourceFromBackendUser(
+          await clerkClient.users.getUser(localUser.authUserId),
+        );
+      } catch (error) {
+        if (!isClerkNotFound(error)) {
+          throw error;
+        }
+        source = clerkUserDeletionProjectionSource(localUser.authUserId);
+      }
+
+      const result = apply
+        ? await applyClerkUserProjectionSource(source, { db, logger })
+        : projectedApplyResult(source, localUser);
+      if (result === 'updated') {
+        if (source.kind === 'deleted') {
+          totals[apply ? 'tombstoned' : 'wouldTombstone'] += 1;
+        } else {
+          totals[apply ? 'updated' : 'wouldUpdate'] += 1;
+        }
+      } else if (result === 'ignored') {
+        totals.ignored += 1;
+      } else {
+        totals.skipped += 1;
+      }
+    } catch (error) {
+      totals.failed += 1;
+      logger.error(
+        { authUserId: localUser.authUserId, error },
+        'Failed to reconcile Clerk user identity',
+      );
+    }
+  }
+
+  return totals;
+}

--- a/src/features/billing/clerk-billing/reconciliation.ts
+++ b/src/features/billing/clerk-billing/reconciliation.ts
@@ -3,6 +3,12 @@ import type { Logger } from '@/lib/logging/logger';
 import type { WebhookEvent } from '@clerk/nextjs/webhooks';
 
 import {
+  applyClerkUserProjectionSource,
+  clerkUserProjectionSourceFromWebhook,
+  type ClerkUserProjectionApplyResult,
+  type ClerkUserProjectionSource,
+} from '@/features/auth/clerk-user-projection';
+import {
   clerkBillingSourceFromBackendSubscription,
   clerkBillingSourceFromWebhook,
   projectClerkBillingSource,
@@ -51,10 +57,18 @@ export type ClerkBillingApplyResult =
   | 'skipped_no_user'
   | 'ignored';
 
+type ClerkWebhookProjectionSource =
+  | { kind: 'billing'; source: ClerkBillingProjectionSource }
+  | { kind: 'user'; source: ClerkUserProjectionSource };
+
+type ClerkWebhookApplyResult =
+  | ClerkBillingApplyResult
+  | ClerkUserProjectionApplyResult;
+
 export type ApplyVerifiedClerkBillingEventResult =
   | { status: 'duplicate' }
   | { status: 'in_flight'; retryAfterSeconds: number }
-  | { status: 'inserted'; result: ClerkBillingApplyResult };
+  | { status: 'inserted'; result: ClerkWebhookApplyResult };
 
 type ClerkWebhookClaimResult =
   | { outcome: 'claimed'; claimToken: string }
@@ -184,7 +198,7 @@ async function finalizeClerkWebhookEvent(
     event: WebhookEvent;
     eventId: string;
     claimToken: string;
-    refreshedSource: ClerkBillingProjectionSource | null;
+    projectionSource: ClerkWebhookProjectionSource | null;
   },
   deps: ApplyVerifiedClerkBillingEventDeps,
 ): Promise<ApplyVerifiedClerkBillingEventResult> {
@@ -227,21 +241,32 @@ async function finalizeClerkWebhookEvent(
       return { status: 'duplicate' };
     }
 
-    if (args.refreshedSource === null) {
+    if (args.projectionSource === null) {
       deps.logger.debug(
         { type: args.event.type },
-        'Ignored non-billing Clerk webhook event',
+        'Ignored unsupported Clerk webhook event',
       );
       return { status: 'inserted', result: 'ignored' };
     }
 
-    const result = await applyClerkBillingSource(args.refreshedSource, {
-      ...deps,
-      db: tx,
-    });
-    if (result === 'skipped_no_user') {
-      throw new Error('No local user found for Clerk Billing payer');
+    if (args.projectionSource.kind === 'billing') {
+      const result = await applyClerkBillingSource(
+        args.projectionSource.source,
+        {
+          ...deps,
+          db: tx,
+        },
+      );
+      if (result === 'skipped_no_user') {
+        throw new Error('No local user found for Clerk Billing payer');
+      }
+      return { status: 'inserted', result };
     }
+
+    const result = await applyClerkUserProjectionSource(
+      args.projectionSource.source,
+      { ...deps, db: tx },
+    );
     return { status: 'inserted', result };
   });
 }
@@ -357,16 +382,25 @@ export async function applyVerifiedClerkBillingEvent(
     }
 
     claimToken = claim.claimToken;
-    const source = clerkBillingSourceFromWebhook(event);
-    const refreshedSource =
-      source === null ? null : await refreshClerkBillingSource(source, deps);
+    const billingSource = clerkBillingSourceFromWebhook(event);
+    const userSource = billingSource
+      ? null
+      : clerkUserProjectionSourceFromWebhook(event);
+    const projectionSource: ClerkWebhookProjectionSource | null = billingSource
+      ? {
+          kind: 'billing',
+          source: await refreshClerkBillingSource(billingSource, deps),
+        }
+      : userSource
+        ? { kind: 'user', source: userSource }
+        : null;
 
     return await finalizeClerkWebhookEvent(
       {
         event,
         eventId,
         claimToken,
-        refreshedSource,
+        projectionSource,
       },
       deps,
     );

--- a/src/features/lesson-content/generate-module-lessons.types.ts
+++ b/src/features/lesson-content/generate-module-lessons.types.ts
@@ -40,7 +40,7 @@ export type GenerateModuleLessonsResult =
       readonly limit: number;
     }
   | { readonly kind: 'success'; readonly durationMs: number }
-  | { readonly kind: 'failed'; readonly message: string };
+  | { readonly kind: 'failed' };
 
 export type ModuleLessonGenerationWorkResult = Exclude<
   GenerateModuleLessonsResult,

--- a/src/features/lesson-content/run-module-lesson-generation-work.ts
+++ b/src/features/lesson-content/run-module-lesson-generation-work.ts
@@ -12,7 +12,6 @@ import {
   resolveTimeoutConfig,
   setupAbortAndTimeout,
 } from '@/features/ai/orchestrator/timeout-lifecycle';
-import { ParserError } from '@/features/ai/parser';
 import { safeNormalizeUsage } from '@/features/ai/usage';
 import {
   type LessonGenerationQuotaWorkResult,
@@ -34,17 +33,7 @@ import { logger } from '@/lib/logging/logger';
 import { db as serviceRoleDb } from '@supabase/service-role';
 
 type LessonQuotaConsumed = { durationMs: number };
-type LessonQuotaReverted = { kind: 'failed'; message: string };
-
-function errorToPersistedMessage(error: unknown): string {
-  if (error instanceof ParserError) {
-    return error.message;
-  }
-  if (error instanceof Error) {
-    return error.message;
-  }
-  return String(error);
-}
+type LessonQuotaReverted = { kind: 'failed' };
 
 /**
  * Provider + quota + persist after a successful CAS claim. Safe for workflow replay
@@ -177,7 +166,6 @@ export async function runModuleLessonGenerationWork(
             },
           };
         } catch (error) {
-          const message = errorToPersistedMessage(error);
           logger.warn(
             { err: error, planId: params.planId, moduleId: params.moduleId },
             'Module lesson batch generation failed',
@@ -188,7 +176,6 @@ export async function runModuleLessonGenerationWork(
               userId: params.userId,
               planId: params.planId,
               moduleId: params.moduleId,
-              message,
               now: nowFn,
             });
           } catch (persistErr) {
@@ -205,7 +192,7 @@ export async function runModuleLessonGenerationWork(
 
           return {
             disposition: 'revert',
-            value: { kind: 'failed' as const, message },
+            value: { kind: 'failed' as const },
           };
         } finally {
           if (lifecycle) {
@@ -219,7 +206,6 @@ export async function runModuleLessonGenerationWork(
       },
     });
   } catch (error) {
-    const message = errorToPersistedMessage(error);
     try {
       await revertModuleLessonGeneratingToNotGenerated(serverDbClient, {
         userId: params.userId,
@@ -244,7 +230,7 @@ export async function runModuleLessonGenerationWork(
       },
       'Module lesson quota reservation failed',
     );
-    return { kind: 'failed', message };
+    return { kind: 'failed' };
   }
 
   if (!quotaResult.ok) {
@@ -286,5 +272,5 @@ export async function runModuleLessonGenerationWork(
     );
   }
 
-  return { kind: 'failed', message: quotaResult.value.message };
+  return { kind: 'failed' };
 }

--- a/src/features/lesson-content/workflows/module-lesson-generation.types.ts
+++ b/src/features/lesson-content/workflows/module-lesson-generation.types.ts
@@ -33,10 +33,7 @@ export type ModuleLessonWorkflowResult =
       readonly kind: 'success';
       readonly durationMs: number;
     })
-  | (ModuleLessonWorkflowRunResultBase & {
-      readonly kind: 'failed';
-      readonly message: string;
-    })
+  | (ModuleLessonWorkflowRunResultBase & { readonly kind: 'failed' })
   | (ModuleLessonWorkflowRunResultBase & {
       readonly kind: 'quota_denied';
       readonly currentCount: number;

--- a/src/features/plans/read-projection/module-detail.ts
+++ b/src/features/plans/read-projection/module-detail.ts
@@ -145,7 +145,7 @@ export function buildModuleDetailReadModel(
       startedAt: rows.module.lessonGenerationStartedAt,
       completedAt: rows.module.lessonGenerationCompletedAt,
       failedAt: rows.module.lessonGenerationFailedAt,
-      error: rows.module.lessonGenerationError,
+      error: null,
     },
     tasks,
   };

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -77,6 +77,9 @@ async function ensureUserRecord(
 ): Promise<ActorUser> {
   const existing = await getUserByAuthId(authUserId, dbClient);
   if (existing) {
+    if (existing.clerkDeletedAt !== null) {
+      throw new AuthError('Auth user has been deleted.');
+    }
     return existing;
   }
 
@@ -94,7 +97,14 @@ async function ensureUserRecord(
 
   const email = session.user.email;
   if (!email) {
-    throw new AuthError('Auth user must have an email address.');
+    throw new AuthError(
+      'Auth user must have a verified primary email address.',
+    );
+  }
+
+  const clerkUserUpdatedAt = session.user.clerkUserUpdatedAt;
+  if (!clerkUserUpdatedAt) {
+    throw new AuthError('Auth user timestamp unavailable.');
   }
 
   const actor = await getOrCreateUser(
@@ -102,6 +112,7 @@ async function ensureUserRecord(
       authUserId,
       email,
       name: session.user.name || undefined,
+      clerkUserUpdatedAt,
     },
     dbClient,
   );

--- a/src/lib/auth/server.ts
+++ b/src/lib/auth/server.ts
@@ -4,6 +4,7 @@ export type AuthSessionUser = {
   id: string;
   email?: string | null;
   name?: string;
+  clerkUserUpdatedAt?: Date;
 };
 
 export type AuthSessionData = {
@@ -14,6 +15,7 @@ type AuthProviderUser = {
   id: string;
   email: string | null;
   name?: string;
+  clerkUserUpdatedAt: Date;
 };
 
 type AuthSessionResult = {
@@ -35,12 +37,13 @@ function getClerkPrimaryEmail(
 ): string | null {
   if (!user) return null;
 
-  const primaryEmail =
-    user.emailAddresses.find(
-      (email) => email.id === user.primaryEmailAddressId,
-    ) ?? user.emailAddresses[0];
+  const primaryEmail = user.emailAddresses.find(
+    (email) => email.id === user.primaryEmailAddressId,
+  );
 
-  return primaryEmail?.emailAddress ?? null;
+  return primaryEmail?.verification?.status === 'verified'
+    ? primaryEmail.emailAddress
+    : null;
 }
 
 /**
@@ -71,6 +74,7 @@ async function getCurrentAuthUserSafe(options?: {
       id: user.id,
       email: getClerkPrimaryEmail(user),
       name: getClerkUserDisplayName(user),
+      clerkUserUpdatedAt: new Date(user.updatedAt),
     };
   } catch (error) {
     if (options?.strict) {
@@ -90,6 +94,7 @@ export const auth = {
               id: authUser.id,
               email: authUser.email,
               name: authUser.name,
+              clerkUserUpdatedAt: authUser.clerkUserUpdatedAt,
             },
           }
         : null,

--- a/src/lib/config/env/shared.ts
+++ b/src/lib/config/env/shared.ts
@@ -280,6 +280,28 @@ export function assertHostedDeployForbiddenFlags(env: EnvSource): void {
   if (!isHostedDeployEnv(env)) {
     return;
   }
+
+  if (parseNodeEnv(env) !== 'production') {
+    throw new EnvValidationError(
+      'NODE_ENV must be production in hosted deploy environments',
+      'NODE_ENV',
+    );
+  }
+
+  if (optionalEnvFrom(env, 'VITEST_WORKER_ID')) {
+    throw new EnvValidationError(
+      'VITEST_WORKER_ID cannot be set in hosted deploy environments',
+      'VITEST_WORKER_ID',
+    );
+  }
+
+  if (optionalEnvFrom(env, 'DEV_AUTH_USER_ID')) {
+    throw new EnvValidationError(
+      'DEV_AUTH_USER_ID cannot be set in hosted deploy environments',
+      'DEV_AUTH_USER_ID',
+    );
+  }
+
   const localProductTestingEnvEnabled = toBoolean(
     optionalEnvFrom(env, 'LOCAL_PRODUCT_TESTING'),
     false,

--- a/src/lib/db/queries/email-delivery-recipients.ts
+++ b/src/lib/db/queries/email-delivery-recipients.ts
@@ -73,10 +73,9 @@ export async function listEmailDeliveryRecipients(args: {
     rows.length > batchSize ? (page[page.length - 1]?.userId ?? null) : null;
 
   return {
-    recipients: page.map((row) => ({
-      userId: row.userId,
-      email: row.email,
-    })),
+    recipients: page.flatMap((row) =>
+      row.email === null ? [] : [{ userId: row.userId, email: row.email }],
+    ),
     nextCursor,
   };
 }

--- a/src/lib/db/queries/email-notification-deliveries.ts
+++ b/src/lib/db/queries/email-notification-deliveries.ts
@@ -48,10 +48,15 @@ function claimSnapshotPredicates(existing: {
   ] as const;
 }
 
-function shouldUseRecomputedRequest(failureClass: string | null): boolean {
+function shouldUseRecomputedRequest(
+  failureClass: string | null,
+  previousRequest: PersistedProviderRequest | null,
+  nextRequest: PersistedProviderRequest,
+): boolean {
   return (
     failureClass === 'provider_configuration' ||
-    failureClass === 'provider_recipient_invalid'
+    failureClass === 'provider_recipient_invalid' ||
+    (previousRequest !== null && previousRequest.to !== nextRequest.to)
   );
 }
 
@@ -172,9 +177,10 @@ async function readCurrentClaimResult(
  * Atomically claim a delivery row for send. Terminal sent/skipped/manual_review
  * is final. Failed rows and expired pending leases can be reclaimed only with
  * their persisted request, except definitively rejected configuration or
- * recipient rows, which accept the recomputed request during recovery. Fresh
- * pending leases return in_flight. Ambiguous pending older than the provider
- * window becomes manual_review.
+ * recipient rows and rows whose recipient changed, which accept the
+ * recomputed request during recovery. Fresh pending leases return in_flight.
+ * An expired pending lease whose recipient changed, or any pending delivery
+ * older than the provider window, becomes manual_review.
  */
 export async function claimEmailNotificationDelivery(
   args: {
@@ -269,6 +275,8 @@ export async function claimEmailNotificationDelivery(
     const previousRequest = asProviderRequest(existing.providerRequest);
     const useRecomputedRequest = shouldUseRecomputedRequest(
       existing.failureClass,
+      previousRequest,
+      args.providerRequest,
     );
     const requestForRetry = useRecomputedRequest
       ? args.providerRequest
@@ -325,15 +333,23 @@ export async function claimEmailNotificationDelivery(
       return { outcome: 'in_flight', status: 'pending' };
     }
 
+    const storedRequest = asProviderRequest(existing.providerRequest);
+    if (!storedRequest) {
+      throw new Error('Expired pending delivery missing provider request');
+    }
+
     // Measure ambiguity from first claim time; reclaim must not reset the window.
     const ambiguityStartedAt = existing.createdAt;
     const ageMs = now.getTime() - ambiguityStartedAt.getTime();
-    if (ageMs > EMAIL_PROVIDER_IDEMPOTENCY_WINDOW_MS) {
+    const recipientChanged = storedRequest.to !== args.providerRequest.to;
+    if (recipientChanged || ageMs > EMAIL_PROVIDER_IDEMPOTENCY_WINDOW_MS) {
       const reviewed = await dbClient
         .update(emailNotificationDeliveries)
         .set({
           status: 'manual_review',
-          failureClass: 'provider_acceptance_ambiguous',
+          failureClass: recipientChanged
+            ? 'recipient_changed_since_claim'
+            : 'provider_acceptance_ambiguous',
           claimToken: null,
           claimExpiresAt: null,
           updatedAt: now,
@@ -351,11 +367,6 @@ export async function claimEmailNotificationDelivery(
         return { outcome: 'manual_review', deliveryId: reviewed[0].id };
       }
       return readCurrentClaimResult(existing.id, dbClient);
-    }
-
-    const storedRequest = asProviderRequest(existing.providerRequest);
-    if (!storedRequest) {
-      throw new Error('Expired pending delivery missing provider request');
     }
 
     const reclaimed = await dbClient

--- a/src/lib/db/queries/module-lesson-generation.ts
+++ b/src/lib/db/queries/module-lesson-generation.ts
@@ -16,7 +16,6 @@ import {
 import { fetchModuleTaskMetricsRows } from '@/lib/db/queries/helpers/task-relations-helpers';
 import { ModuleLessonGenerationMetadataSchema } from '@/shared/schemas/lesson-content.schemas';
 import { learningPlans, modules, tasks } from '@supabase/schema';
-import { MAX_MODULE_LESSON_GENERATION_ERROR_LENGTH } from '@supabase/schema/constants';
 import { and, asc, eq, inArray, sql, type InferSelectModel } from 'drizzle-orm';
 
 type GenerationDb = Pick<
@@ -170,10 +169,6 @@ type ModuleLessonWorkflowClaimMetadata = {
   readonly runId: string;
   readonly startedAt: string;
 };
-
-function truncateGenerationError(message: string): string {
-  return message.slice(0, MAX_MODULE_LESSON_GENERATION_ERROR_LENGTH);
-}
 
 function assertParsedTasksMatchCurrentTaskRows(
   parsed: ModuleLessonBatchProviderOutput,
@@ -485,7 +480,6 @@ export type CommitModuleLessonGenerationFailureInput = {
   readonly userId: string;
   readonly planId: string;
   readonly moduleId: string;
-  readonly message: string;
   readonly now?: () => Date;
 };
 
@@ -508,7 +502,7 @@ export async function commitModuleLessonGenerationFailure(
       .set({
         lessonGenerationStatus: 'failed',
         lessonGenerationFailedAt: failedAt,
-        lessonGenerationError: truncateGenerationError(input.message),
+        lessonGenerationError: null,
         lessonGenerationCompletedAt: null,
       })
       .where(

--- a/src/lib/db/queries/types/users.types.ts
+++ b/src/lib/db/queries/types/users.types.ts
@@ -20,7 +20,7 @@ type DbUserInsert = InferInsertModel<typeof users>;
 /** Input data for createUser (authUserId, email, optional name). */
 export type CreateUserData = Pick<
   DbUserInsert,
-  'authUserId' | 'email' | 'name'
+  'authUserId' | 'email' | 'name' | 'clerkUserUpdatedAt'
 >;
 
 /** RLS-enforced database client for user queries. */

--- a/src/lib/db/queries/users.ts
+++ b/src/lib/db/queries/users.ts
@@ -46,7 +46,7 @@ function hasCoreIdentityFields(maybeUser: Partial<ActorUser>): boolean {
   return (
     typeof maybeUser.id === 'string' &&
     typeof maybeUser.authUserId === 'string' &&
-    typeof maybeUser.email === 'string'
+    (typeof maybeUser.email === 'string' || maybeUser.email === null)
   );
 }
 
@@ -190,6 +190,7 @@ export async function createUser(
     authUserId: userData.authUserId,
     email: userData.email,
     name: userData.name,
+    clerkUserUpdatedAt: userData.clerkUserUpdatedAt,
   };
 
   const result = await client.insert(users).values(insertData).returning();
@@ -212,6 +213,7 @@ export async function getOrCreateUser(
       authUserId: userData.authUserId,
       email: userData.email,
       name: userData.name,
+      clerkUserUpdatedAt: userData.clerkUserUpdatedAt,
     })
     .onConflictDoNothing({ target: users.authUserId })
     .returning();

--- a/supabase/migrations/20260811100000_clear_module_lesson_generation_errors.sql
+++ b/supabase/migrations/20260811100000_clear_module_lesson_generation_errors.sql
@@ -1,0 +1,3 @@
+UPDATE "modules"
+SET "lesson_generation_error" = NULL
+WHERE "lesson_generation_error" IS NOT NULL;

--- a/supabase/migrations/20260811100100_add_clerk_user_identity_projection.sql
+++ b/supabase/migrations/20260811100100_add_clerk_user_identity_projection.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "users"
+ALTER COLUMN "email" DROP NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "users"
+ADD COLUMN "clerk_user_updated_at" timestamp with time zone;
+--> statement-breakpoint
+ALTER TABLE "users"
+ADD COLUMN "clerk_deleted_at" timestamp with time zone;

--- a/supabase/migrations/20260811100200_enforce_resolved_email_delivery_payload_minimization.sql
+++ b/supabase/migrations/20260811100200_enforce_resolved_email_delivery_payload_minimization.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "email_notification_deliveries"
+ADD CONSTRAINT "email_notification_deliveries_resolved_provider_request_null"
+CHECK (
+  "status" NOT IN ('sent', 'skipped')
+  OR "provider_request" IS NULL
+) NOT VALID;

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -330,6 +330,27 @@
       "when": 1785859200000,
       "tag": "20260804160000_revoke_task_progress_delete",
       "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "7",
+      "when": 1786442400000,
+      "tag": "20260811100000_clear_module_lesson_generation_errors",
+      "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1786442460000,
+      "tag": "20260811100100_add_clerk_user_identity_projection",
+      "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "7",
+      "when": 1786442520000,
+      "tag": "20260811100200_enforce_resolved_email_delivery_payload_minimization",
+      "breakpoints": true
     }
   ]
 }

--- a/supabase/schema/tables/email-notification-deliveries.ts
+++ b/supabase/schema/tables/email-notification-deliveries.ts
@@ -77,6 +77,10 @@ export const emailNotificationDeliveries = pgTable(
         AND ${table.providerRequest} IS NOT NULL
       )`,
     ),
+    check(
+      'email_notification_deliveries_resolved_provider_request_null',
+      sql`${table.status} NOT IN ('sent', 'skipped') OR ${table.providerRequest} IS NULL`,
+    ),
     pgPolicy('email_notification_deliveries_deny_all', {
       as: 'restrictive',
       for: 'all',

--- a/supabase/schema/tables/tasks.ts
+++ b/supabase/schema/tables/tasks.ts
@@ -311,7 +311,8 @@ export const taskProgress = pgTable(
       `,
       }),
 
-      // Users can delete only their own progress
+      // Defense in depth only: authenticated DELETE is revoked at the table level;
+      // this ownership policy remains inert unless DELETE is deliberately reintroduced.
       pgPolicy('task_progress_delete_own', {
         for: 'delete',
         to: 'authenticated',

--- a/supabase/schema/tables/users.ts
+++ b/supabase/schema/tables/users.ts
@@ -19,7 +19,11 @@ export const users = pgTable(
   {
     id: uuid('id').primaryKey().defaultRandom(),
     authUserId: text('auth_user_id').notNull().unique(),
-    email: text('email').notNull().unique(),
+    email: text('email').unique(),
+    clerkUserUpdatedAt: timestamp('clerk_user_updated_at', {
+      withTimezone: true,
+    }),
+    clerkDeletedAt: timestamp('clerk_deleted_at', { withTimezone: true }),
     name: text('name'),
     subscriptionTier: subscriptionTier('subscription_tier')
       .notNull()

--- a/tests/fixtures/profile.ts
+++ b/tests/fixtures/profile.ts
@@ -5,7 +5,7 @@
 interface ProfileFixture {
   id: string;
   name: string;
-  email: string;
+  email: string | null;
   subscriptionTier: string;
   subscriptionStatus: string;
   createdAt: string;

--- a/tests/fixtures/users.ts
+++ b/tests/fixtures/users.ts
@@ -99,6 +99,8 @@ export function buildUserFixture(
     id: `user_${randomSuffix()}`,
     authUserId: `auth_test_${randomSuffix()}`,
     email: `test-${randomSuffix()}@example.test`,
+    clerkUserUpdatedAt: null,
+    clerkDeletedAt: null,
     name: null,
     subscriptionTier: 'free',
     ...resolveSubscriptionLifecycle({

--- a/tests/helpers/mock-server-auth.ts
+++ b/tests/helpers/mock-server-auth.ts
@@ -6,13 +6,20 @@ export type MockServerSessionUser =
       id: string;
       email?: string;
       name?: string;
+      clerkUserUpdatedAt?: Date;
     };
 
 export function mockServerSession(
   getSession: ReturnType<typeof vi.fn>,
   user: MockServerSessionUser,
 ): void {
-  const userPayload = typeof user === 'string' ? { id: user } : user;
+  const userPayload =
+    typeof user === 'string'
+      ? { id: user, clerkUserUpdatedAt: new Date('2026-08-05T00:00:00.000Z') }
+      : {
+          clerkUserUpdatedAt: new Date('2026-08-05T00:00:00.000Z'),
+          ...user,
+        };
   getSession.mockResolvedValue({
     data: { user: userPayload },
   });

--- a/tests/integration/api/plans.module-lesson-content.generate.spec.ts
+++ b/tests/integration/api/plans.module-lesson-content.generate.spec.ts
@@ -193,12 +193,30 @@ describe('POST /api/v1/plans/:planId/modules/:moduleId/lesson-content/generate',
     });
   });
 
-  it('maps provider failure to provider_failure state', async () => {
+  it('maps failed generation to a generic provider failure response', async () => {
     const userId = await authenticateTestUser('provider-failure');
     await seedOwnedPlanForLessonContentApi(userId);
+    mockStartModuleLessonGeneration.mockResolvedValue({ kind: 'failed' });
+
+    const { request, context } = createRequest();
+    const response = await POST(request, context);
+    const body = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(body).toEqual({
+      state: 'provider_failure',
+      planId: VALID_PLAN_ID,
+      moduleId: VALID_MODULE_ID,
+      message: 'Lesson generation failed. Please try again.',
+    });
+  });
+
+  it('does not expose workflow startup diagnostics', async () => {
+    const userId = await authenticateTestUser('workflow-start-failure');
+    await seedOwnedPlanForLessonContentApi(userId);
     mockStartModuleLessonGeneration.mockResolvedValue({
-      kind: 'failed',
-      message: 'Provider output was invalid.',
+      kind: 'workflow_start_failed',
+      message: 'internal workflow setup detail',
     });
 
     const { request, context } = createRequest();
@@ -210,8 +228,11 @@ describe('POST /api/v1/plans/:planId/modules/:moduleId/lesson-content/generate',
       state: 'provider_failure',
       planId: VALID_PLAN_ID,
       moduleId: VALID_MODULE_ID,
-      message: 'Provider output was invalid.',
+      message: 'Lesson generation failed. Please try again.',
     });
+    expect(JSON.stringify(body)).not.toContain(
+      'internal workflow setup detail',
+    );
   });
 
   it('maps disabled generation to disabled state', async () => {

--- a/tests/integration/db/clerk-billing-webhook-claims.spec.ts
+++ b/tests/integration/db/clerk-billing-webhook-claims.spec.ts
@@ -29,6 +29,35 @@ function billingEvent(): WebhookEvent {
   } as unknown as WebhookEvent;
 }
 
+function userUpdatedEvent(
+  authUserId: string,
+  email: string,
+  updatedAt: Date,
+): WebhookEvent {
+  return {
+    type: 'user.updated',
+    data: {
+      id: authUserId,
+      updated_at: updatedAt.getTime(),
+      primary_email_address_id: 'email_primary',
+      email_addresses: [
+        {
+          id: 'email_primary',
+          email_address: email,
+          verification: { status: 'verified' },
+        },
+      ],
+    },
+  } as unknown as WebhookEvent;
+}
+
+function userDeletedEvent(authUserId: string): WebhookEvent {
+  return {
+    type: 'user.deleted',
+    data: { id: authUserId },
+  } as unknown as WebhookEvent;
+}
+
 function subscription(
   overrides: Partial<BackendBillingSubscription> = {},
 ): BackendBillingSubscription {
@@ -92,6 +121,184 @@ describe('Clerk billing webhook claims', () => {
         .from(clerkWebhookEventClaims)
         .where(eq(clerkWebhookEventClaims.eventId, 'evt_claim_completed')),
     ).resolves.toEqual([]);
+  });
+
+  it('projects a signed user event once without refreshing Clerk Billing', async () => {
+    const authUserId = buildTestAuthUserId('clerk-identity-webhook');
+    const initialEmail = buildTestEmail(authUserId);
+    const projectedEmail = `projected-${initialEmail}`;
+    const clerkUpdatedAt = new Date('2026-08-11T10:01:00.000Z');
+    await ensureUser({ authUserId, email: initialEmail });
+    const getSubscription = vi.fn();
+    const eventId = `evt_identity_${authUserId}`;
+    const event = userUpdatedEvent(authUserId, projectedEmail, clerkUpdatedAt);
+
+    await expect(
+      applyVerifiedClerkBillingEvent(event, eventId, {
+        clerkClient: {
+          billing: { getUserBillingSubscription: getSubscription },
+        },
+        db,
+        logger: logger(),
+      }),
+    ).resolves.toEqual({ status: 'inserted', result: 'updated' });
+
+    expect(getSubscription).not.toHaveBeenCalled();
+    await expect(
+      db
+        .select({
+          email: users.email,
+          clerkUserUpdatedAt: users.clerkUserUpdatedAt,
+        })
+        .from(users)
+        .where(eq(users.authUserId, authUserId)),
+    ).resolves.toEqual([
+      { email: projectedEmail, clerkUserUpdatedAt: clerkUpdatedAt },
+    ]);
+
+    await expect(
+      applyVerifiedClerkBillingEvent(event, eventId, {
+        clerkClient: {
+          billing: { getUserBillingSubscription: getSubscription },
+        },
+        db,
+        logger: logger(),
+      }),
+    ).resolves.toEqual({ status: 'duplicate' });
+    expect(getSubscription).not.toHaveBeenCalled();
+    await expect(
+      db
+        .select({ eventId: clerkWebhookEvents.eventId })
+        .from(clerkWebhookEvents)
+        .where(eq(clerkWebhookEvents.eventId, eventId)),
+    ).resolves.toEqual([{ eventId }]);
+  });
+
+  it('does not let stale events or updates after deletion restore an identity', async () => {
+    const authUserId = buildTestAuthUserId('clerk-identity-tombstone');
+    const initialEmail = buildTestEmail(authUserId);
+    const newerEmail = `newer-${initialEmail}`;
+    const staleEmail = `stale-${initialEmail}`;
+    const updatedAt = new Date('2026-08-11T10:02:00.000Z');
+    await ensureUser({ authUserId, email: initialEmail });
+
+    await expect(
+      applyVerifiedClerkBillingEvent(
+        userUpdatedEvent(authUserId, newerEmail, updatedAt),
+        `evt_identity_new_${authUserId}`,
+        { db, logger: logger() },
+      ),
+    ).resolves.toEqual({ status: 'inserted', result: 'updated' });
+    await expect(
+      applyVerifiedClerkBillingEvent(
+        userUpdatedEvent(
+          authUserId,
+          staleEmail,
+          new Date(updatedAt.getTime() - 1),
+        ),
+        `evt_identity_stale_${authUserId}`,
+        { db, logger: logger() },
+      ),
+    ).resolves.toEqual({ status: 'inserted', result: 'ignored' });
+    await expect(
+      applyVerifiedClerkBillingEvent(
+        userDeletedEvent(authUserId),
+        `evt_identity_deleted_${authUserId}`,
+        { db, logger: logger() },
+      ),
+    ).resolves.toEqual({ status: 'inserted', result: 'updated' });
+    await expect(
+      applyVerifiedClerkBillingEvent(
+        userUpdatedEvent(
+          authUserId,
+          `late-${initialEmail}`,
+          new Date(updatedAt.getTime() + 1),
+        ),
+        `evt_identity_late_${authUserId}`,
+        { db, logger: logger() },
+      ),
+    ).resolves.toEqual({
+      status: 'inserted',
+      result: 'skipped_deleted_user',
+    });
+
+    await expect(
+      db
+        .select({
+          email: users.email,
+          clerkDeletedAt: users.clerkDeletedAt,
+        })
+        .from(users)
+        .where(eq(users.authUserId, authUserId)),
+    ).resolves.toMatchObject([
+      { email: null, clerkDeletedAt: expect.any(Date) },
+    ]);
+  });
+
+  it('rolls back a conflicting identity email instead of transferring it', async () => {
+    const firstAuthUserId = buildTestAuthUserId('clerk-identity-first');
+    const secondAuthUserId = buildTestAuthUserId('clerk-identity-second');
+    const firstEmail = buildTestEmail(firstAuthUserId);
+    const conflictingEmail = buildTestEmail(secondAuthUserId);
+    await ensureUser({ authUserId: firstAuthUserId, email: firstEmail });
+    await ensureUser({ authUserId: secondAuthUserId, email: conflictingEmail });
+    const eventId = `evt_identity_conflict_${firstAuthUserId}`;
+
+    await expect(
+      applyVerifiedClerkBillingEvent(
+        userUpdatedEvent(
+          firstAuthUserId,
+          conflictingEmail,
+          new Date('2026-08-11T10:04:00.000Z'),
+        ),
+        eventId,
+        { db, logger: logger() },
+      ),
+    ).rejects.toThrow();
+
+    await expect(
+      db
+        .select({ authUserId: users.authUserId, email: users.email })
+        .from(users)
+        .where(eq(users.authUserId, firstAuthUserId)),
+    ).resolves.toEqual([{ authUserId: firstAuthUserId, email: firstEmail }]);
+    await expect(
+      db
+        .select({ authUserId: users.authUserId, email: users.email })
+        .from(users)
+        .where(eq(users.authUserId, secondAuthUserId)),
+    ).resolves.toEqual([
+      { authUserId: secondAuthUserId, email: conflictingEmail },
+    ]);
+    await expect(
+      db
+        .select({ eventId: clerkWebhookEvents.eventId })
+        .from(clerkWebhookEvents)
+        .where(eq(clerkWebhookEvents.eventId, eventId)),
+    ).resolves.toEqual([]);
+  });
+
+  it('acknowledges a lifecycle event that arrives before local provisioning', async () => {
+    const authUserId = buildTestAuthUserId('clerk-identity-missing');
+    const eventId = `evt_identity_missing_${authUserId}`;
+
+    await expect(
+      applyVerifiedClerkBillingEvent(
+        userUpdatedEvent(
+          authUserId,
+          buildTestEmail(authUserId),
+          new Date('2026-08-11T10:03:00.000Z'),
+        ),
+        eventId,
+        { db, logger: logger() },
+      ),
+    ).resolves.toEqual({ status: 'inserted', result: 'skipped_no_user' });
+    await expect(
+      db
+        .select({ eventId: clerkWebhookEvents.eventId })
+        .from(clerkWebhookEvents)
+        .where(eq(clerkWebhookEvents.eventId, eventId)),
+    ).resolves.toEqual([{ eventId }]);
   });
 
   it('allows only one concurrent claimant and one Clerk refresh', async () => {

--- a/tests/integration/db/email-notification-deliveries.spec.ts
+++ b/tests/integration/db/email-notification-deliveries.spec.ts
@@ -7,6 +7,7 @@ import {
   EmailDeliveryLostLeaseError,
   markEmailNotificationDeliveryFailed,
   markEmailNotificationDeliverySent,
+  markEmailNotificationDeliverySkipped,
   summarizeEmailNotificationDeliveriesForRun,
 } from '@/lib/db/queries/email-notification-deliveries';
 import { emailNotificationDeliveries } from '@supabase/schema';
@@ -29,6 +30,32 @@ function providerRequest(
     idempotencyKey: 'user:daily_reminder:2026-07-09',
     ...overrides,
   };
+}
+
+function hasCheckConstraintViolation(
+  err: unknown,
+  constraintName: string,
+): boolean {
+  let current: unknown = err;
+  for (let i = 0; i < 8 && current; i += 1) {
+    if (
+      current !== null &&
+      typeof current === 'object' &&
+      'code' in current &&
+      (current as { code?: unknown }).code === '23514'
+    ) {
+      return true;
+    }
+    if (current instanceof Error) {
+      if (current.message.includes(constraintName)) {
+        return true;
+      }
+      current = current.cause;
+      continue;
+    }
+    break;
+  }
+  return false;
 }
 
 describe('email notification deliveries ledger', () => {
@@ -127,6 +154,110 @@ describe('email notification deliveries ledger', () => {
     expect(row?.providerRequest).toMatchObject(providerRequest());
     expect(row?.attemptCount).toBe(1);
   });
+
+  it('clears resolved delivery payloads while preserving ledger tombstones', async () => {
+    const authUserId = buildTestAuthUserId('email-ledger-resolved-payload');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+    });
+
+    const sent = await claimEmailNotificationDelivery(
+      {
+        userId,
+        category: 'daily_reminder',
+        deliveryKey: '2026-07-09',
+        providerRequest: providerRequest(),
+      },
+      db,
+    );
+    expect(sent.outcome).toBe('claimed');
+    if (sent.outcome !== 'claimed') return;
+
+    await markEmailNotificationDeliverySent(
+      {
+        deliveryId: sent.deliveryId,
+        claimToken: sent.claimToken,
+        providerMessageId: 'msg_resolved',
+      },
+      db,
+    );
+
+    const skipped = await claimEmailNotificationDelivery(
+      {
+        userId,
+        category: 'weekly_summary',
+        deliveryKey: '2026-07-13',
+        providerRequest: providerRequest({
+          idempotencyKey: 'resolved:weekly_summary:2026-07-13',
+        }),
+      },
+      db,
+    );
+    expect(skipped.outcome).toBe('claimed');
+    if (skipped.outcome !== 'claimed') return;
+
+    await markEmailNotificationDeliverySkipped(
+      {
+        deliveryId: skipped.deliveryId,
+        claimToken: skipped.claimToken,
+        failureClass: 'preference_disabled',
+      },
+      db,
+    );
+
+    const rows = await db
+      .select()
+      .from(emailNotificationDeliveries)
+      .where(eq(emailNotificationDeliveries.userId, userId));
+    const sentRow = rows.find((row) => row.id === sent.deliveryId);
+    const skippedRow = rows.find((row) => row.id === skipped.deliveryId);
+
+    expect(sentRow).toMatchObject({
+      status: 'sent',
+      providerRequest: null,
+      claimToken: null,
+      claimExpiresAt: null,
+      attemptCount: 1,
+      providerMessageId: 'msg_resolved',
+    });
+    expect(skippedRow).toMatchObject({
+      status: 'skipped',
+      providerRequest: null,
+      claimToken: null,
+      claimExpiresAt: null,
+      attemptCount: 1,
+      failureClass: 'preference_disabled',
+    });
+  });
+
+  it.each(['sent', 'skipped'] as const)(
+    'rejects provider payloads on %s delivery tombstones',
+    async (status) => {
+      const authUserId = buildTestAuthUserId(
+        `email-ledger-${status}-payload-check`,
+      );
+      const userId = await ensureUser({
+        authUserId,
+        email: buildTestEmail(authUserId),
+      });
+
+      await expect(
+        db.insert(emailNotificationDeliveries).values({
+          userId,
+          category: 'daily_reminder',
+          deliveryKey: `2026-07-09-${status}`,
+          status,
+          providerRequest: providerRequest(),
+        }),
+      ).rejects.toSatisfy((error: unknown) =>
+        hasCheckConstraintViolation(
+          error,
+          'email_notification_deliveries_resolved_provider_request_null',
+        ),
+      );
+    },
+  );
 
   it('allows only one concurrent owner for the same delivery key', async () => {
     const authUserId = buildTestAuthUserId('email-ledger-race');
@@ -323,6 +454,59 @@ describe('email notification deliveries ledger', () => {
     });
   });
 
+  it('rebinds a definitively failed delivery when its recipient changes', async () => {
+    const authUserId = buildTestAuthUserId('email-ledger-recipient-rebind');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+    });
+    const original = providerRequest({
+      to: 'old@example.com',
+      idempotencyKey: 'rebind:daily:2026-07-10',
+    });
+    const first = await claimEmailNotificationDelivery(
+      {
+        userId,
+        category: 'daily_reminder',
+        deliveryKey: '2026-07-10',
+        providerRequest: original,
+      },
+      db,
+    );
+    expect(first.outcome).toBe('claimed');
+    if (first.outcome !== 'claimed') return;
+
+    await markEmailNotificationDeliveryFailed(
+      {
+        deliveryId: first.deliveryId,
+        claimToken: first.claimToken,
+        failureClass: 'provider_rate_limited',
+      },
+      db,
+    );
+
+    const replacement = providerRequest({
+      to: 'new@example.com',
+      idempotencyKey: original.idempotencyKey,
+    });
+    const retried = await claimEmailNotificationDelivery(
+      {
+        userId,
+        category: 'daily_reminder',
+        deliveryKey: '2026-07-10',
+        providerRequest: replacement,
+      },
+      db,
+    );
+
+    expect(retried).toMatchObject({
+      outcome: 'claimed',
+      deliveryId: first.deliveryId,
+      providerRequest: replacement,
+      reusedProviderRequest: false,
+    });
+  });
+
   it('reuses failed requests when optional fields and headers reorder', async () => {
     const authUserId = buildTestAuthUserId('email-ledger-request-order');
     const userId = await ensureUser({
@@ -501,6 +685,64 @@ describe('email notification deliveries ledger', () => {
       .from(emailNotificationDeliveries)
       .where(eq(emailNotificationDeliveries.id, first.deliveryId));
     expect(row?.status).toBe('manual_review');
+  });
+
+  it('moves an expired pending delivery with a changed recipient to manual review', async () => {
+    const authUserId = buildTestAuthUserId('email-ledger-recipient-review');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+    });
+    const claimedAt = new Date('2026-07-01T12:00:00.000Z');
+    const original = providerRequest({
+      to: 'old@example.com',
+      idempotencyKey: 'review:weekly:2026-06-30',
+    });
+    const first = await claimEmailNotificationDelivery(
+      {
+        userId,
+        category: 'weekly_summary',
+        deliveryKey: '2026-06-30',
+        providerRequest: original,
+        now: claimedAt,
+      },
+      db,
+    );
+    expect(first.outcome).toBe('claimed');
+    if (first.outcome !== 'claimed') return;
+
+    const retriedAt = new Date(
+      claimedAt.getTime() + EMAIL_DELIVERY_LEASE_MS + 1,
+    );
+    const result = await claimEmailNotificationDelivery(
+      {
+        userId,
+        category: 'weekly_summary',
+        deliveryKey: '2026-06-30',
+        providerRequest: providerRequest({
+          to: 'new@example.com',
+          idempotencyKey: original.idempotencyKey,
+        }),
+        now: retriedAt,
+      },
+      db,
+    );
+
+    expect(result).toEqual({
+      outcome: 'manual_review',
+      deliveryId: first.deliveryId,
+    });
+    const [row] = await db
+      .select()
+      .from(emailNotificationDeliveries)
+      .where(eq(emailNotificationDeliveries.id, first.deliveryId));
+    expect(row).toMatchObject({
+      status: 'manual_review',
+      failureClass: 'recipient_changed_since_claim',
+      providerRequest: original,
+      claimToken: null,
+      claimExpiresAt: null,
+    });
   });
 
   it('does not reset the ambiguity window when an expired pending lease is reclaimed', async () => {

--- a/tests/integration/db/module-lesson-generation.boundary.spec.ts
+++ b/tests/integration/db/module-lesson-generation.boundary.spec.ts
@@ -392,7 +392,13 @@ describe('module lesson generation boundary (integration)', () => {
       .from(modules)
       .where(eq(modules.id, mod.id));
     expect(modRow?.lessonGenerationStatus).toBe('failed');
-    expect(modRow?.lessonGenerationError).toMatch(/valid JSON/i);
+    expect(modRow?.lessonGenerationError).toBeNull();
+
+    const [ownerVisibleModule] = await rlsDb
+      .select({ lessonGenerationError: modules.lessonGenerationError })
+      .from(modules)
+      .where(eq(modules.id, mod.id));
+    expect(ownerVisibleModule?.lessonGenerationError).toBeNull();
 
     const [taskRow] = await db
       .select({ lessonContent: tasks.lessonContent })
@@ -465,10 +471,7 @@ describe('module lesson generation boundary (integration)', () => {
       { provider: driftingProvider },
     );
 
-    expect(result.kind).toBe('failed');
-    expect(result.kind === 'failed' ? result.message : '').toMatch(
-      /coverage drifted/i,
-    );
+    expect(result).toEqual({ kind: 'failed' });
 
     const [modRow] = await db
       .select()
@@ -721,7 +724,7 @@ describe('module lesson generation boundary (integration)', () => {
       },
     );
 
-    expect(result.kind).toBe('failed');
+    expect(result).toEqual({ kind: 'failed' });
     expect(provider.generateModuleLessonBatch).not.toHaveBeenCalled();
 
     const [modRow] = await db

--- a/tests/mocks/shared/auth-server.ts
+++ b/tests/mocks/shared/auth-server.ts
@@ -5,6 +5,7 @@ type AuthSessionData = {
     id: string;
     email?: string | null;
     name?: string;
+    clerkUserUpdatedAt?: Date;
   } | null;
 };
 
@@ -12,6 +13,7 @@ type AuthProviderUser = {
   id: string;
   email: string | null;
   name?: string;
+  clerkUserUpdatedAt: Date;
 };
 
 type GetSessionResult = { data: AuthSessionData | null };
@@ -26,6 +28,7 @@ const defaultSession: GetSessionResult = {
       id: 'test-auth-user',
       email: 'test@example.com',
       name: 'Test User',
+      clerkUserUpdatedAt: new Date('2026-08-05T00:00:00.000Z'),
     },
   },
 };
@@ -34,6 +37,7 @@ const defaultAuthUser: AuthProviderUser = {
   id: 'test-auth-user',
   email: 'test@example.com',
   name: 'Test User',
+  clerkUserUpdatedAt: new Date('2026-08-05T00:00:00.000Z'),
 };
 
 export const auth: MockAuth = {

--- a/tests/unit/api/auth.spec.ts
+++ b/tests/unit/api/auth.spec.ts
@@ -62,6 +62,22 @@ describe('auth helpers', () => {
     expect(mockGetOrCreateUser).not.toHaveBeenCalled();
   });
 
+  it('requireCurrentUserRecord rejects a tombstoned local user', async () => {
+    const user = buildUserFixture({
+      authUserId: 'auth_deleted',
+      clerkDeletedAt: new Date('2026-08-11T10:02:00.000Z'),
+    });
+
+    setTestUser('auth_deleted');
+    mockGetUserByAuthId.mockResolvedValue(user);
+
+    await expect(requireCurrentUserRecord()).rejects.toThrow(
+      'Auth user has been deleted.',
+    );
+    expect(mockGetSession).not.toHaveBeenCalled();
+    expect(mockGetOrCreateUser).not.toHaveBeenCalled();
+  });
+
   it('requireCurrentUserRecord provisions a missing user from Clerk session data', async () => {
     const created = buildUserFixture({
       id: 'user_created',
@@ -78,6 +94,7 @@ describe('auth helpers', () => {
           id: 'auth_created',
           email: 'created@example.com',
           name: 'Created User',
+          clerkUserUpdatedAt: new Date('2026-08-05T00:00:00.000Z'),
         },
       },
     });
@@ -89,6 +106,7 @@ describe('auth helpers', () => {
         authUserId: 'auth_created',
         email: 'created@example.com',
         name: 'Created User',
+        clerkUserUpdatedAt: new Date('2026-08-05T00:00:00.000Z'),
       },
       undefined,
     );

--- a/tests/unit/architecture/db-migration-workflows.spec.ts
+++ b/tests/unit/architecture/db-migration-workflows.spec.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
@@ -91,10 +91,51 @@ describe('Supabase migration workflows', () => {
       '20260810120000_create_clerk_webhook_event_claims.sql',
     );
     expect(script).toContain(
+      '20260811100100_add_clerk_user_identity_projection.sql',
+    );
+    expect(script).toContain(
+      '20260811100200_enforce_resolved_email_delivery_payload_minimization.sql',
+    );
+    expect(script).not.toContain(
+      '20260811100000_clear_module_lesson_generation_errors.sql',
+    );
+    expect(script).toContain(
       'supabase migration up --linked --include-all --yes',
     );
     expect(script).not.toContain('supabase migration repair');
     expect(script).not.toContain('db query --linked --file');
+  });
+
+  it('keeps authenticated task-progress deletion revoked after the broad grant', () => {
+    const broadGrantMigration =
+      '20260520194501_harden_authenticated_server_owned_writes.sql';
+    const revokeMigration = '20260804160000_revoke_task_progress_delete.sql';
+    const broadGrant = readFileSync(
+      join(MIGRATIONS_DIR, broadGrantMigration),
+      'utf8',
+    );
+    const revoke = readFileSync(join(MIGRATIONS_DIR, revokeMigration), 'utf8');
+
+    expect(broadGrant).toContain(
+      'GRANT INSERT, UPDATE, DELETE ON "task_progress" TO authenticated',
+    );
+    expect(revokeMigration > broadGrantMigration).toBe(true);
+    expect(revoke).toContain(
+      'REVOKE DELETE ON "task_progress" FROM authenticated',
+    );
+
+    const laterMigrationSql = readdirSync(MIGRATIONS_DIR)
+      .filter(
+        (fileName) => fileName.endsWith('.sql') && fileName > revokeMigration,
+      )
+      .map((fileName) => readFileSync(join(MIGRATIONS_DIR, fileName), 'utf8'))
+      .join('\n');
+    expect(laterMigrationSql).not.toMatch(
+      /GRANT\s+(?:[A-Z]+,\s*)*DELETE\s+ON\s+"task_progress"\s+TO\s+authenticated/i,
+    );
+
+    const script = readFileSync(PHASED_MIGRATION_SCRIPT, 'utf8');
+    expect(script).toContain(revokeMigration);
   });
 
   it('repairs claim retention after out-of-order contract migrations', () => {

--- a/tests/unit/components/ModuleLessonsClient.spec.tsx
+++ b/tests/unit/components/ModuleLessonsClient.spec.tsx
@@ -466,27 +466,7 @@ describe('ModuleLessonsClient', () => {
     expect(refreshMock).toHaveBeenCalledTimes(1);
   });
 
-  it('shows failed generation copy from server and retry affordance', () => {
-    renderClient({
-      lessonGeneration: {
-        status: 'failed',
-        startedAt: null,
-        completedAt: null,
-        failedAt: new Date('2025-06-01T00:00:00.000Z'),
-        error: 'Upstream provider timed out.',
-      },
-    });
-
-    expect(screen.getByText('Failed')).toBeInTheDocument();
-    expect(
-      screen.getByText('Upstream provider timed out.'),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: 'Retry lesson generation' }),
-    ).toBeInTheDocument();
-  });
-
-  it('shows fallback failure hint when server error is empty', () => {
+  it('shows a generic failed-generation hint and retry affordance', () => {
     renderClient({
       lessonGeneration: {
         status: 'failed',
@@ -497,11 +477,36 @@ describe('ModuleLessonsClient', () => {
       },
     });
 
+    expect(screen.getByText('Failed')).toBeInTheDocument();
     expect(
       screen.getByText(
         'Generation failed. Retry to create fresh lesson content for this module.',
       ),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Retry lesson generation' }),
+    ).toBeInTheDocument();
+  });
+
+  it('does not render stale server diagnostics when a prior row contains one', () => {
+    renderClient({
+      lessonGeneration: {
+        status: 'failed',
+        startedAt: null,
+        completedAt: null,
+        failedAt: new Date('2025-06-01T00:00:00.000Z'),
+        error: 'Upstream provider timed out.',
+      },
+    });
+
+    expect(
+      screen.getByText(
+        'Generation failed. Retry to create fresh lesson content for this module.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('Upstream provider timed out.'),
+    ).not.toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: 'Retry lesson generation' }),
     ).toBeInTheDocument();

--- a/tests/unit/config/env.spec.ts
+++ b/tests/unit/config/env.spec.ts
@@ -124,14 +124,79 @@ describe('Environment Configuration', () => {
       ).not.toThrow();
     });
 
-    it('rejects local-only flags in hosted deploy environments', () => {
-      expect(() =>
-        assertHostedDeployForbiddenFlags({
-          NODE_ENV: 'production',
+    it.each([
+      {
+        label: 'missing NODE_ENV',
+        env: { VERCEL: '1' },
+        envKey: 'NODE_ENV',
+      },
+      {
+        label: 'blank NODE_ENV',
+        env: { VERCEL: '1', NODE_ENV: ' ' },
+        envKey: 'NODE_ENV',
+      },
+      {
+        label: 'development NODE_ENV',
+        env: { VERCEL: '1', NODE_ENV: 'development' },
+        envKey: 'NODE_ENV',
+      },
+      {
+        label: 'test NODE_ENV',
+        env: { VERCEL: '1', NODE_ENV: 'test' },
+        envKey: 'NODE_ENV',
+      },
+      {
+        label: 'Vitest worker marker',
+        env: {
           VERCEL: '1',
+          NODE_ENV: 'production',
+          VITEST_WORKER_ID: '1',
+        },
+        envKey: 'VITEST_WORKER_ID',
+      },
+      {
+        label: 'development auth identity override',
+        env: {
+          VERCEL: '1',
+          NODE_ENV: 'production',
+          DEV_AUTH_USER_ID: 'user_test',
+        },
+        envKey: 'DEV_AUTH_USER_ID',
+      },
+      {
+        label: 'local product-testing flag',
+        env: {
+          VERCEL: '1',
+          NODE_ENV: 'production',
           LOCAL_PRODUCT_TESTING: 'true',
-        }),
-      ).toThrow(/LOCAL_PRODUCT_TESTING cannot be enabled in production/);
+        },
+        envKey: 'LOCAL_PRODUCT_TESTING',
+      },
+    ])('rejects $label in hosted deploy environments', ({ env, envKey }) => {
+      expect(() => assertHostedDeployForbiddenFlags(env)).toThrow(
+        EnvValidationError,
+      );
+      try {
+        assertHostedDeployForbiddenFlags(env);
+      } catch (error) {
+        expect(error).toMatchObject({ envKey });
+      }
+    });
+
+    it.each([
+      {
+        VERCEL: '1',
+        NODE_ENV: 'production',
+      },
+      {
+        VERCEL: '1',
+        NODE_ENV: 'production',
+        VITEST_WORKER_ID: ' ',
+        DEV_AUTH_USER_ID: '',
+        LOCAL_PRODUCT_TESTING: '0',
+      },
+    ])('allows production-only hosted runtime inputs', (env) => {
+      expect(() => assertHostedDeployForbiddenFlags(env)).not.toThrow();
     });
   });
 

--- a/tests/unit/features/auth/clerk-user-projection.spec.ts
+++ b/tests/unit/features/auth/clerk-user-projection.spec.ts
@@ -1,0 +1,147 @@
+import type { WebhookEvent } from '@clerk/nextjs/webhooks';
+
+import {
+  clerkUserProjectionSourceFromWebhook,
+  reconcileClerkUserIdentities,
+} from '@/features/auth/clerk-user-projection';
+import { describe, expect, it, vi } from 'vitest';
+
+function userUpdatedEvent(
+  emailAddresses: readonly {
+    id: string;
+    email_address: string;
+    verification: { status: string };
+  }[],
+  primaryEmailAddressId: string | null,
+): WebhookEvent {
+  return {
+    type: 'user.updated',
+    data: {
+      id: 'user_identity_fixture',
+      updated_at: new Date('2026-08-11T10:00:00.000Z').getTime(),
+      primary_email_address_id: primaryEmailAddressId,
+      email_addresses: emailAddresses,
+    },
+  } as unknown as WebhookEvent;
+}
+
+function dryRunDb(
+  localUsers: readonly {
+    id: string;
+    authUserId: string;
+    clerkUserUpdatedAt: Date | null;
+    clerkDeletedAt: Date | null;
+  }[],
+) {
+  const limit = vi.fn().mockResolvedValue(localUsers);
+  const orderBy = vi.fn().mockReturnValue({ limit });
+  const where = vi.fn().mockReturnValue({ orderBy });
+  const from = vi.fn().mockReturnValue({ where, orderBy });
+
+  return {
+    select: vi.fn().mockReturnValue({ from }),
+    update: vi.fn(),
+  };
+}
+
+describe('clerkUserProjectionSourceFromWebhook', () => {
+  it('uses only the exact verified primary email', () => {
+    const source = clerkUserProjectionSourceFromWebhook(
+      userUpdatedEvent(
+        [
+          {
+            id: 'primary',
+            email_address: 'primary@example.com',
+            verification: { status: 'unverified' },
+          },
+          {
+            id: 'secondary',
+            email_address: 'secondary@example.com',
+            verification: { status: 'verified' },
+          },
+        ],
+        'primary',
+      ),
+    );
+
+    expect(source).toEqual({
+      kind: 'upsert',
+      type: 'user.updated',
+      authUserId: 'user_identity_fixture',
+      email: null,
+      clerkUserUpdatedAt: new Date('2026-08-11T10:00:00.000Z'),
+    });
+  });
+
+  it('returns a permanent tombstone source for a valid user deletion', () => {
+    const receivedAt = new Date('2026-08-11T10:05:00.000Z');
+    const source = clerkUserProjectionSourceFromWebhook(
+      {
+        type: 'user.deleted',
+        data: { id: 'user_identity_fixture' },
+      } as unknown as WebhookEvent,
+      receivedAt,
+    );
+
+    expect(source).toEqual({
+      kind: 'deleted',
+      type: 'user.deleted',
+      authUserId: 'user_identity_fixture',
+      clerkDeletedAt: receivedAt,
+    });
+  });
+
+  it('dry-runs updates and Clerk 404 tombstones without writing', async () => {
+    const db = dryRunDb([
+      {
+        id: 'local_user',
+        authUserId: 'user_current',
+        clerkUserUpdatedAt: null,
+        clerkDeletedAt: null,
+      },
+      {
+        id: 'local_deleted_user',
+        authUserId: 'user_missing_in_clerk',
+        clerkUserUpdatedAt: null,
+        clerkDeletedAt: null,
+      },
+    ]);
+    const getUser = vi.fn(async (authUserId: string) => {
+      if (authUserId === 'user_missing_in_clerk') {
+        throw { status: 404 };
+      }
+      return {
+        id: authUserId,
+        updatedAt: new Date('2026-08-11T10:10:00.000Z').getTime(),
+        primaryEmailAddressId: 'primary',
+        emailAddresses: [
+          {
+            id: 'primary',
+            emailAddress: 'current@example.com',
+            verification: { status: 'verified' },
+          },
+        ],
+      };
+    });
+
+    await expect(
+      reconcileClerkUserIdentities({
+        apply: false,
+        clerkClient: { users: { getUser } },
+        db: db as never,
+        logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+      }),
+    ).resolves.toEqual({
+      checked: 2,
+      updated: 0,
+      tombstoned: 0,
+      wouldUpdate: 1,
+      wouldTombstone: 1,
+      skipped: 0,
+      ignored: 0,
+      failed: 0,
+      nextCursor: null,
+    });
+    expect(db.update).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/features/plans/read-projection/module-detail.spec.ts
+++ b/tests/unit/features/plans/read-projection/module-detail.spec.ts
@@ -209,6 +209,7 @@ describe('module-detail read projection', () => {
         lessonGenerationStatus: 'ready',
         lessonGenerationStartedAt: BASE,
         lessonGenerationCompletedAt: updatedAt,
+        lessonGenerationError: 'legacy provider diagnostic',
       },
       taskRows: [
         {
@@ -229,6 +230,7 @@ describe('module-detail read projection', () => {
       failedAt: null,
       error: null,
     });
+    expect(JSON.stringify(model)).not.toContain('legacy provider diagnostic');
     expect(model!.module.tasks[0].lessonContent).toEqual(lessonContent);
     expect(model!.module.tasks[0].lessonContentUpdatedAt).toBe(updatedAt);
   });

--- a/tests/unit/settings/profile/ProfileForm.spec.tsx
+++ b/tests/unit/settings/profile/ProfileForm.spec.tsx
@@ -71,7 +71,9 @@ describe('ProfileForm', () => {
     });
 
     expect(screen.getByText(MOCK_PROFILE.name)).toBeInTheDocument();
-    expect(screen.getByText(MOCK_PROFILE.email)).toBeInTheDocument();
+    expect(
+      screen.getByText(MOCK_PROFILE.email ?? 'Unavailable'),
+    ).toBeInTheDocument();
     expect(
       screen.getByText(
         new Date(MOCK_PROFILE.createdAt).toLocaleDateString('en-US', {
@@ -81,6 +83,16 @@ describe('ProfileForm', () => {
         }),
       ),
     ).toBeInTheDocument();
+  });
+
+  it('shows a neutral email placeholder when Clerk has no verified primary email', async () => {
+    mockFetchSuccess(buildProfile({ email: null }));
+
+    render(<ProfileForm />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Unavailable')).toBeInTheDocument();
+    });
   });
 
   it('shows error message when profile fetch fails', async () => {


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication provisioning, Clerk webhook identity semantics, and email idempotency edge cases; incorrect cutover or reconciliation could tombstone users or strand deliveries in manual_review.
> 
> **Overview**
> This PR tightens **security and privacy boundaries** across auth, webhooks, email delivery, and lesson generation, with matching migrations and operator docs.
> 
> **Clerk identity on the existing signed webhook path:** `user.created` / `user.updated` / `user.deleted` now project into `users` (nullable **verified primary only** email, `clerk_user_updated_at`, permanent `clerk_deleted_at`). Billing reconciliation applies user events in the same idempotent ledger flow. First sign-in provisions from Clerk session data; tombstoned users fail closed at `ensureUserRecord`. New **`pnpm clerk:user:reconcile`** supports dry-run/apply repair after lifecycle subscription cutover.
> 
> **Hosted runtime:** Import-time checks on Preview/Staging/Production require `NODE_ENV=production` and reject `VITEST_WORKER_ID`, `DEV_AUTH_USER_ID`, and `LOCAL_PRODUCT_TESTING`. Internal worker docs clarify that only **local** non-prod may omit tokens.
> 
> **Email notification ledger:** `sent`/`skipped` rows must clear `provider_request` (CHECK + write path). Expired pending claims with a **changed recipient** go to `manual_review` instead of silent resend; failed retries can rebind when the recipient changes. Recipient paging skips users without email.
> 
> **Module lesson generation:** Failures no longer persist or return raw provider/parser messages; API and UI use a generic retry message. Contract migration clears historical `lesson_generation_error` after app drain.
> 
> **Deploy / schema:** Expand-phase migrations add identity columns and email payload constraint; deploy checklist adds `task_progress` DELETE revoke attestation and email inventory steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a29b1367e0a4e6c68e140b4ee6fca22bf879f7b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->