### PR TITLE
fix(security): complete I1-I8 hardening

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -281,7 +281,7 @@ jobs:
 
           # Filter to TS/TSX files under src/ or tests/
           FILES=$(echo "${CHANGED_FILES}" | tr ' ' '\n' | grep -E '^(src|tests)/.*\.(ts|tsx)$' || true)
-          COUNT=$(echo "${FILES}" | wc -l | tr -d ' ')
+          COUNT=$(printf '%s\n' "${FILES}" | awk 'NF { count += 1 } END { print count + 0 }')
           echo "Changed candidate files: ${COUNT}"
 
           if [ "${COUNT}" -gt 0 ] && [ "${COUNT}" -le 50 ]; then
@@ -436,7 +436,7 @@ jobs:
           fi
 
           FILES=$(echo "${CHANGED_FILES}" | tr ' ' '\n' | grep -E '^(src|tests)/.*\.(ts|tsx)$' || true)
-          COUNT=$(echo "${FILES}" | wc -l | tr -d ' ')
+          COUNT=$(printf '%s\n' "${FILES}" | awk 'NF { count += 1 } END { print count + 0 }')
           echo "Changed candidate files: ${COUNT}"
 
           read -r -d '' GLOBAL_TRIGGER_PATTERN <<'EOF' || true

--- a/docs/api/error-contract.md
+++ b/docs/api/error-contract.md
@@ -44,6 +44,13 @@ Use these helpers only:
 
 Do not return ad-hoc `Response.json(...)` error payloads from API handlers.
 
+### Completed bulk operations
+
+A completed bulk evaluation returns HTTP `200` with its per-item result array,
+including when every item has an intentional domain outcome such as a conflict
+or not found result. An unexpected execution failure must escape to the
+canonical HTTP `500` response; never synthesize it as an item conflict.
+
 ## Required client parser
 
 Client fetch consumers must parse errors with:

--- a/docs/architecture/clerk-billing-architecture.md
+++ b/docs/architecture/clerk-billing-architecture.md
@@ -84,7 +84,7 @@ Webhook applies refresh from Clerk Billing API (`refreshFromClerk: true`) before
 
 The identity projection is intentionally narrow. `user.created` and `user.updated` use only Clerk's **exact** primary email when its verification status is `verified`; there is no fallback to another address. A missing or unverified primary address stores `NULL`. The provider's `updated_at` timestamp prevents stale deliveries from replacing newer data. A `user.deleted` event clears the email and sets `clerk_deleted_at`; later lifecycle updates cannot resurrect that row.
 
-The event ledger acknowledges lifecycle events for users that do not yet have an Atlaris row as `skipped_no_user`. On the first authenticated use, Atlaris provisions the current Clerk identity instead. A unique-email conflict never transfers an address between local users; the transaction rolls back and Clerk retries the delivery.
+The event ledger acknowledges no-row `user.created` and `user.updated` events as `skipped_no_user`. A no-row `user.deleted` event is left unacknowledged so Clerk can retry it if provisioning races the deletion. On first authenticated use, Atlaris provisions the current Clerk identity instead. A unique-email conflict never transfers an address between local users; the transaction rolls back and Clerk retries the delivery.
 
 For a deliberate one-shot repair after enabling lifecycle subscriptions, the command is dry-run by default:
 

--- a/docs/architecture/email-notification-delivery-runbook.md
+++ b/docs/architecture/email-notification-delivery-runbook.md
@@ -48,11 +48,11 @@ Signed one-click unsubscribe (RFC 8058) at `GET|POST /api/v1/notifications/email
 
 1. Category enabled and `unsubscribeAllOptionalEmails` false (effective prefs).
 2. Flag `email-notification-delivery` on; `RESEND_API_KEY`, `RESEND_FROM`, and a valid `EMAIL_UNSUBSCRIBE_TOKEN_SECRET` are configured; `APP_URL` is production HTTPS.
-3. Recipient has a non-empty email and qualifies for the requested category:
+3. Recipient has a non-empty, current Clerk-projected email and qualifies for the requested category:
    - Daily reminder: no activity today in the user's local time zone and an incomplete plan.
    - Streak reminder: no activity today and activity on each of the prior three local days.
    - Weekly summary: a Monday run and activity on at least one day in the prior week.
-4. Logical run claimed and not stuck (`email_notification_delivery_runs`); ledger row not already terminal (`email_notification_deliveries`).
+4. Logical run claimed and not stuck (`email_notification_delivery_runs`); ledger row not already terminal (`email_notification_deliveries`). Before provider delivery, the worker rechecks the recipient's email/timestamp projection and effective preferences.
 5. Not suppressed by streak reminder in the same daily pass.
 
 ## Schedule and ownership
@@ -87,7 +87,7 @@ The run record is an operational checkpoint. `email_notification_deliveries` rem
 
 ## Payload minimization and inventory
 
-Resolved `sent` and `skipped` ledger rows retain their compact idempotency tombstone but must have `provider_request = NULL`. Pending, retryable failed, and `manual_review` rows retain their request because retry/review correctness still depends on it. There is no age-based email-ledger cleanup policy yet.
+Resolved `sent` and `skipped` ledger rows retain their compact idempotency tombstone but must have `provider_request = NULL`. Contract migration `20260811100300_scrub_resolved_email_delivery_payloads` scrubs historical resolved payloads and validates that invariant. Pending, retryable failed, and `manual_review` rows retain their request because retry/review correctness still depends on it. There is no age-based email-ledger cleanup policy yet: compact tombstones remain until a maximum replay, manual-review, and idempotency period is approved.
 
 Inspect only aggregate state while setting that policy; do not select recipient addresses, content, headers, tokens, or `provider_request`:
 
@@ -103,7 +103,7 @@ GROUP BY status
 ORDER BY status;
 ```
 
-If a `sent` or `skipped` row has a payload, stop before validating the invariant and resolve the row under the approved operator policy. Do not delete its tombstone.
+If a `sent` or `skipped` row has a payload, treat it as an invariant breach and incident. Do not delete its tombstone.
 
 ## Trigger a safe manual run
 
@@ -131,7 +131,7 @@ For a weekly run, use a Monday UTC date and `"runKind":"weekly"`. A `start` requ
 
 `needs_review` means the run observed an isolated recipient error or an ambiguous provider/idempotency outcome. It is intentionally terminal and does not automatically resend.
 
-If an expired pending claim has a different current recipient, the ledger enters `manual_review` and retains the original request. Do not replace or resend it automatically: determine whether the provider may have accepted the original delivery first.
+If an expired pending claim has a different current recipient, or preferences are disabled after a persisted provider request is reclaimed, the ledger enters `manual_review` and retains the original request. A fresh claim with a stale recipient or disabled preference is skipped before provider delivery. Do not replace or resend an ambiguous request automatically: determine whether the provider may have accepted the original delivery first.
 
 1. Inspect the affected ledger rows and resolve the underlying data or provider state.
 2. Confirm no unresolved `manual_review` ledger rows remain for the logical run.

--- a/docs/architecture/email-notification-delivery-runbook.md
+++ b/docs/architecture/email-notification-delivery-runbook.md
@@ -48,11 +48,11 @@ Signed one-click unsubscribe (RFC 8058) at `GET|POST /api/v1/notifications/email
 
 1. Category enabled and `unsubscribeAllOptionalEmails` false (effective prefs).
 2. Flag `email-notification-delivery` on; `RESEND_API_KEY`, `RESEND_FROM`, and a valid `EMAIL_UNSUBSCRIBE_TOKEN_SECRET` are configured; `APP_URL` is production HTTPS.
-3. Recipient has a non-empty, current Clerk-projected email and qualifies for the requested category:
+3. Recipient has a non-empty, current Clerk-projected email and qualifies for the requested category. The Clerk watermark orders lifecycle projections; it does not exclude an otherwise valid existing recipient:
    - Daily reminder: no activity today in the user's local time zone and an incomplete plan.
    - Streak reminder: no activity today and activity on each of the prior three local days.
    - Weekly summary: a Monday run and activity on at least one day in the prior week.
-4. Logical run claimed and not stuck (`email_notification_delivery_runs`); ledger row not already terminal (`email_notification_deliveries`). Before provider delivery, the worker rechecks the recipient's email/timestamp projection and effective preferences.
+4. Logical run claimed and not stuck (`email_notification_delivery_runs`); ledger row not already terminal (`email_notification_deliveries`). Before provider delivery, the worker rechecks the recipient's current email/deletion identity and effective preferences.
 5. Not suppressed by streak reminder in the same daily pass.
 
 ## Schedule and ownership
@@ -131,7 +131,7 @@ For a weekly run, use a Monday UTC date and `"runKind":"weekly"`. A `start` requ
 
 `needs_review` means the run observed an isolated recipient error or an ambiguous provider/idempotency outcome. It is intentionally terminal and does not automatically resend.
 
-If an expired pending claim has a different current recipient, or preferences are disabled after a persisted provider request is reclaimed, the ledger enters `manual_review` and retains the original request. A fresh claim with a stale recipient or disabled preference is skipped before provider delivery. Do not replace or resend an ambiguous request automatically: determine whether the provider may have accepted the original delivery first.
+If an expired pending claim has a different current recipient, or preferences are disabled after an expired pending claim is reclaimed, the ledger enters `manual_review` and retains the original request. A fresh claim or confirmed failed retry with a stale recipient or disabled preference is skipped before provider delivery. Do not replace or resend an ambiguous request automatically: determine whether the provider may have accepted the original delivery first.
 
 1. Inspect the affected ledger rows and resolve the underlying data or provider state.
 2. Confirm no unresolved `manual_review` ledger rows remain for the logical run.

--- a/docs/development/deploy.md
+++ b/docs/development/deploy.md
@@ -28,6 +28,18 @@ Do not deploy the application release before the expand migration is applied. Au
 
 Do not run the contract migration before the new application release is fully rolled out. Older binaries may still read or write the legacy `users` preference columns during rolling deploys.
 
+## Authenticated users INSERT revoke cutover
+
+Migration `20260811100400_revoke_users_authenticated_insert` is intentionally contract-only. The expand runner applies the explicit predeploy set; the confirmed contract phase runs `supabase db push --include-all` after the application rollout. Older binaries provision a first user through the authenticated database role and still need table-level `INSERT`; the new release provisions through the service-role boundary.
+
+Required order:
+
+1. Dispatch the target environment's migration workflow with phase `expand`. The users `INSERT` revoke must not be applied yet.
+2. Deploy the release that uses service-role user provisioning, wait for all old instances to drain, and verify the new release is healthy.
+3. Dispatch phase `contract` with confirmation `post-deploy-health-verified`. This applies the users `INSERT` revoke after the old binary path is no longer serving traffic.
+
+Rolling back before the contract phase preserves the old binary's provisioning path. After the revoke is applied, do not roll back to a binary that provisions through `authenticated`; its first-user insert will fail with a permission error. Roll forward the service-role provisioner instead of restoring the broad grant as an ad hoc rollback step.
+
 ## Legacy Stripe entitlement archive
 
 The expand phase runs `20260706221000_archive_legacy_stripe_entitlements` before the contract phase can drop the legacy Stripe columns. Before contract dispatch, verify every legacy Stripe identity was archived:

--- a/docs/development/deploy.md
+++ b/docs/development/deploy.md
@@ -53,21 +53,13 @@ After deploying a release that includes new Supabase migrations:
 
 1. Before deploying code that needs new schema, manually dispatch the environment workflow's `expand` phase (`staging-db-migrations.yaml` from `develop`, `production-db-migrations.yaml` from `main`).
 2. After rollout health and any migration-specific archive checks pass, dispatch `contract` with confirmation `post-deploy-health-verified`. Do not run `supabase db push --include-all` directly; the confirmed contract phase owns out-of-order/destructive application.
-3. After the expand workflow, attest that authenticated users cannot delete task progress:
+3. Each successful phase runs the read-only effective-privilege attestation automatically. To re-run it against the linked target, use:
 
-```sql
-SELECT version::text
-FROM supabase_migrations.schema_migrations
-WHERE version::text = '20260804160000';
-
-SELECT
-  has_table_privilege('authenticated', 'public.task_progress', 'SELECT') AS can_select,
-  has_table_privilege('authenticated', 'public.task_progress', 'INSERT') AS can_insert,
-  has_table_privilege('authenticated', 'public.task_progress', 'UPDATE') AS can_update,
-  has_table_privilege('authenticated', 'public.task_progress', 'DELETE') AS can_delete;
+```bash
+bash scripts/db/attest-effective-privileges.sh
 ```
 
-The expected result is migration version `20260804160000`, `can_select`, `can_insert`, and `can_update` true, and `can_delete` false.
+It fails closed if browser roles can bypass RLS, if any public application table lacks RLS, if effective table or column grants exceed the client allowlists, if `task_progress` loses its allowed writes, or if client roles can reach service-only tables, security-definer functions, the private schema, or unsafe default table-write grants.
 4. Set worker tokens in the target environment for enabled internal routes:
    - `REGENERATION_WORKER_TOKEN` for regeneration drains
    - `WORKER_HEALTH_TOKEN` for `GET /api/health/worker` operator metrics
@@ -93,7 +85,7 @@ If the migration applied but no cron job exists, enable `pg_cron` in Supabase an
 8. Enable opted-in email notification delivery only after the env and ledger are ready:
    - Confirm `APP_URL` is the canonical https origin for that environment (required for unsubscribe and deeplink URLs; production throws if unset).
    - Configure `RESEND_API_KEY`, `RESEND_FROM`, and `EMAIL_UNSUBSCRIBE_TOKEN_SECRET` (see `emailEnv` in `docs/development/environment.md`).
-   - Apply the email notification deliveries ledger migration and `20260811100200_enforce_resolved_email_delivery_payload_minimization`, then run the non-PII inventory in the email delivery runbook. Do not validate the new check until the inventory reports no historical violations or remediation is approved.
+   - Apply the email notification deliveries ledger migration and `20260811100200_enforce_resolved_email_delivery_payload_minimization` in the expand phase. After rollout health verification, the confirmed contract phase applies `20260811100300_scrub_resolved_email_delivery_payloads` to scrub historical resolved payloads and validate the invariant; then run the non-PII inventory in the email delivery runbook.
    - Enable the Vercel Flag `email-notification-delivery` after a smoke pass. The flag is fail-closed / default disabled.
    - Confirm Vercel Cron and `CRON_SECRET` are configured for production; keep `MAINTENANCE_WORKER_TOKEN` for manual recovery only. See `docs/architecture/internal-worker-routes.md`.
 

--- a/docs/technical-debt.md
+++ b/docs/technical-debt.md
@@ -128,15 +128,16 @@ and UI logic.~~
 
 ~~This remains deferred until a broader resource-taxonomy cleanup is scheduled.~~
 
-## `users` table column-level UPDATE grant
+## `users` table client grants
 
-The migration chain restricts the `authenticated` role to only UPDATE `name`
-and `updated_at` on the `users` table. User-owned preferences live in
-`user_preferences` with their own RLS policies and column-level grants. All
-other `users` columns (billing, system-managed) are only writable by the
-service-role which has BYPASSRLS.
+The migration chain gives the `authenticated` role no direct INSERT access
+to `users` and restricts UPDATE to only `name` and `updated_at`. First-row
+provisioning uses the service role only after the server has read the current
+Clerk session. User-owned preferences live in `user_preferences` with their
+own RLS policies and column-level grants. All other `users` columns
+(billing, system-managed) remain service-role-only.
 
-**Canonical column list:** [`supabase/privileges/users-authenticated-update-columns.ts`](../supabase/privileges/users-authenticated-update-columns.ts) (`USERS_AUTHENTICATED_UPDATE_COLUMNS`). Every other copy must match this module and the migration.
+**Canonical column list:** [`users-authenticated-update-columns.ts`](../supabase/privileges/users-authenticated-update-columns.ts) (`USERS_AUTHENTICATED_UPDATE_COLUMNS`). Every other copy must match this module and the migration.
 
 When adding new user-editable columns to the `users` table, update in lockstep:
 
@@ -145,8 +146,8 @@ When adding new user-editable columns to the `users` table, update in lockstep:
 3. [`tests/helpers/db/rls-bootstrap.ts`](../tests/helpers/db/rls-bootstrap.ts) — `ensureRlsRolesAndPermissions()` (integration helpers that mirror grants after `db:migrate`).
 4. [`tests/helpers/db/bootstrap.ts`](../tests/helpers/db/bootstrap.ts) — `grantRlsPermissions()` (shared with [`tests/setup/testcontainers.ts`](../tests/setup/testcontainers.ts) for ephemeral Postgres).
 
-Unit tests in `tests/unit/db/users-authenticated-update-columns.spec.ts` compare the migration and bootstrap sources against the canonical list.
+Unit tests in `tests/unit/db/users-authenticated-update-columns.spec.ts` compare the migration and bootstrap sources against the canonical list and direct-INSERT revoke.
 
 **CI PR note:** The fast integration job in `.github/workflows/ci-pr.yml` uses the Testcontainers-backed migration bootstrap instead of a `pnpm db:push` shortcut, so PR integration DBs now run through the committed migration path. Keep this aligned with trunk (`ci-trunk.yml`) and the files above when privilege rules change.
 
-Failure to update consumers after changing the allowlist will cause authenticated users to lose `UPDATE` on new columns or leave billing columns writable — caught by security/unit tests and the drift spec.
+Failure to update consumers after changing the allowlist will cause authenticated users to lose `UPDATE` on new columns or leave system columns writable — caught by security/unit tests and the drift spec.

--- a/scripts/db/attest-effective-privileges.sh
+++ b/scripts/db/attest-effective-privileges.sh
@@ -4,4 +4,35 @@ set -euo pipefail
 
 readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
-supabase db query --linked --file "$SCRIPT_DIR/attest-effective-privileges.sql"
+if (( $# > 1 )); then
+  printf 'Usage: %s [expand|contract].\n' "$0" >&2
+  exit 1
+fi
+
+if (( $# == 0 )); then
+  ATTESTATION_PHASE='contract'
+else
+  ATTESTATION_PHASE="$1"
+fi
+readonly ATTESTATION_PHASE
+
+case "$ATTESTATION_PHASE" in
+  expand|contract)
+    ;;
+  *)
+    printf 'Attestation phase must be expand or contract.\n' >&2
+    exit 1
+    ;;
+esac
+
+ATTESTATION_SQL_FILE="$(mktemp)"
+readonly ATTESTATION_SQL_FILE
+trap 'rm -f -- "$ATTESTATION_SQL_FILE"' EXIT
+
+{
+  printf "SELECT set_config('app.atlaris_migration_phase', '%s', false);\n" \
+    "$ATTESTATION_PHASE"
+  cat "$SCRIPT_DIR/attest-effective-privileges.sql"
+} >"$ATTESTATION_SQL_FILE"
+
+supabase db query --linked --file "$ATTESTATION_SQL_FILE"

--- a/scripts/db/attest-effective-privileges.sh
+++ b/scripts/db/attest-effective-privileges.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+supabase db query --linked --file "$SCRIPT_DIR/attest-effective-privileges.sql"

--- a/scripts/db/attest-effective-privileges.sql
+++ b/scripts/db/attest-effective-privileges.sql
@@ -1,0 +1,326 @@
+-- Read-only deployment gate for the privileges actually effective for browser roles.
+DO $$
+DECLARE
+  violation text;
+BEGIN
+  SELECT format('role %I is missing, superuser, or bypasses RLS', expected.role_name)
+    INTO violation
+  FROM (VALUES ('anon'), ('authenticated')) AS expected(role_name)
+  LEFT JOIN pg_roles AS role ON role.rolname = expected.role_name
+  WHERE role.oid IS NULL OR role.rolsuper OR role.rolbypassrls
+  LIMIT 1;
+  IF violation IS NOT NULL THEN
+    RAISE EXCEPTION '%', violation;
+  END IF;
+
+  SELECT format(
+      'permissive policy %I on public.%I includes %I',
+      policy.policyname,
+      policy.tablename,
+      policy_role.role_name
+    )
+    INTO violation
+  FROM pg_policies AS policy
+  CROSS JOIN LATERAL unnest(policy.roles) AS policy_role(role_name)
+  WHERE policy.schemaname = 'public'
+    AND policy.permissive = 'PERMISSIVE'
+    AND lower(policy_role.role_name::text) IN ('public', 'anon')
+  LIMIT 1;
+  IF violation IS NOT NULL THEN
+    RAISE EXCEPTION '%', violation;
+  END IF;
+
+  WITH application_tables AS (
+    SELECT class.oid, class.relname, class.relrowsecurity
+    FROM pg_class AS class
+    JOIN pg_namespace AS namespace ON namespace.oid = class.relnamespace
+    WHERE namespace.nspname = 'public'
+      AND class.relkind IN ('r', 'p')
+      AND NOT EXISTS (
+        SELECT 1
+        FROM pg_depend AS dependency
+        WHERE dependency.classid = 'pg_class'::regclass
+          AND dependency.objid = class.oid
+          AND dependency.deptype = 'e'
+      )
+  )
+  SELECT format('public table %I does not have RLS enabled', relname)
+    INTO violation
+  FROM application_tables
+  WHERE NOT relrowsecurity
+  LIMIT 1;
+  IF violation IS NOT NULL THEN
+    RAISE EXCEPTION '%', violation;
+  END IF;
+
+  WITH application_tables AS (
+    SELECT class.oid, class.relname
+    FROM pg_class AS class
+    JOIN pg_namespace AS namespace ON namespace.oid = class.relnamespace
+    WHERE namespace.nspname = 'public'
+      AND class.relkind IN ('r', 'p')
+      AND NOT EXISTS (
+        SELECT 1
+        FROM pg_depend AS dependency
+        WHERE dependency.classid = 'pg_class'::regclass
+          AND dependency.objid = class.oid
+          AND dependency.deptype = 'e'
+      )
+  ), forbidden_privileges AS (
+    SELECT unnest(
+      ARRAY['INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER']
+    ) AS privilege_type
+  )
+  SELECT format('anon has %s on public.%I', privilege_type, relname)
+    INTO violation
+  FROM application_tables
+  CROSS JOIN forbidden_privileges
+  WHERE has_table_privilege('anon', oid, privilege_type)
+  LIMIT 1;
+  IF violation IS NOT NULL THEN
+    RAISE EXCEPTION '%', violation;
+  END IF;
+
+  WITH required_tables AS (
+    SELECT unnest(
+      ARRAY['ai_usage_events', 'generation_attempts', 'learning_activity_events', 'learning_plans', 'modules', 'plan_schedules', 'resources', 'task_resources', 'tasks', 'usage_metrics']
+    ) AS table_name
+  ), forbidden_privileges AS (
+    SELECT unnest(
+      ARRAY['INSERT', 'UPDATE', 'DELETE']
+    ) AS privilege_type
+  )
+  SELECT format(
+      'authenticated has %s on server-owned public.%I',
+      privilege_type,
+      required_tables.table_name
+    )
+    INTO violation
+  FROM required_tables
+  LEFT JOIN pg_class AS class
+    ON class.relname = required_tables.table_name
+   AND class.relnamespace = 'public'::regnamespace
+  CROSS JOIN forbidden_privileges
+  WHERE class.oid IS NULL
+     OR has_table_privilege('authenticated', class.oid, privilege_type)
+  LIMIT 1;
+  IF violation IS NOT NULL THEN
+    RAISE EXCEPTION '%', violation;
+  END IF;
+
+  -- The legacy Stripe archive is expand-phase-only. Check it when present without
+  -- requiring fresh local schemas to materialize a deliberately phased archive.
+  WITH required_tables AS (
+    SELECT unnest(
+      ARRAY['legacy_stripe_entitlement_archive', 'clerk_webhook_events', 'clerk_webhook_event_claims', 'email_notification_delivery_runs', 'email_notification_deliveries']
+    ) AS table_name
+  ), client_roles AS (
+    SELECT unnest(ARRAY['anon', 'authenticated']) AS role_name
+  ), all_privileges AS (
+    SELECT unnest(
+      ARRAY['SELECT', 'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER']
+    ) AS privilege_type
+  )
+  SELECT format(
+      '%I has %s on service-only public.%I',
+      role_name,
+      privilege_type,
+      required_tables.table_name
+    )
+    INTO violation
+  FROM required_tables
+  LEFT JOIN pg_class AS class
+    ON class.relname = required_tables.table_name
+   AND class.relnamespace = 'public'::regnamespace
+  CROSS JOIN client_roles
+  CROSS JOIN all_privileges
+  WHERE has_table_privilege(role_name, class.oid, privilege_type)
+  LIMIT 1;
+  IF violation IS NOT NULL THEN
+    RAISE EXCEPTION '%', violation;
+  END IF;
+
+  WITH required_tables AS (
+    SELECT unnest(
+      ARRAY['users', 'task_progress', 'user_preferences', 'user_email_notification_settings', 'user_email_notification_preferences']
+    ) AS table_name
+  )
+  SELECT format('authenticated has DELETE on public.%I', required_tables.table_name)
+    INTO violation
+  FROM required_tables
+  LEFT JOIN pg_class AS class
+    ON class.relname = required_tables.table_name
+   AND class.relnamespace = 'public'::regnamespace
+  WHERE class.oid IS NULL
+     OR has_table_privilege('authenticated', class.oid, 'DELETE')
+  LIMIT 1;
+  IF violation IS NOT NULL THEN
+    RAISE EXCEPTION '%', violation;
+  END IF;
+
+  WITH required_privileges AS (
+    SELECT unnest(ARRAY['SELECT', 'INSERT', 'UPDATE']) AS privilege_type
+  )
+  SELECT format('authenticated lacks %s on public.task_progress', privilege_type)
+    INTO violation
+  FROM required_privileges
+  LEFT JOIN pg_class AS class
+    ON class.relname = 'task_progress'
+   AND class.relnamespace = 'public'::regnamespace
+  WHERE class.oid IS NULL
+     OR NOT has_table_privilege('authenticated', class.oid, privilege_type)
+  LIMIT 1;
+  IF violation IS NOT NULL THEN
+    RAISE EXCEPTION '%', violation;
+  END IF;
+
+  WITH client_roles AS (
+    SELECT unnest(ARRAY['anon', 'authenticated']) AS role_name
+  ), forbidden_privileges AS (
+    SELECT unnest(ARRAY['INSERT', 'UPDATE', 'DELETE']) AS privilege_type
+  )
+  SELECT format('%I has %s on public.job_queue', role_name, privilege_type)
+    INTO violation
+  FROM client_roles
+  CROSS JOIN forbidden_privileges
+  LEFT JOIN pg_class AS class
+    ON class.relname = 'job_queue'
+   AND class.relnamespace = 'public'::regnamespace
+  WHERE class.oid IS NULL
+     OR has_table_privilege(role_name, class.oid, privilege_type)
+  LIMIT 1;
+  IF violation IS NOT NULL THEN
+    RAISE EXCEPTION '%', violation;
+  END IF;
+
+  WITH expected_grants AS (
+    SELECT *
+    FROM (VALUES
+      ('users', 'UPDATE', ARRAY['name', 'updated_at']),
+      ('user_preferences', 'INSERT', ARRAY['user_id', 'preferred_ai_model', 'analytics_timezone', 'updated_at']),
+      ('user_preferences', 'UPDATE', ARRAY['preferred_ai_model', 'analytics_timezone', 'updated_at']),
+      ('user_email_notification_settings', 'INSERT', ARRAY['user_id', 'unsubscribe_all_optional_emails', 'updated_at']),
+      ('user_email_notification_settings', 'UPDATE', ARRAY['unsubscribe_all_optional_emails', 'updated_at']),
+      ('user_email_notification_preferences', 'INSERT', ARRAY['user_id', 'category', 'enabled', 'unsubscribed_at', 'updated_at']),
+      ('user_email_notification_preferences', 'UPDATE', ARRAY['enabled', 'unsubscribed_at', 'updated_at'])
+    ) AS expected(table_name, privilege_type, allowed_columns)
+  )
+  SELECT format(
+      'authenticated %s columns are wrong for public.%I (missing %I)',
+      privilege_type,
+      expected_grants.table_name,
+      allowed_column
+    )
+    INTO violation
+  FROM expected_grants
+  CROSS JOIN LATERAL unnest(allowed_columns) AS allowed_column
+  LEFT JOIN information_schema.columns AS column_info
+    ON column_info.table_schema = 'public'
+   AND column_info.table_name = expected_grants.table_name
+   AND column_info.column_name = allowed_column
+  WHERE column_info.column_name IS NULL
+  LIMIT 1;
+  IF violation IS NOT NULL THEN
+    RAISE EXCEPTION '%', violation;
+  END IF;
+
+  WITH expected_grants AS (
+    SELECT *
+    FROM (VALUES
+      ('users', 'UPDATE', ARRAY['name', 'updated_at']),
+      ('user_preferences', 'INSERT', ARRAY['user_id', 'preferred_ai_model', 'analytics_timezone', 'updated_at']),
+      ('user_preferences', 'UPDATE', ARRAY['preferred_ai_model', 'analytics_timezone', 'updated_at']),
+      ('user_email_notification_settings', 'INSERT', ARRAY['user_id', 'unsubscribe_all_optional_emails', 'updated_at']),
+      ('user_email_notification_settings', 'UPDATE', ARRAY['unsubscribe_all_optional_emails', 'updated_at']),
+      ('user_email_notification_preferences', 'INSERT', ARRAY['user_id', 'category', 'enabled', 'unsubscribed_at', 'updated_at']),
+      ('user_email_notification_preferences', 'UPDATE', ARRAY['enabled', 'unsubscribed_at', 'updated_at'])
+    ) AS expected(table_name, privilege_type, allowed_columns)
+  )
+  SELECT format(
+      'authenticated has incorrect %s column privilege on public.%I.%I',
+      privilege_type,
+      expected_grants.table_name,
+      column_info.column_name
+    )
+    INTO violation
+  FROM expected_grants
+  JOIN information_schema.columns AS column_info
+    ON column_info.table_schema = 'public'
+   AND column_info.table_name = expected_grants.table_name
+  WHERE has_column_privilege(
+      'authenticated',
+      format('public.%I', expected_grants.table_name),
+      column_info.column_name,
+      privilege_type
+    ) IS DISTINCT FROM (column_info.column_name = ANY(allowed_columns))
+  LIMIT 1;
+  IF violation IS NOT NULL THEN
+    RAISE EXCEPTION '%', violation;
+  END IF;
+
+  WITH security_definers AS (
+    SELECT procedure.oid, namespace.nspname, procedure.proname
+    FROM pg_proc AS procedure
+    JOIN pg_namespace AS namespace ON namespace.oid = procedure.pronamespace
+    WHERE procedure.prosecdef
+      AND namespace.nspname !~ '^pg_'
+      AND namespace.nspname <> 'information_schema'
+  ), client_roles AS (
+    SELECT unnest(ARRAY['anon', 'authenticated']) AS role_name
+  )
+  SELECT format(
+      '%I can execute security-definer function %I.%I',
+      role_name,
+      nspname,
+      proname
+    )
+    INTO violation
+  FROM security_definers
+  CROSS JOIN client_roles
+  WHERE has_function_privilege(role_name, oid, 'EXECUTE')
+  LIMIT 1;
+  IF violation IS NOT NULL THEN
+    RAISE EXCEPTION '%', violation;
+  END IF;
+
+  SELECT format('%I has USAGE on private schema', role_name)
+    INTO violation
+  FROM (VALUES ('anon'), ('authenticated')) AS client_roles(role_name)
+  JOIN pg_namespace AS namespace ON namespace.nspname = 'private'
+  WHERE has_schema_privilege(role_name, namespace.oid, 'USAGE')
+  LIMIT 1;
+  IF violation IS NOT NULL THEN
+    RAISE EXCEPTION '%', violation;
+  END IF;
+
+  WITH client_roles AS (
+    SELECT unnest(ARRAY['anon', 'authenticated']) AS role_name
+  ), table_default_acls AS (
+    SELECT default_acl.defaclrole,
+      namespace.nspname,
+      privilege.grantee,
+      privilege.privilege_type
+    FROM pg_default_acl AS default_acl
+    LEFT JOIN pg_namespace AS namespace
+      ON namespace.oid = default_acl.defaclnamespace
+    CROSS JOIN LATERAL aclexplode(default_acl.defaclacl) AS privilege
+    WHERE default_acl.defaclobjtype = 'r'
+      AND (default_acl.defaclnamespace = 0 OR namespace.nspname = 'public')
+  )
+  SELECT format(
+      '%I inherits default %s table privilege in schema %I',
+      role_name,
+      privilege_type,
+      COALESCE(nspname, 'global')
+    )
+    INTO violation
+  FROM table_default_acls
+  CROSS JOIN client_roles
+  WHERE privilege_type IN ('INSERT', 'UPDATE', 'DELETE')
+    AND (grantee = 0 OR pg_has_role(role_name, grantee, 'member'))
+  LIMIT 1;
+  IF violation IS NOT NULL THEN
+    RAISE EXCEPTION '%', violation;
+  END IF;
+END;
+$$;

--- a/scripts/db/attest-effective-privileges.sql
+++ b/scripts/db/attest-effective-privileges.sql
@@ -3,9 +3,33 @@ DO $$
 DECLARE
   violation text;
   migration_phase text := current_setting('app.atlaris_migration_phase', true);
+  users_update_columns text[] := ARRAY['name', 'updated_at'];
 BEGIN
   IF migration_phase IS NULL OR migration_phase NOT IN ('expand', 'contract') THEN
     RAISE EXCEPTION 'attestation phase must be expand or contract';
+  END IF;
+
+  IF migration_phase = 'expand'
+    AND EXISTS (
+      SELECT 1
+      FROM information_schema.columns AS legacy_column
+      WHERE legacy_column.table_schema = 'public'
+        AND legacy_column.table_name = 'users'
+        AND legacy_column.column_name = 'preferred_ai_model'
+    )
+    AND EXISTS (
+      SELECT 1
+      FROM information_schema.columns AS legacy_column
+      WHERE legacy_column.table_schema = 'public'
+        AND legacy_column.table_name = 'users'
+        AND legacy_column.column_name = 'analytics_timezone'
+    ) THEN
+    users_update_columns := ARRAY[
+      'name',
+      'preferred_ai_model',
+      'analytics_timezone',
+      'updated_at'
+    ];
   END IF;
 
   SELECT format('role %I is missing, superuser, or bypasses RLS', expected.role_name)
@@ -365,7 +389,7 @@ BEGIN
   WITH expected_grants AS (
     SELECT *
     FROM (VALUES
-      ('users', 'UPDATE', ARRAY['name', 'updated_at']),
+      ('users', 'UPDATE', users_update_columns),
       ('user_preferences', 'INSERT', ARRAY['user_id', 'preferred_ai_model', 'analytics_timezone', 'updated_at']),
       ('user_preferences', 'UPDATE', ARRAY['preferred_ai_model', 'analytics_timezone', 'updated_at']),
       ('user_email_notification_settings', 'INSERT', ARRAY['user_id', 'unsubscribe_all_optional_emails', 'updated_at']),
@@ -396,7 +420,7 @@ BEGIN
   WITH expected_grants AS (
     SELECT *
     FROM (VALUES
-      ('users', 'UPDATE', ARRAY['name', 'updated_at']),
+      ('users', 'UPDATE', users_update_columns),
       ('user_preferences', 'INSERT', ARRAY['user_id', 'preferred_ai_model', 'analytics_timezone', 'updated_at']),
       ('user_preferences', 'UPDATE', ARRAY['preferred_ai_model', 'analytics_timezone', 'updated_at']),
       ('user_email_notification_settings', 'INSERT', ARRAY['user_id', 'unsubscribe_all_optional_emails', 'updated_at']),

--- a/scripts/db/attest-effective-privileges.sql
+++ b/scripts/db/attest-effective-privileges.sql
@@ -108,9 +108,27 @@ BEGIN
     RAISE EXCEPTION '%', violation;
   END IF;
 
-  -- The legacy Stripe archive is expand-phase-only. Check it when present without
-  -- requiring fresh local schemas to materialize a deliberately phased archive.
+  -- Webhook and email ledgers are mandatory service-only tables. The legacy
+  -- Stripe archive is expand-phase-only, so it remains optional when absent.
   WITH required_tables AS (
+    SELECT unnest(
+      ARRAY['clerk_webhook_events', 'clerk_webhook_event_claims', 'email_notification_delivery_runs', 'email_notification_deliveries']
+    ) AS table_name
+  )
+  SELECT format('required service-only public.%I table is missing', required_tables.table_name)
+    INTO violation
+  FROM required_tables
+  LEFT JOIN pg_class AS class
+    ON class.relname = required_tables.table_name
+   AND class.relnamespace = 'public'::regnamespace
+   AND class.relkind IN ('r', 'p')
+  WHERE class.oid IS NULL
+  LIMIT 1;
+  IF violation IS NOT NULL THEN
+    RAISE EXCEPTION '%', violation;
+  END IF;
+
+  WITH service_only_tables AS (
     SELECT unnest(
       ARRAY['legacy_stripe_entitlement_archive', 'clerk_webhook_events', 'clerk_webhook_event_claims', 'email_notification_delivery_runs', 'email_notification_deliveries']
     ) AS table_name
@@ -125,16 +143,55 @@ BEGIN
       '%I has %s on service-only public.%I',
       role_name,
       privilege_type,
-      required_tables.table_name
+      service_only_tables.table_name
     )
     INTO violation
-  FROM required_tables
-  LEFT JOIN pg_class AS class
-    ON class.relname = required_tables.table_name
+  FROM service_only_tables
+  JOIN pg_class AS class
+    ON class.relname = service_only_tables.table_name
    AND class.relnamespace = 'public'::regnamespace
+   AND class.relkind IN ('r', 'p')
   CROSS JOIN client_roles
   CROSS JOIN all_privileges
   WHERE has_table_privilege(role_name, class.oid, privilege_type)
+  LIMIT 1;
+  IF violation IS NOT NULL THEN
+    RAISE EXCEPTION '%', violation;
+  END IF;
+
+  WITH service_only_tables AS (
+    SELECT unnest(
+      ARRAY['legacy_stripe_entitlement_archive', 'clerk_webhook_events', 'clerk_webhook_event_claims', 'email_notification_delivery_runs', 'email_notification_deliveries']
+    ) AS table_name
+  ), client_roles AS (
+    SELECT unnest(ARRAY['anon', 'authenticated']) AS role_name
+  ), column_privileges AS (
+    SELECT unnest(ARRAY['SELECT', 'INSERT', 'UPDATE', 'REFERENCES']) AS privilege_type
+  )
+  SELECT format(
+      '%I has %s column privilege on service-only public.%I.%I',
+      role_name,
+      privilege_type,
+      service_only_tables.table_name,
+      column_info.column_name
+    )
+    INTO violation
+  FROM service_only_tables
+  JOIN pg_class AS class
+    ON class.relname = service_only_tables.table_name
+   AND class.relnamespace = 'public'::regnamespace
+   AND class.relkind IN ('r', 'p')
+  JOIN information_schema.columns AS column_info
+    ON column_info.table_schema = 'public'
+   AND column_info.table_name = service_only_tables.table_name
+  CROSS JOIN client_roles
+  CROSS JOIN column_privileges
+  WHERE has_column_privilege(
+      role_name,
+      format('public.%I', service_only_tables.table_name),
+      column_info.column_name,
+      privilege_type
+    )
   LIMIT 1;
   IF violation IS NOT NULL THEN
     RAISE EXCEPTION '%', violation;

--- a/scripts/db/attest-effective-privileges.sql
+++ b/scripts/db/attest-effective-privileges.sql
@@ -158,6 +158,17 @@ BEGIN
     RAISE EXCEPTION '%', violation;
   END IF;
 
+  SELECT format('authenticated has INSERT on public.%I', class.relname)
+    INTO violation
+  FROM pg_class AS class
+  WHERE class.relname = 'users'
+    AND class.relnamespace = 'public'::regnamespace
+    AND has_table_privilege('authenticated', class.oid, 'INSERT')
+  LIMIT 1;
+  IF violation IS NOT NULL THEN
+    RAISE EXCEPTION '%', violation;
+  END IF;
+
   WITH required_privileges AS (
     SELECT unnest(ARRAY['SELECT', 'INSERT', 'UPDATE']) AS privilege_type
   )
@@ -263,8 +274,7 @@ BEGIN
     FROM pg_proc AS procedure
     JOIN pg_namespace AS namespace ON namespace.oid = procedure.pronamespace
     WHERE procedure.prosecdef
-      AND namespace.nspname !~ '^pg_'
-      AND namespace.nspname <> 'information_schema'
+      AND namespace.nspname IN ('public', 'private')
   ), client_roles AS (
     SELECT unnest(ARRAY['anon', 'authenticated']) AS role_name
   )

--- a/scripts/db/attest-effective-privileges.sql
+++ b/scripts/db/attest-effective-privileges.sql
@@ -2,7 +2,12 @@
 DO $$
 DECLARE
   violation text;
+  migration_phase text := current_setting('app.atlaris_migration_phase', true);
 BEGIN
+  IF migration_phase IS NULL OR migration_phase NOT IN ('expand', 'contract') THEN
+    RAISE EXCEPTION 'attestation phase must be expand or contract';
+  END IF;
+
   SELECT format('role %I is missing, superuser, or bypasses RLS', expected.role_name)
     INTO violation
   FROM (VALUES ('anon'), ('authenticated')) AS expected(role_name)
@@ -81,6 +86,46 @@ BEGIN
     RAISE EXCEPTION '%', violation;
   END IF;
 
+  WITH application_tables AS (
+    SELECT class.oid, class.relname
+    FROM pg_class AS class
+    JOIN pg_namespace AS namespace ON namespace.oid = class.relnamespace
+    WHERE namespace.nspname = 'public'
+      AND class.relkind IN ('r', 'p')
+      AND NOT EXISTS (
+        SELECT 1
+        FROM pg_depend AS dependency
+        WHERE dependency.classid = 'pg_class'::regclass
+          AND dependency.objid = class.oid
+          AND dependency.deptype = 'e'
+      )
+  ), column_privileges AS (
+    SELECT unnest(ARRAY['INSERT', 'UPDATE', 'REFERENCES']) AS privilege_type
+  )
+  SELECT format(
+      'anon has %s column privilege on public.%I.%I',
+      privilege_type,
+      application_tables.relname,
+      column_info.column_name
+    )
+    INTO violation
+  FROM application_tables
+  JOIN information_schema.columns AS column_info
+    ON column_info.table_schema = 'public'
+   AND column_info.table_name = application_tables.relname
+  CROSS JOIN column_privileges
+  WHERE NOT has_table_privilege('anon', application_tables.oid, privilege_type)
+    AND has_column_privilege(
+      'anon',
+      format('public.%I', application_tables.relname),
+      column_info.column_name,
+      privilege_type
+    )
+  LIMIT 1;
+  IF violation IS NOT NULL THEN
+    RAISE EXCEPTION '%', violation;
+  END IF;
+
   WITH required_tables AS (
     SELECT unnest(
       ARRAY['ai_usage_events', 'generation_attempts', 'learning_activity_events', 'learning_plans', 'modules', 'plan_schedules', 'resources', 'task_resources', 'tasks', 'usage_metrics']
@@ -103,6 +148,41 @@ BEGIN
   CROSS JOIN forbidden_privileges
   WHERE class.oid IS NULL
      OR has_table_privilege('authenticated', class.oid, privilege_type)
+  LIMIT 1;
+  IF violation IS NOT NULL THEN
+    RAISE EXCEPTION '%', violation;
+  END IF;
+
+  WITH required_tables AS (
+    SELECT unnest(
+      ARRAY['ai_usage_events', 'generation_attempts', 'learning_activity_events', 'learning_plans', 'modules', 'plan_schedules', 'resources', 'task_resources', 'tasks', 'usage_metrics']
+    ) AS table_name
+  ), column_privileges AS (
+    SELECT unnest(ARRAY['INSERT', 'UPDATE']) AS privilege_type
+  )
+  SELECT format(
+      'authenticated has %s column privilege on server-owned public.%I.%I',
+      privilege_type,
+      required_tables.table_name,
+      column_info.column_name
+    )
+    INTO violation
+  FROM required_tables
+  JOIN pg_class AS class
+    ON class.relname = required_tables.table_name
+   AND class.relnamespace = 'public'::regnamespace
+   AND class.relkind IN ('r', 'p')
+  JOIN information_schema.columns AS column_info
+    ON column_info.table_schema = 'public'
+   AND column_info.table_name = required_tables.table_name
+  CROSS JOIN column_privileges
+  WHERE NOT has_table_privilege('authenticated', class.oid, privilege_type)
+    AND has_column_privilege(
+      'authenticated',
+      format('public.%I', required_tables.table_name),
+      column_info.column_name,
+      privilege_type
+    )
   LIMIT 1;
   IF violation IS NOT NULL THEN
     RAISE EXCEPTION '%', violation;
@@ -220,7 +300,28 @@ BEGIN
   FROM pg_class AS class
   WHERE class.relname = 'users'
     AND class.relnamespace = 'public'::regnamespace
+    AND migration_phase = 'contract'
     AND has_table_privilege('authenticated', class.oid, 'INSERT')
+  LIMIT 1;
+  IF violation IS NOT NULL THEN
+    RAISE EXCEPTION '%', violation;
+  END IF;
+
+  SELECT format(
+      'authenticated has INSERT column privilege on public.users.%I',
+      column_info.column_name
+    )
+    INTO violation
+  FROM information_schema.columns AS column_info
+  WHERE column_info.table_schema = 'public'
+    AND column_info.table_name = 'users'
+    AND NOT has_table_privilege('authenticated', 'public.users', 'INSERT')
+    AND has_column_privilege(
+      'authenticated',
+      'public.users',
+      column_info.column_name,
+      'INSERT'
+    )
   LIMIT 1;
   IF violation IS NOT NULL THEN
     RAISE EXCEPTION '%', violation;

--- a/scripts/db/run-phased-migrations.sh
+++ b/scripts/db/run-phased-migrations.sh
@@ -17,6 +17,7 @@ readonly -a EXPAND_MIGRATIONS=(
   supabase/migrations/20260810120000_create_clerk_webhook_event_claims.sql
   supabase/migrations/20260811100100_add_clerk_user_identity_projection.sql
   supabase/migrations/20260811100200_enforce_resolved_email_delivery_payload_minimization.sql
+  supabase/migrations/20260811100400_revoke_users_authenticated_insert.sql
 )
 
 declare -A APPLIED_VERSIONS=()

--- a/scripts/db/run-phased-migrations.sh
+++ b/scripts/db/run-phased-migrations.sh
@@ -17,8 +17,9 @@ readonly -a EXPAND_MIGRATIONS=(
   supabase/migrations/20260810120000_create_clerk_webhook_event_claims.sql
   supabase/migrations/20260811100100_add_clerk_user_identity_projection.sql
   supabase/migrations/20260811100200_enforce_resolved_email_delivery_payload_minimization.sql
-  supabase/migrations/20260811100400_revoke_users_authenticated_insert.sql
 )
+
+# Keep the users INSERT revoke contract-only until service-role provisioning is live.
 
 declare -A APPLIED_VERSIONS=()
 

--- a/scripts/db/run-phased-migrations.sh
+++ b/scripts/db/run-phased-migrations.sh
@@ -51,6 +51,10 @@ require_archive_recovery_if_drop_already_ran() {
   fi
 }
 
+attest_effective_privileges() {
+  bash scripts/db/attest-effective-privileges.sh
+}
+
 apply_expand_migrations() {
   local migration
   local migration_workspace
@@ -108,9 +112,11 @@ apply_contract_migrations() {
 case "${MIGRATION_PHASE:-}" in
   expand)
     apply_expand_migrations
+    attest_effective_privileges
     ;;
   contract)
     apply_contract_migrations
+    attest_effective_privileges
     ;;
   *)
     printf 'MIGRATION_PHASE must be expand or contract.\n' >&2

--- a/scripts/db/run-phased-migrations.sh
+++ b/scripts/db/run-phased-migrations.sh
@@ -54,7 +54,9 @@ require_archive_recovery_if_drop_already_ran() {
 }
 
 attest_effective_privileges() {
-  bash scripts/db/attest-effective-privileges.sh
+  local phase="$1"
+
+  bash scripts/db/attest-effective-privileges.sh "$phase"
 }
 
 apply_expand_migrations() {
@@ -114,11 +116,11 @@ apply_contract_migrations() {
 case "${MIGRATION_PHASE:-}" in
   expand)
     apply_expand_migrations
-    attest_effective_privileges
+    attest_effective_privileges expand
     ;;
   contract)
     apply_contract_migrations
-    attest_effective_privileges
+    attest_effective_privileges contract
     ;;
   *)
     printf 'MIGRATION_PHASE must be expand or contract.\n' >&2

--- a/src/app/api/v1/plans/bulk-delete/route.ts
+++ b/src/app/api/v1/plans/bulk-delete/route.ts
@@ -42,9 +42,7 @@ function parseBulkDeletePlanIds(body: BulkDeleteRequestBody): string[] {
     });
   }
 
-  const dedupedPlanIds = [...new Set(body.planIds)];
-
-  const invalidIds = dedupedPlanIds.filter(
+  const invalidIds = body.planIds.filter(
     (planId) => typeof planId !== 'string' || !UUID_REGEX.test(planId),
   );
 
@@ -54,7 +52,11 @@ function parseBulkDeletePlanIds(body: BulkDeleteRequestBody): string[] {
     });
   }
 
-  return dedupedPlanIds as string[];
+  return [
+    ...new Set(
+      (body.planIds as string[]).map((planId) => planId.toLowerCase()),
+    ),
+  ];
 }
 
 /**

--- a/src/features/auth/clerk-user-projection.ts
+++ b/src/features/auth/clerk-user-projection.ts
@@ -65,6 +65,7 @@ export type ClerkUserIdentityClient = {
 type LocalUserProjection = {
   id: string;
   authUserId: string;
+  email: string | null;
   clerkUserUpdatedAt: Date | null;
   clerkDeletedAt: Date | null;
 };
@@ -189,11 +190,15 @@ function projectedApplyResult(
     return 'skipped_deleted_user';
   }
 
-  if (
-    user.clerkUserUpdatedAt !== null &&
-    source.clerkUserUpdatedAt.getTime() < user.clerkUserUpdatedAt.getTime()
-  ) {
-    return 'ignored';
+  if (user.clerkUserUpdatedAt !== null) {
+    const sourceUpdatedAt = source.clerkUserUpdatedAt.getTime();
+    const localUpdatedAt = user.clerkUserUpdatedAt.getTime();
+    if (
+      sourceUpdatedAt < localUpdatedAt ||
+      (sourceUpdatedAt === localUpdatedAt && source.email === user.email)
+    ) {
+      return 'ignored';
+    }
   }
 
   return 'updated';
@@ -207,6 +212,7 @@ export async function applyClerkUserProjectionSource(
     .select({
       id: users.id,
       authUserId: users.authUserId,
+      email: users.email,
       clerkUserUpdatedAt: users.clerkUserUpdatedAt,
       clerkDeletedAt: users.clerkDeletedAt,
     })
@@ -329,6 +335,7 @@ export async function reconcileClerkUserIdentities({
         .select({
           id: users.id,
           authUserId: users.authUserId,
+          email: users.email,
           clerkUserUpdatedAt: users.clerkUserUpdatedAt,
           clerkDeletedAt: users.clerkDeletedAt,
         })
@@ -340,6 +347,7 @@ export async function reconcileClerkUserIdentities({
         .select({
           id: users.id,
           authUserId: users.authUserId,
+          email: users.email,
           clerkUserUpdatedAt: users.clerkUserUpdatedAt,
           clerkDeletedAt: users.clerkDeletedAt,
         })

--- a/src/features/auth/clerk-user-projection.ts
+++ b/src/features/auth/clerk-user-projection.ts
@@ -3,7 +3,7 @@ import type { Logger } from '@/lib/logging/logger';
 import type { WebhookEvent } from '@clerk/nextjs/webhooks';
 
 import { users } from '@supabase/schema';
-import { and, asc, eq, gt, isNull, lte, or } from 'drizzle-orm';
+import { and, asc, eq, gt, isNull, lt, lte, or } from 'drizzle-orm';
 
 type UserProjectionDb = Pick<DbTransaction, 'select' | 'update'>;
 
@@ -38,6 +38,7 @@ export type ClerkBackendUser = {
 export type ClerkUserProjectionSource =
   | {
       readonly kind: 'upsert';
+      readonly origin: 'webhook' | 'reconciliation';
       readonly type: 'user.created' | 'user.updated';
       readonly authUserId: string;
       readonly email: string | null;
@@ -123,6 +124,7 @@ export function clerkUserProjectionSourceFromWebhook(
     const user = event.data as ClerkWebhookUser;
     return {
       kind: 'upsert',
+      origin: 'webhook',
       type: event.type,
       authUserId: user.id,
       email: verifiedPrimaryEmail(
@@ -153,6 +155,7 @@ export function clerkUserProjectionSourceFromBackendUser(
 ): ClerkUserProjectionSource {
   return {
     kind: 'upsert',
+    origin: 'reconciliation',
     type: 'user.updated',
     authUserId: user.id,
     email: verifiedPrimaryEmail(
@@ -195,7 +198,8 @@ function projectedApplyResult(
     const localUpdatedAt = user.clerkUserUpdatedAt.getTime();
     if (
       sourceUpdatedAt < localUpdatedAt ||
-      (sourceUpdatedAt === localUpdatedAt && source.email === user.email)
+      (sourceUpdatedAt === localUpdatedAt &&
+        (source.origin === 'webhook' || source.email === user.email))
     ) {
       return 'ignored';
     }
@@ -274,10 +278,15 @@ export async function applyClerkUserProjectionSource(
       and(
         eq(users.id, user.id),
         isNull(users.clerkDeletedAt),
-        or(
-          isNull(users.clerkUserUpdatedAt),
-          lte(users.clerkUserUpdatedAt, source.clerkUserUpdatedAt),
-        ),
+        source.origin === 'webhook'
+          ? or(
+              isNull(users.clerkUserUpdatedAt),
+              lt(users.clerkUserUpdatedAt, source.clerkUserUpdatedAt),
+            )
+          : or(
+              isNull(users.clerkUserUpdatedAt),
+              lte(users.clerkUserUpdatedAt, source.clerkUserUpdatedAt),
+            ),
       ),
     )
     .returning({ id: users.id });

--- a/src/features/auth/user-provisioning.ts
+++ b/src/features/auth/user-provisioning.ts
@@ -1,0 +1,16 @@
+import type {
+  ActorUser,
+  CreateUserData,
+} from '@/lib/db/queries/types/users.types';
+
+import { getOrCreateUser } from '@/lib/db/queries/users';
+import { db as serviceRoleDb } from '@supabase/service-role';
+
+/**
+ * Creates a first local row from Clerk data already verified by the auth boundary.
+ */
+export async function provisionUserFromVerifiedAuthSession(
+  userData: CreateUserData,
+): Promise<ActorUser | undefined> {
+  return getOrCreateUser(userData, serviceRoleDb);
+}

--- a/src/features/billing/clerk-billing/reconciliation.ts
+++ b/src/features/billing/clerk-billing/reconciliation.ts
@@ -273,6 +273,13 @@ async function finalizeClerkWebhookEvent(
     ) {
       throw new Error('No local user found for Clerk deletion event');
     }
+    if (
+      result === 'skipped_no_user' &&
+      args.projectionSource.source.kind === 'upsert' &&
+      args.projectionSource.source.type === 'user.updated'
+    ) {
+      throw new Error('No local user found for Clerk update event');
+    }
     return { status: 'inserted', result };
   });
 }

--- a/src/features/billing/clerk-billing/reconciliation.ts
+++ b/src/features/billing/clerk-billing/reconciliation.ts
@@ -267,6 +267,12 @@ async function finalizeClerkWebhookEvent(
       args.projectionSource.source,
       { ...deps, db: tx },
     );
+    if (
+      result === 'skipped_no_user' &&
+      args.projectionSource.source.kind === 'deleted'
+    ) {
+      throw new Error('No local user found for Clerk deletion event');
+    }
     return { status: 'inserted', result };
   });
 }

--- a/src/features/notifications/email/delivery-service.ts
+++ b/src/features/notifications/email/delivery-service.ts
@@ -19,6 +19,7 @@ import {
   listEmailActivityDayKeysForUser,
 } from '@/lib/db/queries/email-delivery-content';
 import {
+  isEmailDeliveryRecipientCurrent,
   listEmailDeliveryRecipients,
   type EmailDeliveryRecipient,
 } from '@/lib/db/queries/email-delivery-recipients';
@@ -469,6 +470,101 @@ async function processEmailContent(args: {
         reason: 'suppressed_by_streak_reminder',
       },
     });
+    return { action: 'continue', streakSentThisPass: args.streakSentThisPass };
+  }
+
+  const recipientIdentityCurrent =
+    claim.providerRequest.to === recipient.email &&
+    (await isEmailDeliveryRecipientCurrent({
+      userId: recipient.userId,
+      email: claim.providerRequest.to,
+      clerkUserUpdatedAt: recipient.clerkUserUpdatedAt,
+      dbClient: context.db,
+    }));
+  if (!recipientIdentityCurrent) {
+    if (claim.reusedProviderRequest) {
+      await persistDeliveryState(() =>
+        markEmailNotificationDeliveryManualReview(
+          {
+            deliveryId: claim.deliveryId,
+            claimToken: claim.claimToken,
+            failureClass: 'recipient_changed_since_claim',
+          },
+          context.db,
+        ),
+      );
+      context.counts.manualReview += 1;
+      context.counts.needsReview = true;
+      countMetric('atlaris.email.notification.manual_review', 1, {
+        attributes: {
+          category: content.category,
+          reason: 'recipient_changed_since_claim',
+        },
+      });
+    } else {
+      await persistDeliveryState(() =>
+        markEmailNotificationDeliverySkipped(
+          {
+            deliveryId: claim.deliveryId,
+            claimToken: claim.claimToken,
+            failureClass: 'recipient_identity_changed',
+          },
+          context.db,
+        ),
+      );
+      context.counts.skipped += 1;
+      countMetric('atlaris.email.notification.skipped', 1, {
+        attributes: {
+          category: content.category,
+          reason: 'recipient_identity_changed',
+        },
+      });
+    }
+    return { action: 'continue', streakSentThisPass: args.streakSentThisPass };
+  }
+
+  const finalPreferences = resolveEffectiveEmailPreferences(
+    await getEmailNotificationPreferences(recipient.userId, context.db),
+  );
+  if (!finalPreferences[content.category]) {
+    if (claim.reusedProviderRequest) {
+      await persistDeliveryState(() =>
+        markEmailNotificationDeliveryManualReview(
+          {
+            deliveryId: claim.deliveryId,
+            claimToken: claim.claimToken,
+            failureClass: 'preferences_disabled_after_ambiguous_claim',
+          },
+          context.db,
+        ),
+      );
+      context.counts.manualReview += 1;
+      context.counts.needsReview = true;
+      countMetric('atlaris.email.notification.manual_review', 1, {
+        attributes: {
+          category: content.category,
+          reason: 'preferences_disabled_after_ambiguous_claim',
+        },
+      });
+    } else {
+      await persistDeliveryState(() =>
+        markEmailNotificationDeliverySkipped(
+          {
+            deliveryId: claim.deliveryId,
+            claimToken: claim.claimToken,
+            failureClass: 'preference_disabled_before_delivery',
+          },
+          context.db,
+        ),
+      );
+      context.counts.skipped += 1;
+      countMetric('atlaris.email.notification.skipped', 1, {
+        attributes: {
+          category: content.category,
+          reason: 'preference_disabled_before_delivery',
+        },
+      });
+    }
     return { action: 'continue', streakSentThisPass: args.streakSentThisPass };
   }
 

--- a/src/features/notifications/email/delivery-service.ts
+++ b/src/features/notifications/email/delivery-service.ts
@@ -465,6 +465,22 @@ async function processEmailContent(args: {
 
   context.counts.claimed += 1;
   if (content.category === 'daily_reminder' && args.streakSentThisPass) {
+    if (claim.reclaimedExpiredPending) {
+      return {
+        action: await handleProviderFailure({
+          failure: {
+            kind: 'manual_review',
+            failureClass: 'provider_acceptance_ambiguous',
+          },
+          claim,
+          category: content.category,
+          db: context.db,
+          counts: context.counts,
+          logger: context.logger,
+        }),
+        streakSentThisPass: args.streakSentThisPass,
+      };
+    }
     await persistDeliveryState(() =>
       markEmailNotificationDeliverySkipped(
         {
@@ -485,13 +501,34 @@ async function processEmailContent(args: {
     return { action: 'continue', streakSentThisPass: args.streakSentThisPass };
   }
 
-  const recipientIdentityCurrent =
-    claim.providerRequest.to === recipient.email &&
-    (await isEmailDeliveryRecipientCurrent({
-      userId: recipient.userId,
-      email: claim.providerRequest.to,
-      dbClient: context.db,
-    }));
+  let recipientIdentityCurrent: boolean;
+  try {
+    recipientIdentityCurrent =
+      claim.providerRequest.to === recipient.email &&
+      (await isEmailDeliveryRecipientCurrent({
+        userId: recipient.userId,
+        email: claim.providerRequest.to,
+        dbClient: context.db,
+      }));
+  } catch (error) {
+    if (claim.reclaimedExpiredPending) {
+      throw error;
+    }
+    return {
+      action: await handleProviderFailure({
+        failure: {
+          kind: 'retryable',
+          failureClass: 'recipient_processing_error',
+        },
+        claim,
+        category: content.category,
+        db: context.db,
+        counts: context.counts,
+        logger: context.logger,
+      }),
+      streakSentThisPass: args.streakSentThisPass,
+    };
+  }
   if (!recipientIdentityCurrent) {
     if (claim.reclaimedExpiredPending) {
       await persistDeliveryState(() =>
@@ -538,10 +575,31 @@ async function processEmailContent(args: {
     return { action: 'continue', streakSentThisPass: args.streakSentThisPass };
   }
 
-  const finalPreferences = await getEffectiveEmailPreferences(
-    recipient.userId,
-    context.db,
-  );
+  let finalPreferences: EffectiveEmailPreferences;
+  try {
+    finalPreferences = await getEffectiveEmailPreferences(
+      recipient.userId,
+      context.db,
+    );
+  } catch (error) {
+    if (claim.reclaimedExpiredPending) {
+      throw error;
+    }
+    return {
+      action: await handleProviderFailure({
+        failure: {
+          kind: 'retryable',
+          failureClass: 'recipient_processing_error',
+        },
+        claim,
+        category: content.category,
+        db: context.db,
+        counts: context.counts,
+        logger: context.logger,
+      }),
+      streakSentThisPass: args.streakSentThisPass,
+    };
+  }
   if (!finalPreferences[content.category]) {
     if (claim.reclaimedExpiredPending) {
       await persistDeliveryState(() =>

--- a/src/features/notifications/email/delivery-service.ts
+++ b/src/features/notifications/email/delivery-service.ts
@@ -25,6 +25,7 @@ import {
 } from '@/lib/db/queries/email-delivery-recipients';
 import {
   claimEmailNotificationDelivery,
+  EMAIL_DELIVERY_FAILURE_CLASS,
   EMAIL_DELIVERY_LEASE_MS,
   type EmailDeliveryClaimResult,
   EmailDeliveryLostLeaseError,
@@ -67,6 +68,9 @@ const RETRYABLE_DATABASE_ERROR_CODES = new Set([
 ]);
 
 type DeliveryDb = DbClient;
+type EffectiveEmailPreferences = ReturnType<
+  typeof resolveEffectiveEmailPreferences
+>;
 
 function isRetryableDatabaseError(error: unknown): boolean {
   if (!error || typeof error !== 'object') {
@@ -138,6 +142,15 @@ function recordDeliveryFailure(
   });
 }
 
+async function getEffectiveEmailPreferences(
+  userId: string,
+  db: DeliveryDb,
+): Promise<EffectiveEmailPreferences> {
+  return resolveEffectiveEmailPreferences(
+    await getEmailNotificationPreferences(userId, db),
+  );
+}
+
 async function buildRecipientEmailContents(args: {
   recipient: EmailDeliveryRecipient;
   requested: ReadonlySet<EmailNotificationCategory>;
@@ -148,11 +161,10 @@ async function buildRecipientEmailContents(args: {
   now: Date;
   deliveryNow: Date;
 }): Promise<BuiltEmailContent[]> {
-  const preferences = await getEmailNotificationPreferences(
+  const effective = await getEffectiveEmailPreferences(
     args.recipient.userId,
     args.db,
   );
-  const effective = resolveEffectiveEmailPreferences(preferences);
   const enabledCategories = new Set(
     (Object.keys(effective) as Array<keyof typeof effective>).filter(
       (category) => effective[category] && args.requested.has(category),
@@ -478,17 +490,17 @@ async function processEmailContent(args: {
     (await isEmailDeliveryRecipientCurrent({
       userId: recipient.userId,
       email: claim.providerRequest.to,
-      clerkUserUpdatedAt: recipient.clerkUserUpdatedAt,
       dbClient: context.db,
     }));
   if (!recipientIdentityCurrent) {
-    if (claim.reusedProviderRequest) {
+    if (claim.reclaimedExpiredPending) {
       await persistDeliveryState(() =>
         markEmailNotificationDeliveryManualReview(
           {
             deliveryId: claim.deliveryId,
             claimToken: claim.claimToken,
-            failureClass: 'recipient_changed_since_claim',
+            failureClass:
+              EMAIL_DELIVERY_FAILURE_CLASS.recipientIdentityChangedAfterAmbiguousClaim,
           },
           context.db,
         ),
@@ -498,7 +510,8 @@ async function processEmailContent(args: {
       countMetric('atlaris.email.notification.manual_review', 1, {
         attributes: {
           category: content.category,
-          reason: 'recipient_changed_since_claim',
+          reason:
+            EMAIL_DELIVERY_FAILURE_CLASS.recipientIdentityChangedAfterAmbiguousClaim,
         },
       });
     } else {
@@ -507,7 +520,8 @@ async function processEmailContent(args: {
           {
             deliveryId: claim.deliveryId,
             claimToken: claim.claimToken,
-            failureClass: 'recipient_identity_changed',
+            failureClass:
+              EMAIL_DELIVERY_FAILURE_CLASS.recipientIdentityChangedBeforeDelivery,
           },
           context.db,
         ),
@@ -516,24 +530,27 @@ async function processEmailContent(args: {
       countMetric('atlaris.email.notification.skipped', 1, {
         attributes: {
           category: content.category,
-          reason: 'recipient_identity_changed',
+          reason:
+            EMAIL_DELIVERY_FAILURE_CLASS.recipientIdentityChangedBeforeDelivery,
         },
       });
     }
     return { action: 'continue', streakSentThisPass: args.streakSentThisPass };
   }
 
-  const finalPreferences = resolveEffectiveEmailPreferences(
-    await getEmailNotificationPreferences(recipient.userId, context.db),
+  const finalPreferences = await getEffectiveEmailPreferences(
+    recipient.userId,
+    context.db,
   );
   if (!finalPreferences[content.category]) {
-    if (claim.reusedProviderRequest) {
+    if (claim.reclaimedExpiredPending) {
       await persistDeliveryState(() =>
         markEmailNotificationDeliveryManualReview(
           {
             deliveryId: claim.deliveryId,
             claimToken: claim.claimToken,
-            failureClass: 'preferences_disabled_after_ambiguous_claim',
+            failureClass:
+              EMAIL_DELIVERY_FAILURE_CLASS.preferencesDisabledAfterAmbiguousClaim,
           },
           context.db,
         ),
@@ -543,7 +560,8 @@ async function processEmailContent(args: {
       countMetric('atlaris.email.notification.manual_review', 1, {
         attributes: {
           category: content.category,
-          reason: 'preferences_disabled_after_ambiguous_claim',
+          reason:
+            EMAIL_DELIVERY_FAILURE_CLASS.preferencesDisabledAfterAmbiguousClaim,
         },
       });
     } else {
@@ -552,7 +570,8 @@ async function processEmailContent(args: {
           {
             deliveryId: claim.deliveryId,
             claimToken: claim.claimToken,
-            failureClass: 'preference_disabled_before_delivery',
+            failureClass:
+              EMAIL_DELIVERY_FAILURE_CLASS.preferencesDisabledBeforeDelivery,
           },
           context.db,
         ),
@@ -561,7 +580,8 @@ async function processEmailContent(args: {
       countMetric('atlaris.email.notification.skipped', 1, {
         attributes: {
           category: content.category,
-          reason: 'preference_disabled_before_delivery',
+          reason:
+            EMAIL_DELIVERY_FAILURE_CLASS.preferencesDisabledBeforeDelivery,
         },
       });
     }

--- a/src/features/plans/write-service/index.ts
+++ b/src/features/plans/write-service/index.ts
@@ -1,10 +1,7 @@
 import { ConflictError, NotFoundError } from '@/lib/api/errors';
 import { deletePlan } from '@/lib/db/queries/plans';
 
-export type BulkRemovePlanFailureReason =
-  | 'not_found'
-  | 'currently_generating'
-  | 'unknown';
+export type BulkRemovePlanFailureReason = 'not_found' | 'currently_generating';
 
 export type BulkRemovePlanResult =
   | { planId: string; success: true }
@@ -21,16 +18,7 @@ const REMOVE_PLAN_FAILURE_MESSAGES: Record<
 > = {
   not_found: 'Learning plan not found.',
   currently_generating: 'Cannot delete a plan that is currently generating.',
-  unknown: 'Cannot delete learning plan in its current state.',
 };
-
-function normalizeRemovePlanFailureReason(
-  reason: string,
-): BulkRemovePlanFailureReason {
-  return reason === 'not_found' || reason === 'currently_generating'
-    ? reason
-    : 'unknown';
-}
 
 /**
  * Deletes a user-owned plan through the feature service boundary so route
@@ -46,45 +34,29 @@ export async function removePlanForWrite(params: {
     return;
   }
 
-  const reason = normalizeRemovePlanFailureReason(result.reason);
-
-  if (reason === 'not_found') {
+  if (result.reason === 'not_found') {
     throw new NotFoundError(REMOVE_PLAN_FAILURE_MESSAGES.not_found);
   }
 
-  if (reason === 'currently_generating') {
-    throw new ConflictError(REMOVE_PLAN_FAILURE_MESSAGES.currently_generating);
-  }
-
-  throw new ConflictError(REMOVE_PLAN_FAILURE_MESSAGES.unknown);
+  throw new ConflictError(REMOVE_PLAN_FAILURE_MESSAGES.currently_generating);
 }
 
 async function removePlanForBulkWrite(params: {
   planId: string;
   userId: string;
 }): Promise<BulkRemovePlanResult> {
-  try {
-    const result = await deletePlan(params.planId, params.userId);
+  const result = await deletePlan(params.planId, params.userId);
 
-    if (result.success) {
-      return { planId: params.planId, success: true };
-    }
-
-    const reason = normalizeRemovePlanFailureReason(result.reason);
-    return {
-      planId: params.planId,
-      success: false,
-      reason,
-      message: REMOVE_PLAN_FAILURE_MESSAGES[reason],
-    };
-  } catch {
-    return {
-      planId: params.planId,
-      success: false,
-      reason: 'unknown',
-      message: REMOVE_PLAN_FAILURE_MESSAGES.unknown,
-    };
+  if (result.success) {
+    return { planId: params.planId, success: true };
   }
+
+  return {
+    planId: params.planId,
+    success: false,
+    reason: result.reason,
+    message: REMOVE_PLAN_FAILURE_MESSAGES[result.reason],
+  };
 }
 
 export async function removePlansForWrite(params: {

--- a/src/features/plans/write-service/index.ts
+++ b/src/features/plans/write-service/index.ts
@@ -70,15 +70,20 @@ export async function removePlansForWrite(params: {
   userId: string;
 }): Promise<BulkRemovePlanResult[]> {
   return serviceRoleDb.transaction(async (tx) => {
-    const results: BulkRemovePlanResult[] = [];
-    for (const planId of params.planIds) {
-      results.push(
-        await removePlanForBulkWrite({
-          planId,
-          userId: params.userId,
-          dbClient: tx,
-        }),
-      );
+    const orderedPlanIds = params.planIds
+      .map((planId, index) => ({ planId, index }))
+      .sort((left, right) => {
+        const leftKey = left.planId.toLowerCase();
+        const rightKey = right.planId.toLowerCase();
+        return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
+      });
+    const results = new Array<BulkRemovePlanResult>(params.planIds.length);
+    for (const { planId, index } of orderedPlanIds) {
+      results[index] = await removePlanForBulkWrite({
+        planId,
+        userId: params.userId,
+        dbClient: tx,
+      });
     }
     return results;
   });

--- a/src/features/plans/write-service/index.ts
+++ b/src/features/plans/write-service/index.ts
@@ -1,5 +1,6 @@
 import { ConflictError, NotFoundError } from '@/lib/api/errors';
-import { deletePlan } from '@/lib/db/queries/plans';
+import { deletePlan, type DeletePlanDbClient } from '@/lib/db/queries/plans';
+import { db as serviceRoleDb } from '@supabase/service-role';
 
 export type BulkRemovePlanFailureReason = 'not_found' | 'currently_generating';
 
@@ -44,8 +45,13 @@ export async function removePlanForWrite(params: {
 async function removePlanForBulkWrite(params: {
   planId: string;
   userId: string;
+  dbClient: DeletePlanDbClient;
 }): Promise<BulkRemovePlanResult> {
-  const result = await deletePlan(params.planId, params.userId);
+  const result = await deletePlan(
+    params.planId,
+    params.userId,
+    params.dbClient,
+  );
 
   if (result.success) {
     return { planId: params.planId, success: true };
@@ -63,12 +69,17 @@ export async function removePlansForWrite(params: {
   planIds: string[];
   userId: string;
 }): Promise<BulkRemovePlanResult[]> {
-  return Promise.all(
-    params.planIds.map((planId) =>
-      removePlanForBulkWrite({
-        planId,
-        userId: params.userId,
-      }),
-    ),
-  );
+  return serviceRoleDb.transaction(async (tx) => {
+    const results: BulkRemovePlanResult[] = [];
+    for (const planId of params.planIds) {
+      results.push(
+        await removePlanForBulkWrite({
+          planId,
+          userId: params.userId,
+          dbClient: tx,
+        }),
+      );
+    }
+    return results;
+  });
 }

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -12,10 +12,11 @@ import type {
 import type { DbClient } from '@/lib/db/types';
 
 import { AuthError } from './errors';
+import { provisionUserFromVerifiedAuthSession } from '@/features/auth/user-provisioning';
 import { createRequestContext, withRequestContext } from '@/lib/api/context';
 import { auth, getSessionSafe } from '@/lib/auth/server';
 import { appEnv, devAuthEnv, localProductTestingEnv } from '@/lib/config/env';
-import { getOrCreateUser, getUserByAuthId } from '@/lib/db/queries/users';
+import { getUserByAuthId } from '@/lib/db/queries/users';
 import { getDb } from '@supabase/runtime';
 
 export type { PlainHandler } from '@/lib/api/types/auth.types';
@@ -95,6 +96,10 @@ async function ensureUserRecord(
     throw new AuthError('Auth user data unavailable.');
   }
 
+  if (session.user.id !== authUserId) {
+    throw new AuthError('Auth user changed during provisioning.');
+  }
+
   const email = session.user.email;
   if (!email) {
     throw new AuthError(
@@ -107,15 +112,12 @@ async function ensureUserRecord(
     throw new AuthError('Auth user timestamp unavailable.');
   }
 
-  const actor = await getOrCreateUser(
-    {
-      authUserId,
-      email,
-      name: session.user.name || undefined,
-      clerkUserUpdatedAt,
-    },
-    dbClient,
-  );
+  const actor = await provisionUserFromVerifiedAuthSession({
+    authUserId,
+    email,
+    name: session.user.name || undefined,
+    clerkUserUpdatedAt,
+  });
 
   if (!actor) {
     throw new AuthError('Failed to provision user record.');

--- a/src/lib/db/queries/email-delivery-recipients.ts
+++ b/src/lib/db/queries/email-delivery-recipients.ts
@@ -6,11 +6,12 @@ import {
   userEmailNotificationSettings,
   users,
 } from '@supabase/schema';
-import { and, eq, gt, isNotNull, ne, sql } from 'drizzle-orm';
+import { and, eq, gt, isNotNull, isNull, ne, sql } from 'drizzle-orm';
 
 export type EmailDeliveryRecipient = {
   userId: string;
   email: string;
+  clerkUserUpdatedAt: Date;
 };
 
 /**
@@ -54,12 +55,15 @@ export async function listEmailDeliveryRecipients(args: {
     .select({
       userId: users.id,
       email: users.email,
+      clerkUserUpdatedAt: users.clerkUserUpdatedAt,
     })
     .from(users)
     .where(
       and(
         isNotNull(users.email),
         ne(users.email, ''),
+        isNotNull(users.clerkUserUpdatedAt),
+        isNull(users.clerkDeletedAt),
         categoryFilter,
         unsubscribeFilter,
         args.cursorUserId ? gt(users.id, args.cursorUserId) : sql`true`,
@@ -73,9 +77,46 @@ export async function listEmailDeliveryRecipients(args: {
     rows.length > batchSize ? (page[page.length - 1]?.userId ?? null) : null;
 
   return {
-    recipients: page.flatMap((row) =>
-      row.email === null ? [] : [{ userId: row.userId, email: row.email }],
-    ),
+    recipients: page.flatMap((row) => {
+      if (row.email === null || row.clerkUserUpdatedAt === null) {
+        return [];
+      }
+
+      return [
+        {
+          userId: row.userId,
+          email: row.email,
+          clerkUserUpdatedAt: row.clerkUserUpdatedAt,
+        },
+      ];
+    }),
     nextCursor,
   };
+}
+
+/**
+ * Fences a scheduled send against the latest locally projected Clerk identity.
+ */
+export async function isEmailDeliveryRecipientCurrent(args: {
+  userId: string;
+  email: string;
+  clerkUserUpdatedAt: Date;
+  dbClient: Pick<DbClient, 'select'>;
+}): Promise<boolean> {
+  const rows = await args.dbClient
+    .select({ userId: users.id })
+    .from(users)
+    .where(
+      and(
+        eq(users.id, args.userId),
+        eq(users.email, args.email),
+        eq(users.clerkUserUpdatedAt, args.clerkUserUpdatedAt),
+        isNotNull(users.email),
+        ne(users.email, ''),
+        isNull(users.clerkDeletedAt),
+      ),
+    )
+    .limit(1);
+
+  return rows.length > 0;
 }

--- a/src/lib/db/queries/email-delivery-recipients.ts
+++ b/src/lib/db/queries/email-delivery-recipients.ts
@@ -11,7 +11,6 @@ import { and, eq, gt, isNotNull, isNull, ne, sql } from 'drizzle-orm';
 export type EmailDeliveryRecipient = {
   userId: string;
   email: string;
-  clerkUserUpdatedAt: Date;
 };
 
 /**
@@ -55,14 +54,12 @@ export async function listEmailDeliveryRecipients(args: {
     .select({
       userId: users.id,
       email: users.email,
-      clerkUserUpdatedAt: users.clerkUserUpdatedAt,
     })
     .from(users)
     .where(
       and(
         isNotNull(users.email),
         ne(users.email, ''),
-        isNotNull(users.clerkUserUpdatedAt),
         isNull(users.clerkDeletedAt),
         categoryFilter,
         unsubscribeFilter,
@@ -78,7 +75,7 @@ export async function listEmailDeliveryRecipients(args: {
 
   return {
     recipients: page.flatMap((row) => {
-      if (row.email === null || row.clerkUserUpdatedAt === null) {
+      if (row.email === null) {
         return [];
       }
 
@@ -86,7 +83,6 @@ export async function listEmailDeliveryRecipients(args: {
         {
           userId: row.userId,
           email: row.email,
-          clerkUserUpdatedAt: row.clerkUserUpdatedAt,
         },
       ];
     }),
@@ -95,12 +91,11 @@ export async function listEmailDeliveryRecipients(args: {
 }
 
 /**
- * Fences a scheduled send against the latest locally projected Clerk identity.
+ * Fences a scheduled send against the current local delivery identity.
  */
 export async function isEmailDeliveryRecipientCurrent(args: {
   userId: string;
   email: string;
-  clerkUserUpdatedAt: Date;
   dbClient: Pick<DbClient, 'select'>;
 }): Promise<boolean> {
   const rows = await args.dbClient
@@ -110,7 +105,6 @@ export async function isEmailDeliveryRecipientCurrent(args: {
       and(
         eq(users.id, args.userId),
         eq(users.email, args.email),
-        eq(users.clerkUserUpdatedAt, args.clerkUserUpdatedAt),
         isNotNull(users.email),
         ne(users.email, ''),
         isNull(users.clerkDeletedAt),

--- a/src/lib/db/queries/email-notification-deliveries.ts
+++ b/src/lib/db/queries/email-notification-deliveries.ts
@@ -9,6 +9,13 @@ import { randomUUID } from 'node:crypto';
 
 export const EMAIL_DELIVERY_LEASE_MS = 15 * 60 * 1000;
 export const EMAIL_PROVIDER_IDEMPOTENCY_WINDOW_MS = 24 * 60 * 60 * 1000;
+export const EMAIL_DELIVERY_FAILURE_CLASS = {
+  recipientIdentityChangedBeforeDelivery: 'recipient_identity_changed',
+  recipientIdentityChangedAfterAmbiguousClaim: 'recipient_changed_since_claim',
+  preferencesDisabledBeforeDelivery: 'preference_disabled_before_delivery',
+  preferencesDisabledAfterAmbiguousClaim:
+    'preferences_disabled_after_ambiguous_claim',
+} as const;
 
 export type EmailDeliveryClaimResult =
   | {
@@ -17,6 +24,7 @@ export type EmailDeliveryClaimResult =
       claimToken: string;
       providerRequest: PersistedProviderRequest;
       reusedProviderRequest: boolean;
+      reclaimedExpiredPending: boolean;
     }
   | {
       outcome: 'already_terminal';
@@ -236,6 +244,7 @@ export async function claimEmailNotificationDelivery(
       claimToken: inserted[0].claimToken,
       providerRequest: stored,
       reusedProviderRequest: false,
+      reclaimedExpiredPending: false,
     };
   }
 
@@ -321,6 +330,7 @@ export async function claimEmailNotificationDelivery(
         claimToken: reclaimed[0].claimToken,
         providerRequest: stored,
         reusedProviderRequest: !useRecomputedRequest,
+        reclaimedExpiredPending: false,
       };
     }
 
@@ -348,7 +358,7 @@ export async function claimEmailNotificationDelivery(
         .set({
           status: 'manual_review',
           failureClass: recipientChanged
-            ? 'recipient_changed_since_claim'
+            ? EMAIL_DELIVERY_FAILURE_CLASS.recipientIdentityChangedAfterAmbiguousClaim
             : 'provider_acceptance_ambiguous',
           claimToken: null,
           claimExpiresAt: null,
@@ -403,6 +413,7 @@ export async function claimEmailNotificationDelivery(
         claimToken: reclaimed[0].claimToken,
         providerRequest: stored,
         reusedProviderRequest: true,
+        reclaimedExpiredPending: true,
       };
     }
 

--- a/src/lib/db/queries/plans.ts
+++ b/src/lib/db/queries/plans.ts
@@ -40,7 +40,7 @@ import {
 import { db as serviceRoleDb } from '@supabase/service-role';
 import { and, asc, count, desc, eq, inArray, sql } from 'drizzle-orm';
 
-type DeletePlanDbClient = Pick<DbClient, 'delete' | 'select'>;
+export type DeletePlanDbClient = Pick<DbClient, 'delete' | 'select'>;
 
 type PlanSummaryRows = {
   planRows: LearningPlan[];

--- a/supabase/migrations/20260811100300_scrub_resolved_email_delivery_payloads.sql
+++ b/supabase/migrations/20260811100300_scrub_resolved_email_delivery_payloads.sql
@@ -1,0 +1,8 @@
+UPDATE "email_notification_deliveries"
+SET "provider_request" = NULL
+WHERE "status" IN ('sent', 'skipped')
+  AND "provider_request" IS NOT NULL;
+--> statement-breakpoint
+
+ALTER TABLE "email_notification_deliveries"
+VALIDATE CONSTRAINT "email_notification_deliveries_resolved_provider_request_null";

--- a/supabase/migrations/20260811100400_revoke_users_authenticated_insert.sql
+++ b/supabase/migrations/20260811100400_revoke_users_authenticated_insert.sql
@@ -1,0 +1,1 @@
+REVOKE INSERT ON "users" FROM authenticated;

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -358,6 +358,13 @@
       "when": 1786442580000,
       "tag": "20260811100300_scrub_resolved_email_delivery_payloads",
       "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "7",
+      "when": 1786442640000,
+      "tag": "20260811100400_revoke_users_authenticated_insert",
+      "breakpoints": true
     }
   ]
 }

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -351,6 +351,13 @@
       "when": 1786442520000,
       "tag": "20260811100200_enforce_resolved_email_delivery_payload_minimization",
       "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "7",
+      "when": 1786442580000,
+      "tag": "20260811100300_scrub_resolved_email_delivery_payloads",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/helpers/db/bootstrap.ts
+++ b/tests/helpers/db/bootstrap.ts
@@ -60,6 +60,7 @@ export async function grantRlsPermissions(
     ).join(', ');
 
     await sql.unsafe(`
+      REVOKE INSERT ON "users" FROM authenticated;
       REVOKE UPDATE ON "users" FROM authenticated;
       GRANT UPDATE (${USERS_AUTHENTICATED_UPDATE_COLUMNS.join(', ')}) ON "users" TO authenticated;
       REVOKE DELETE ON "users" FROM authenticated;

--- a/tests/helpers/db/bootstrap.ts
+++ b/tests/helpers/db/bootstrap.ts
@@ -72,8 +72,8 @@ export async function grantRlsPermissions(
       REVOKE INSERT, UPDATE, DELETE ON "user_email_notification_preferences" FROM authenticated;
       GRANT INSERT (${USER_EMAIL_NOTIFICATION_PREFERENCES_AUTHENTICATED_INSERT_COLUMNS.join(', ')}) ON "user_email_notification_preferences" TO authenticated;
       GRANT UPDATE (${USER_EMAIL_NOTIFICATION_PREFERENCES_AUTHENTICATED_UPDATE_COLUMNS.join(', ')}) ON "user_email_notification_preferences" TO authenticated;
-      REVOKE ALL ON "user_preferences", "user_email_notification_settings", "user_email_notification_preferences", "email_notification_delivery_runs" FROM anon;
-      REVOKE ALL ON "email_notification_delivery_runs" FROM authenticated;
+      REVOKE ALL ON "user_preferences", "user_email_notification_settings", "user_email_notification_preferences", "clerk_webhook_events", "clerk_webhook_event_claims", "email_notification_delivery_runs", "email_notification_deliveries" FROM anon;
+      REVOKE ALL ON "clerk_webhook_events", "clerk_webhook_event_claims", "email_notification_delivery_runs", "email_notification_deliveries" FROM authenticated;
       REVOKE INSERT, UPDATE, DELETE ON "job_queue" FROM authenticated;
       REVOKE INSERT, UPDATE, DELETE ON "job_queue" FROM anon;
       REVOKE INSERT, UPDATE, DELETE ON ${serverOwnedTablesSql} FROM authenticated;
@@ -141,6 +141,10 @@ export async function grantRlsPermissions(
       );
     }
 
+    await sql`
+      ALTER DEFAULT PRIVILEGES IN SCHEMA public
+        REVOKE INSERT, UPDATE, DELETE ON TABLES FROM authenticated
+    `;
     await sql`
       ALTER DEFAULT PRIVILEGES IN SCHEMA public
         GRANT SELECT ON TABLES TO authenticated

--- a/tests/helpers/db/rls-bootstrap.ts
+++ b/tests/helpers/db/rls-bootstrap.ts
@@ -79,8 +79,8 @@ export async function ensureRlsRolesAndPermissions() {
     REVOKE INSERT, UPDATE, DELETE ON "user_email_notification_preferences" FROM authenticated;
     GRANT INSERT (${sql.raw(USER_EMAIL_NOTIFICATION_PREFERENCES_AUTHENTICATED_INSERT_COLUMNS_SQL)}) ON "user_email_notification_preferences" TO authenticated;
     GRANT UPDATE (${sql.raw(USER_EMAIL_NOTIFICATION_PREFERENCES_AUTHENTICATED_UPDATE_COLUMNS_SQL)}) ON "user_email_notification_preferences" TO authenticated;
-    REVOKE ALL ON "user_preferences", "user_email_notification_settings", "user_email_notification_preferences", "email_notification_delivery_runs" FROM anon;
-    REVOKE ALL ON "email_notification_delivery_runs" FROM authenticated;
+    REVOKE ALL ON "user_preferences", "user_email_notification_settings", "user_email_notification_preferences", "clerk_webhook_events", "clerk_webhook_event_claims", "email_notification_delivery_runs", "email_notification_deliveries" FROM anon;
+    REVOKE ALL ON "clerk_webhook_events", "clerk_webhook_event_claims", "email_notification_delivery_runs", "email_notification_deliveries" FROM authenticated;
     REVOKE INSERT, UPDATE, DELETE ON "job_queue" FROM authenticated;
     REVOKE INSERT, UPDATE, DELETE ON "job_queue" FROM anon;
     REVOKE INSERT, UPDATE, DELETE ON ${sql.raw(
@@ -96,6 +96,11 @@ export async function ensureRlsRolesAndPermissions() {
   `);
 
   // Grant default permissions for future tables
+  await db.execute(sql`
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public
+    REVOKE INSERT, UPDATE, DELETE ON TABLES FROM authenticated;
+  `);
+
   await db.execute(sql`
     ALTER DEFAULT PRIVILEGES IN SCHEMA public
     GRANT SELECT ON TABLES TO authenticated;

--- a/tests/helpers/db/rls-bootstrap.ts
+++ b/tests/helpers/db/rls-bootstrap.ts
@@ -67,6 +67,7 @@ export async function ensureRlsRolesAndPermissions() {
   // Matches the final migration grant and users-authenticated-update-columns.
   // Harden `job_queue` to match 0028: no role writes from clients (service role for workers only).
   await db.execute(sql`
+    REVOKE INSERT ON "users" FROM authenticated;
     REVOKE UPDATE ON "users" FROM authenticated;
     GRANT UPDATE (${sql.raw(USERS_AUTHENTICATED_UPDATE_COLUMNS_SQL)}) ON "users" TO authenticated;
     REVOKE DELETE ON "users" FROM authenticated;

--- a/tests/integration/api/user-preferences.spec.ts
+++ b/tests/integration/api/user-preferences.spec.ts
@@ -7,7 +7,7 @@ import { getPersistableModelsForTier } from '@/features/ai/model-preferences';
 import { userPreferences, users } from '@supabase/schema';
 import { db } from '@supabase/service-role';
 import { eq } from 'drizzle-orm';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
 
 assertLocalIntegrationDatabaseUrl();
 
@@ -45,7 +45,7 @@ function expectModelArray(value: unknown): ApiModelResponse[] {
 describe('GET /api/v1/user/preferences', () => {
   const testAuthUserId = `preferences-get-user-${Date.now()}`;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     await ensureUser({
       authUserId: testAuthUserId,
       email: `${testAuthUserId}@example.com`,
@@ -142,7 +142,7 @@ describe('GET /api/v1/user/preferences', () => {
 describe('PATCH /api/v1/user/preferences', () => {
   const testAuthUserId = `preferences-patch-user-${Date.now()}`;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     await ensureUser({
       authUserId: testAuthUserId,
       email: `${testAuthUserId}@example.com`,
@@ -471,7 +471,7 @@ describe('PATCH /api/v1/user/preferences', () => {
 describe('GET /api/v1/user/preferences — invalid stored preference', () => {
   const testAuthUserId = `preferences-downgrade-invalid-${Date.now()}`;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     await ensureUser({
       authUserId: testAuthUserId,
       email: `${testAuthUserId}@example.com`,

--- a/tests/integration/contract/plans.bulk-delete.spec.ts
+++ b/tests/integration/contract/plans.bulk-delete.spec.ts
@@ -247,6 +247,40 @@ describe('POST /api/v1/plans/bulk-delete', () => {
     expect(remaining).toHaveLength(1);
   });
 
+  it('returns 200 with per-plan conflicts when every selected plan is generating', async () => {
+    setTestUser(ownerAuthId);
+    const ownerId = await ensureUser({
+      authUserId: ownerAuthId,
+      email: ownerEmail,
+    });
+    const plans = await db
+      .insert(learningPlans)
+      .values([
+        buildPlanValues(ownerId, 'Bulk Generating Plan One', 'generating'),
+        buildPlanValues(ownerId, 'Bulk Generating Plan Two', 'generating'),
+      ])
+      .returning();
+
+    const response = await POST(
+      buildBulkDeleteRequest(plans.map((plan) => plan.id)),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      deletedCount: 0,
+      failedCount: 2,
+      results: expect.arrayContaining(
+        plans.map((plan) => ({
+          planId: plan.id,
+          success: false,
+          reason: 'currently_generating',
+          message: 'Cannot delete a plan that is currently generating.',
+        })),
+      ),
+    });
+  });
+
   it('returns 400 for invalid bulk delete payloads', async () => {
     setTestUser(ownerAuthId);
     await ensureUser({

--- a/tests/integration/db/clerk-billing-webhook-claims.spec.ts
+++ b/tests/integration/db/clerk-billing-webhook-claims.spec.ts
@@ -301,6 +301,54 @@ describe('Clerk billing webhook claims', () => {
     ).resolves.toEqual([{ eventId }]);
   });
 
+  it('replays a missing user deletion after local provisioning', async () => {
+    const authUserId = buildTestAuthUserId('clerk-deletion-missing');
+    const eventId = `evt_deletion_missing_${authUserId}`;
+    const event = userDeletedEvent(authUserId);
+
+    await expect(
+      applyVerifiedClerkBillingEvent(event, eventId, {
+        db,
+        logger: logger(),
+      }),
+    ).rejects.toThrow('No local user found for Clerk deletion event');
+    await expect(
+      db
+        .select({ eventId: clerkWebhookEvents.eventId })
+        .from(clerkWebhookEvents)
+        .where(eq(clerkWebhookEvents.eventId, eventId)),
+    ).resolves.toEqual([]);
+
+    await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+    });
+
+    await expect(
+      applyVerifiedClerkBillingEvent(event, eventId, {
+        db,
+        logger: logger(),
+      }),
+    ).resolves.toEqual({ status: 'inserted', result: 'updated' });
+    await expect(
+      db
+        .select({
+          email: users.email,
+          clerkDeletedAt: users.clerkDeletedAt,
+        })
+        .from(users)
+        .where(eq(users.authUserId, authUserId)),
+    ).resolves.toMatchObject([
+      { email: null, clerkDeletedAt: expect.any(Date) },
+    ]);
+    await expect(
+      db
+        .select({ eventId: clerkWebhookEvents.eventId })
+        .from(clerkWebhookEvents)
+        .where(eq(clerkWebhookEvents.eventId, eventId)),
+    ).resolves.toEqual([{ eventId }]);
+  });
+
   it('allows only one concurrent claimant and one Clerk refresh', async () => {
     await seedBillingUser();
     let releaseRefresh!: () => void;

--- a/tests/integration/db/clerk-billing-webhook-claims.spec.ts
+++ b/tests/integration/db/clerk-billing-webhook-claims.spec.ts
@@ -51,6 +51,17 @@ function userUpdatedEvent(
   } as unknown as WebhookEvent;
 }
 
+function userCreatedEvent(
+  authUserId: string,
+  email: string,
+  updatedAt: Date,
+): WebhookEvent {
+  return {
+    ...userUpdatedEvent(authUserId, email, updatedAt),
+    type: 'user.created',
+  } as unknown as WebhookEvent;
+}
+
 function userDeletedEvent(authUserId: string): WebhookEvent {
   return {
     type: 'user.deleted',
@@ -278,13 +289,13 @@ describe('Clerk billing webhook claims', () => {
     ).resolves.toEqual([]);
   });
 
-  it('acknowledges a lifecycle event that arrives before local provisioning', async () => {
+  it('acknowledges user.created before local provisioning', async () => {
     const authUserId = buildTestAuthUserId('clerk-identity-missing');
     const eventId = `evt_identity_missing_${authUserId}`;
 
     await expect(
       applyVerifiedClerkBillingEvent(
-        userUpdatedEvent(
+        userCreatedEvent(
           authUserId,
           buildTestEmail(authUserId),
           new Date('2026-08-11T10:03:00.000Z'),
@@ -293,6 +304,72 @@ describe('Clerk billing webhook claims', () => {
         { db, logger: logger() },
       ),
     ).resolves.toEqual({ status: 'inserted', result: 'skipped_no_user' });
+    await expect(
+      db
+        .select({ eventId: clerkWebhookEvents.eventId })
+        .from(clerkWebhookEvents)
+        .where(eq(clerkWebhookEvents.eventId, eventId)),
+    ).resolves.toEqual([{ eventId }]);
+  });
+
+  it('replays a missing user.updated event after local provisioning', async () => {
+    const authUserId = buildTestAuthUserId('clerk-identity-updated-missing');
+    const eventId = `evt_identity_updated_missing_${authUserId}`;
+    const staleEmail = buildTestEmail(`stale-${authUserId}`);
+    const projectedEmail = buildTestEmail(`projected-${authUserId}`);
+    const clerkUpdatedAt = new Date('2026-08-11T10:03:00.000Z');
+    const event = userUpdatedEvent(authUserId, projectedEmail, clerkUpdatedAt);
+
+    await expect(
+      applyVerifiedClerkBillingEvent(event, eventId, {
+        db,
+        logger: logger(),
+      }),
+    ).rejects.toThrow('No local user found for Clerk update event');
+    await expect(
+      db
+        .select({ eventId: clerkWebhookEvents.eventId })
+        .from(clerkWebhookEvents)
+        .where(eq(clerkWebhookEvents.eventId, eventId)),
+    ).resolves.toEqual([]);
+    await expect(
+      db
+        .select({ eventId: clerkWebhookEventClaims.eventId })
+        .from(clerkWebhookEventClaims)
+        .where(eq(clerkWebhookEventClaims.eventId, eventId)),
+    ).resolves.toEqual([]);
+
+    const staleUpdatedAt = new Date(clerkUpdatedAt.getTime() - 1_000);
+    await ensureUser({ authUserId, email: staleEmail });
+    await db
+      .update(users)
+      .set({ email: staleEmail, clerkUserUpdatedAt: staleUpdatedAt })
+      .where(eq(users.authUserId, authUserId));
+
+    await expect(
+      applyVerifiedClerkBillingEvent(event, eventId, {
+        db,
+        logger: logger(),
+      }),
+    ).resolves.toEqual({ status: 'inserted', result: 'updated' });
+    await expect(
+      db
+        .select({
+          email: users.email,
+          clerkUserUpdatedAt: users.clerkUserUpdatedAt,
+        })
+        .from(users)
+        .where(eq(users.authUserId, authUserId)),
+    ).resolves.toEqual([
+      { email: projectedEmail, clerkUserUpdatedAt: clerkUpdatedAt },
+    ]);
+
+    await expect(
+      applyVerifiedClerkBillingEvent(event, eventId, {
+        db,
+        logger: logger(),
+      }),
+    ).resolves.toEqual({ status: 'duplicate' });
     await expect(
       db
         .select({ eventId: clerkWebhookEvents.eventId })

--- a/tests/integration/db/email-delivery-recipients.spec.ts
+++ b/tests/integration/db/email-delivery-recipients.spec.ts
@@ -49,12 +49,6 @@ describe('email delivery recipient query', () => {
       userId: unsubscribedUserId,
       unsubscribeAllOptionalEmails: true,
     });
-    const clerkUserUpdatedAt = new Date('2026-08-05T12:00:00.000Z');
-    await db
-      .update(users)
-      .set({ clerkUserUpdatedAt })
-      .where(eq(users.id, enabledUserId));
-
     const result = await listEmailDeliveryRecipients({
       batchSize: 1,
       categories: ['daily_reminder'],
@@ -65,35 +59,26 @@ describe('email delivery recipient query', () => {
       {
         userId: enabledUserId,
         email: buildTestEmail(enabledAuthUserId),
-        clerkUserUpdatedAt,
       },
     ]);
     expect(result.nextCursor).toBeNull();
   });
 
-  it('excludes unprojected and tombstoned identities from scheduled delivery', async () => {
+  it('excludes tombstoned identities from scheduled delivery', async () => {
     const validAuthUserId = buildTestAuthUserId('email-recipient-projected');
-    const unprojectedAuthUserId = buildTestAuthUserId(
-      'email-recipient-unprojected',
-    );
     const tombstonedAuthUserId = buildTestAuthUserId(
       'email-recipient-tombstoned',
     );
-    const [validUserId, unprojectedUserId, tombstonedUserId] =
-      await Promise.all([
-        ensureUser({
-          authUserId: validAuthUserId,
-          email: buildTestEmail(validAuthUserId),
-        }),
-        ensureUser({
-          authUserId: unprojectedAuthUserId,
-          email: buildTestEmail(unprojectedAuthUserId),
-        }),
-        ensureUser({
-          authUserId: tombstonedAuthUserId,
-          email: buildTestEmail(tombstonedAuthUserId),
-        }),
-      ]);
+    const [validUserId, tombstonedUserId] = await Promise.all([
+      ensureUser({
+        authUserId: validAuthUserId,
+        email: buildTestEmail(validAuthUserId),
+      }),
+      ensureUser({
+        authUserId: tombstonedAuthUserId,
+        email: buildTestEmail(tombstonedAuthUserId),
+      }),
+    ]);
     const clerkUserUpdatedAt = new Date('2026-08-05T12:00:00.000Z');
 
     await db
@@ -109,11 +94,6 @@ describe('email delivery recipient query', () => {
       .where(eq(users.id, tombstonedUserId));
     await db.insert(userEmailNotificationPreferences).values([
       { userId: validUserId, category: 'daily_reminder', enabled: true },
-      {
-        userId: unprojectedUserId,
-        category: 'daily_reminder',
-        enabled: true,
-      },
       {
         userId: tombstonedUserId,
         category: 'daily_reminder',
@@ -131,7 +111,6 @@ describe('email delivery recipient query', () => {
       {
         userId: validUserId,
         email: buildTestEmail(validAuthUserId),
-        clerkUserUpdatedAt,
       },
     ]);
   });
@@ -142,15 +121,9 @@ describe('email delivery recipient query', () => {
       authUserId,
       email: buildTestEmail(authUserId),
     });
-    const clerkUserUpdatedAt = new Date('2026-08-05T12:00:00.000Z');
-    await db
-      .update(users)
-      .set({ clerkUserUpdatedAt })
-      .where(eq(users.id, userId));
     const args = {
       userId,
       email: buildTestEmail(authUserId),
-      clerkUserUpdatedAt,
       dbClient: db,
     };
 
@@ -158,9 +131,14 @@ describe('email delivery recipient query', () => {
 
     await db
       .update(users)
+      .set({ clerkUserUpdatedAt: new Date('2026-08-05T12:01:00.000Z') })
+      .where(eq(users.id, userId));
+    await expect(isEmailDeliveryRecipientCurrent(args)).resolves.toBe(true);
+
+    await db
+      .update(users)
       .set({
         email: 'new-address@example.com',
-        clerkUserUpdatedAt: new Date('2026-08-05T12:01:00.000Z'),
       })
       .where(eq(users.id, userId));
     await expect(isEmailDeliveryRecipientCurrent(args)).resolves.toBe(false);

--- a/tests/integration/db/email-delivery-recipients.spec.ts
+++ b/tests/integration/db/email-delivery-recipients.spec.ts
@@ -1,11 +1,16 @@
-import { listEmailDeliveryRecipients } from '@/lib/db/queries/email-delivery-recipients';
+import {
+  isEmailDeliveryRecipientCurrent,
+  listEmailDeliveryRecipients,
+} from '@/lib/db/queries/email-delivery-recipients';
 import {
   userEmailNotificationPreferences,
   userEmailNotificationSettings,
+  users,
 } from '@supabase/schema';
 import { db } from '@supabase/service-role';
 import { ensureUser } from '@tests/helpers/db/users';
 import { buildTestAuthUserId, buildTestEmail } from '@tests/helpers/testIds';
+import { eq } from 'drizzle-orm';
 import { describe, expect, it } from 'vitest';
 
 describe('email delivery recipient query', () => {
@@ -44,6 +49,11 @@ describe('email delivery recipient query', () => {
       userId: unsubscribedUserId,
       unsubscribeAllOptionalEmails: true,
     });
+    const clerkUserUpdatedAt = new Date('2026-08-05T12:00:00.000Z');
+    await db
+      .update(users)
+      .set({ clerkUserUpdatedAt })
+      .where(eq(users.id, enabledUserId));
 
     const result = await listEmailDeliveryRecipients({
       batchSize: 1,
@@ -55,8 +65,110 @@ describe('email delivery recipient query', () => {
       {
         userId: enabledUserId,
         email: buildTestEmail(enabledAuthUserId),
+        clerkUserUpdatedAt,
       },
     ]);
     expect(result.nextCursor).toBeNull();
+  });
+
+  it('excludes unprojected and tombstoned identities from scheduled delivery', async () => {
+    const validAuthUserId = buildTestAuthUserId('email-recipient-projected');
+    const unprojectedAuthUserId = buildTestAuthUserId(
+      'email-recipient-unprojected',
+    );
+    const tombstonedAuthUserId = buildTestAuthUserId(
+      'email-recipient-tombstoned',
+    );
+    const [validUserId, unprojectedUserId, tombstonedUserId] =
+      await Promise.all([
+        ensureUser({
+          authUserId: validAuthUserId,
+          email: buildTestEmail(validAuthUserId),
+        }),
+        ensureUser({
+          authUserId: unprojectedAuthUserId,
+          email: buildTestEmail(unprojectedAuthUserId),
+        }),
+        ensureUser({
+          authUserId: tombstonedAuthUserId,
+          email: buildTestEmail(tombstonedAuthUserId),
+        }),
+      ]);
+    const clerkUserUpdatedAt = new Date('2026-08-05T12:00:00.000Z');
+
+    await db
+      .update(users)
+      .set({ clerkUserUpdatedAt })
+      .where(eq(users.id, validUserId));
+    await db
+      .update(users)
+      .set({
+        clerkUserUpdatedAt,
+        clerkDeletedAt: new Date('2026-08-05T12:01:00.000Z'),
+      })
+      .where(eq(users.id, tombstonedUserId));
+    await db.insert(userEmailNotificationPreferences).values([
+      { userId: validUserId, category: 'daily_reminder', enabled: true },
+      {
+        userId: unprojectedUserId,
+        category: 'daily_reminder',
+        enabled: true,
+      },
+      {
+        userId: tombstonedUserId,
+        category: 'daily_reminder',
+        enabled: true,
+      },
+    ]);
+
+    const result = await listEmailDeliveryRecipients({
+      batchSize: 10,
+      categories: ['daily_reminder'],
+      dbClient: db,
+    });
+
+    expect(result.recipients).toEqual([
+      {
+        userId: validUserId,
+        email: buildTestEmail(validAuthUserId),
+        clerkUserUpdatedAt,
+      },
+    ]);
+  });
+
+  it('fences delivery against the current Clerk identity projection', async () => {
+    const authUserId = buildTestAuthUserId('email-recipient-fence');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+    });
+    const clerkUserUpdatedAt = new Date('2026-08-05T12:00:00.000Z');
+    await db
+      .update(users)
+      .set({ clerkUserUpdatedAt })
+      .where(eq(users.id, userId));
+    const args = {
+      userId,
+      email: buildTestEmail(authUserId),
+      clerkUserUpdatedAt,
+      dbClient: db,
+    };
+
+    await expect(isEmailDeliveryRecipientCurrent(args)).resolves.toBe(true);
+
+    await db
+      .update(users)
+      .set({
+        email: 'new-address@example.com',
+        clerkUserUpdatedAt: new Date('2026-08-05T12:01:00.000Z'),
+      })
+      .where(eq(users.id, userId));
+    await expect(isEmailDeliveryRecipientCurrent(args)).resolves.toBe(false);
+
+    await db
+      .update(users)
+      .set({ clerkDeletedAt: new Date('2026-08-05T12:02:00.000Z') })
+      .where(eq(users.id, userId));
+    await expect(isEmailDeliveryRecipientCurrent(args)).resolves.toBe(false);
   });
 });

--- a/tests/integration/db/email-notification-deliveries.spec.ts
+++ b/tests/integration/db/email-notification-deliveries.spec.ts
@@ -259,6 +259,16 @@ describe('email notification deliveries ledger', () => {
     },
   );
 
+  it('validates the resolved-payload constraint after scrubbing legacy rows', async () => {
+    const constraints = (await db.execute(sql`
+      select convalidated
+      from pg_constraint
+      where conname = 'email_notification_deliveries_resolved_provider_request_null'
+    `)) as Array<{ convalidated: boolean }>;
+
+    expect(constraints).toEqual([{ convalidated: true }]);
+  });
+
   it('allows only one concurrent owner for the same delivery key', async () => {
     const authUserId = buildTestAuthUserId('email-ledger-race');
     const userId = await ensureUser({

--- a/tests/integration/db/email-notification-deliveries.spec.ts
+++ b/tests/integration/db/email-notification-deliveries.spec.ts
@@ -575,6 +575,7 @@ describe('email notification deliveries ledger', () => {
       firstRequest.idempotencyKey,
     );
     expect(second.reusedProviderRequest).toBe(true);
+    expect(second.reclaimedExpiredPending).toBe(false);
   });
 
   it('does not steal a fresh pending lease and reclaims an expired one with the original request', async () => {
@@ -639,6 +640,7 @@ describe('email notification deliveries ledger', () => {
     if (reclaimed.outcome !== 'claimed') return;
     expect(reclaimed.providerRequest).toMatchObject(original);
     expect(reclaimed.reusedProviderRequest).toBe(true);
+    expect(reclaimed.reclaimedExpiredPending).toBe(true);
   });
 
   it('moves ambiguous pending older than the provider window to manual_review', async () => {

--- a/tests/results/integration/08-06-2026-results.md
+++ b/tests/results/integration/08-06-2026-results.md
@@ -1,0 +1,13 @@
+# Integration test results — 08-06-2026
+
+- Command: `NODE_ENV=test pnpm vitest run --config vitest.config.ts --project integration tests/integration/api/user-preferences.spec.ts tests/integration/db/clerk-billing-webhook-claims.spec.ts tests/integration/db/email-delivery-recipients.spec.ts tests/integration/db/email-notification-deliveries.spec.ts`
+- Result: passed — 4 test files, 48 tests.
+- Scope: all 18 user-preferences API cases with isolated per-test provisioning, replayable missing-row Clerk deletion, legacy null-watermark email recipients, identity-only delivery currentness, and failed-retry versus expired-pending claim provenance.
+
+- Command: `NODE_ENV=test pnpm vitest run --config vitest.config.ts --project integration tests/integration/api/user-provisioning.spec.ts`
+- Result: passed — 1 test file, 1 test.
+- Scope: first-user provisioning after direct authenticated `users` INSERT was revoked.
+
+- Command: `NODE_ENV=test pnpm vitest run --config vitest.config.ts --project integration tests/integration/db/clerk-billing-webhook-claims.spec.ts`
+- Result: passed — 1 test file, 12 tests.
+- Scope: replayable missing-row `user.updated`, no-row `user.created` acknowledgement, unchanged deletion retry, projection watermark behavior, and webhook claim fencing.

--- a/tests/results/security/08-06-2026-results.md
+++ b/tests/results/security/08-06-2026-results.md
@@ -1,0 +1,9 @@
+# Security test results — 08-06-2026
+
+- Command: `NODE_ENV=test pnpm vitest run --config vitest.config.ts --project security tests/security/effective-privileges-attestation.spec.ts tests/security/rls.policies.spec.ts`
+- Result: passed — 2 test files, 33 tests.
+- Scope: effective privilege attestation, project-schema SECURITY DEFINER coverage, and denial of authenticated direct `users` INSERT.
+
+- Command: `NODE_ENV=test pnpm vitest run --config vitest.config.ts --project security tests/security/effective-privileges-attestation.spec.ts`
+- Result: passed — 1 test file, 6 tests.
+- Scope: phase-specific `users` INSERT compatibility, column-only privilege rejection, mandatory ledger checks, and effective privilege attestation.

--- a/tests/results/security/08-06-2026-results.md
+++ b/tests/results/security/08-06-2026-results.md
@@ -7,3 +7,7 @@
 - Command: `NODE_ENV=test pnpm vitest run --config vitest.config.ts --project security tests/security/effective-privileges-attestation.spec.ts`
 - Result: passed — 1 test file, 6 tests.
 - Scope: phase-specific `users` INSERT compatibility, column-only privilege rejection, mandatory ledger checks, and effective privilege attestation.
+
+- Command: `NODE_ENV=test pnpm vitest run --config vitest.config.ts --project security tests/security/effective-privileges-attestation.spec.ts`
+- Result: passed — 1 test file, 7 tests.
+- Scope: phase-aware legacy `users` UPDATE grants, contract enforcement, and broader UPDATE grant rejection.

--- a/tests/results/unit/08-06-2026-results.md
+++ b/tests/results/unit/08-06-2026-results.md
@@ -1,0 +1,18 @@
+# Unit test results — 08-06-2026
+
+- Command: `SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit tests/unit/api/auth.spec.ts tests/unit/features/auth/user-provisioning.spec.ts tests/unit/features/auth/clerk-user-projection.spec.ts tests/unit/features/notifications/email/delivery-service.spec.ts tests/unit/features/plans/write-service.spec.ts tests/unit/db/users-authenticated-update-columns.spec.ts`
+- Result: passed — 6 test files, 50 tests.
+- Scope: service-role first-user provisioning boundary, Clerk identity equal-watermark no-op behavior, recipient delivery failure provenance and preference recheck, transactional bulk plan deletion, and users INSERT revoke drift checks.
+- Command: `SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit tests/unit/features/notifications/email/delivery-service.spec.ts`
+- Result: passed — 1 test file, 24 tests.
+- Scope: each claimed email category re-reads the effective preferences immediately before provider delivery.
+- Command: `SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit tests/unit/architecture/db-migration-workflows.spec.ts`
+- Result: passed — 1 test file, 13 tests.
+- Scope: expand/contract workflow ordering, including deferral of the authenticated users INSERT revoke to the confirmed contract phase.
+
+- Command: `SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit tests/unit/architecture/db-migration-workflows.spec.ts`
+- Result: passed — 1 test file, 13 tests.
+- Scope: phase-aware effective-privilege attestation invocation and migration workflow invariants.
+- Command: `SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit tests/unit/features/billing/clerk-billing/reconciliation.spec.ts`
+- Result: passed — 1 test file, 13 tests.
+- Scope: replayable missing-row `user.updated` webhook handling while preserving `user.created` acknowledgement and billing claim behavior.

--- a/tests/results/unit/08-06-2026-results.md
+++ b/tests/results/unit/08-06-2026-results.md
@@ -16,3 +16,11 @@
 - Command: `SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit tests/unit/features/billing/clerk-billing/reconciliation.spec.ts`
 - Result: passed — 1 test file, 13 tests.
 - Scope: replayable missing-row `user.updated` webhook handling while preserving `user.created` acknowledgement and billing claim behavior.
+
+- Command: `SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit tests/unit/features/notifications/email/delivery-service.spec.ts tests/unit/features/plans/write-service.spec.ts`
+- Result: passed — 2 test files, 36 tests.
+- Scope: reclaimed pending daily-send ambiguity, fresh pre-send eligibility-read finalization, and canonical transactional bulk-delete lock ordering with input-order results.
+
+- Command: `SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit tests/unit/api/plans.bulk-delete-route.spec.ts tests/unit/features/plans/write-service.spec.ts`
+- Result: passed — 2 test files, 11 tests.
+- Scope: case-insensitive bulk-delete UUID normalization and canonical de-duplication before transactional lock ordering.

--- a/tests/security/effective-privileges-attestation.spec.ts
+++ b/tests/security/effective-privileges-attestation.spec.ts
@@ -171,6 +171,67 @@ describe('effective database privilege attestation', () => {
     });
   });
 
+  it('allows legacy users UPDATE columns only during expand', async () => {
+    await runInRolledBackTransaction(async (tx) => {
+      await tx.execute(sql`
+        ALTER TABLE "users" ADD COLUMN "preferred_ai_model" text;
+        ALTER TABLE "users" ADD COLUMN "analytics_timezone" text;
+        REVOKE UPDATE ON TABLE "users" FROM authenticated;
+        GRANT UPDATE ("name", "preferred_ai_model", "analytics_timezone", "updated_at") ON TABLE "users" TO authenticated;
+      `);
+
+      await expect(
+        tx.execute(sql.raw(attestationSql('expand'))),
+      ).resolves.toBeDefined();
+      await expect(
+        tx.execute(sql.raw(attestationSql('contract'))),
+      ).rejects.toMatchObject({
+        cause: expect.objectContaining({
+          message: expect.stringMatching(
+            /authenticated has incorrect UPDATE column privilege on public\.users\.(preferred_ai_model|analytics_timezone)/,
+          ),
+        }),
+      });
+    });
+
+    await runInRolledBackTransaction(async (tx) => {
+      await tx.execute(sql`
+        ALTER TABLE "users" ADD COLUMN "preferred_ai_model" text;
+        ALTER TABLE "users" ADD COLUMN "analytics_timezone" text;
+        REVOKE UPDATE ON TABLE "users" FROM authenticated;
+        GRANT UPDATE ("name", "preferred_ai_model", "analytics_timezone", "updated_at", "auth_user_id") ON TABLE "users" TO authenticated;
+      `);
+
+      await expect(
+        tx.execute(sql.raw(attestationSql('expand'))),
+      ).rejects.toMatchObject({
+        cause: expect.objectContaining({
+          message: expect.stringMatching(
+            /authenticated has incorrect UPDATE column privilege on public\.users\.auth_user_id/,
+          ),
+        }),
+      });
+    });
+
+    await runInRolledBackTransaction(async (tx) => {
+      await tx.execute(sql`
+        ALTER TABLE "users" ADD COLUMN "preferred_ai_model" text;
+        ALTER TABLE "users" ADD COLUMN "analytics_timezone" text;
+        GRANT UPDATE ON TABLE "users" TO authenticated;
+      `);
+
+      await expect(
+        tx.execute(sql.raw(attestationSql('expand'))),
+      ).rejects.toMatchObject({
+        cause: expect.objectContaining({
+          message: expect.stringMatching(
+            /authenticated has incorrect UPDATE column privilege on public\.users\./,
+          ),
+        }),
+      });
+    });
+  });
+
   it('rejects a column-only users INSERT grant in every phase', async () => {
     for (const phase of ['expand', 'contract'] as const) {
       await runInRolledBackTransaction(async (tx) => {

--- a/tests/security/effective-privileges-attestation.spec.ts
+++ b/tests/security/effective-privileges-attestation.spec.ts
@@ -1,0 +1,65 @@
+import { AUTHENTICATED_SERVER_OWNED_WRITE_TABLES } from '@supabase/privileges/authenticated-table-privileges';
+import {
+  USER_EMAIL_NOTIFICATION_PREFERENCES_AUTHENTICATED_INSERT_COLUMNS,
+  USER_EMAIL_NOTIFICATION_PREFERENCES_AUTHENTICATED_UPDATE_COLUMNS,
+  USER_EMAIL_NOTIFICATION_SETTINGS_AUTHENTICATED_INSERT_COLUMNS,
+  USER_EMAIL_NOTIFICATION_SETTINGS_AUTHENTICATED_UPDATE_COLUMNS,
+  USER_PREFERENCES_AUTHENTICATED_INSERT_COLUMNS,
+  USER_PREFERENCES_AUTHENTICATED_UPDATE_COLUMNS,
+} from '@supabase/privileges/user-preferences-authenticated-columns';
+import { USERS_AUTHENTICATED_UPDATE_COLUMNS } from '@supabase/privileges/users-authenticated-update-columns';
+import { db } from '@supabase/service-role';
+import { sql } from 'drizzle-orm';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..');
+const ATTESTATION_SQL = readFileSync(
+  join(REPO_ROOT, 'scripts', 'db', 'attest-effective-privileges.sql'),
+  'utf8',
+);
+
+function sqlArray(values: readonly string[]): string {
+  return `ARRAY['${values.join("', '")}']`;
+}
+
+describe('effective database privilege attestation', () => {
+  it('uses the canonical client privilege allowlists and passes the migrated database', async () => {
+    expect(ATTESTATION_SQL).toContain(
+      "ARRAY['INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER']",
+    );
+    expect(ATTESTATION_SQL).toContain("policy.permissive = 'PERMISSIVE'");
+    expect(ATTESTATION_SQL).toContain("IN ('public', 'anon')");
+    expect(ATTESTATION_SQL).toContain(
+      sqlArray(AUTHENTICATED_SERVER_OWNED_WRITE_TABLES),
+    );
+    expect(ATTESTATION_SQL).toContain(
+      sqlArray(USERS_AUTHENTICATED_UPDATE_COLUMNS),
+    );
+    expect(ATTESTATION_SQL).toContain(
+      sqlArray(USER_PREFERENCES_AUTHENTICATED_INSERT_COLUMNS),
+    );
+    expect(ATTESTATION_SQL).toContain(
+      sqlArray(USER_PREFERENCES_AUTHENTICATED_UPDATE_COLUMNS),
+    );
+    expect(ATTESTATION_SQL).toContain(
+      sqlArray(USER_EMAIL_NOTIFICATION_SETTINGS_AUTHENTICATED_INSERT_COLUMNS),
+    );
+    expect(ATTESTATION_SQL).toContain(
+      sqlArray(USER_EMAIL_NOTIFICATION_SETTINGS_AUTHENTICATED_UPDATE_COLUMNS),
+    );
+    expect(ATTESTATION_SQL).toContain(
+      sqlArray(
+        USER_EMAIL_NOTIFICATION_PREFERENCES_AUTHENTICATED_INSERT_COLUMNS,
+      ),
+    );
+    expect(ATTESTATION_SQL).toContain(
+      sqlArray(
+        USER_EMAIL_NOTIFICATION_PREFERENCES_AUTHENTICATED_UPDATE_COLUMNS,
+      ),
+    );
+
+    await expect(db.execute(sql.raw(ATTESTATION_SQL))).resolves.toBeDefined();
+  });
+});

--- a/tests/security/effective-privileges-attestation.spec.ts
+++ b/tests/security/effective-privileges-attestation.spec.ts
@@ -20,6 +20,10 @@ const ATTESTATION_SQL = readFileSync(
   'utf8',
 );
 
+function attestationSql(phase: 'expand' | 'contract' = 'contract'): string {
+  return `SELECT set_config('app.atlaris_migration_phase', '${phase}', true);\n${ATTESTATION_SQL}`;
+}
+
 function sqlArray(values: readonly string[]): string {
   return `ARRAY['${values.join("', '")}']`;
 }
@@ -79,7 +83,7 @@ describe('effective database privilege attestation', () => {
       ),
     );
 
-    await expect(db.execute(sql.raw(ATTESTATION_SQL))).resolves.toBeDefined();
+    await expect(db.execute(sql.raw(attestationSql()))).resolves.toBeDefined();
   });
 
   it('rejects a service-only column grant when table-level privileges are absent', async () => {
@@ -98,8 +102,14 @@ describe('effective database privilege attestation', () => {
       `)) as Array<{ has_table_select: boolean }>;
       expect(tablePrivilegeRows[0]?.has_table_select).toBe(false);
 
-      await expect(tx.execute(sql.raw(ATTESTATION_SQL))).rejects.toThrow(
-        /authenticated has SELECT column privilege on service-only public\.clerk_webhook_events\./,
+      await expect(tx.execute(sql.raw(attestationSql()))).rejects.toMatchObject(
+        {
+          cause: expect.objectContaining({
+            message: expect.stringMatching(
+              /authenticated has SELECT column privilege on service-only public\.clerk_webhook_events\./,
+            ),
+          }),
+        },
       );
     });
   });
@@ -111,8 +121,14 @@ describe('effective database privilege attestation', () => {
         RENAME TO "effective_privileges_attestation_missing_email_runs";
       `);
 
-      await expect(tx.execute(sql.raw(ATTESTATION_SQL))).rejects.toThrow(
-        /required service-only public\.email_notification_delivery_runs table is missing/,
+      await expect(tx.execute(sql.raw(attestationSql()))).rejects.toMatchObject(
+        {
+          cause: expect.objectContaining({
+            message: expect.stringMatching(
+              /required service-only public\.email_notification_delivery_runs table is missing/,
+            ),
+          }),
+        },
       );
     });
 
@@ -128,7 +144,89 @@ describe('effective database privilege attestation', () => {
         `);
       }
 
-      await expect(tx.execute(sql.raw(ATTESTATION_SQL))).resolves.toBeDefined();
+      await expect(
+        tx.execute(sql.raw(attestationSql())),
+      ).resolves.toBeDefined();
+    });
+  });
+
+  it('allows the expand-only users INSERT grant but rejects it in contract', async () => {
+    await runInRolledBackTransaction(async (tx) => {
+      await tx.execute(sql`
+        GRANT INSERT ON TABLE "users" TO authenticated;
+      `);
+
+      await expect(
+        tx.execute(sql.raw(attestationSql('expand'))),
+      ).resolves.toBeDefined();
+      await expect(
+        tx.execute(sql.raw(attestationSql('contract'))),
+      ).rejects.toMatchObject({
+        cause: expect.objectContaining({
+          message: expect.stringMatching(
+            /authenticated has INSERT on public\.users/,
+          ),
+        }),
+      });
+    });
+  });
+
+  it('rejects a column-only users INSERT grant in every phase', async () => {
+    for (const phase of ['expand', 'contract'] as const) {
+      await runInRolledBackTransaction(async (tx) => {
+        await tx.execute(sql`
+          REVOKE INSERT ON TABLE "users" FROM authenticated;
+          GRANT INSERT (auth_user_id) ON TABLE "users" TO authenticated;
+        `);
+
+        await expect(
+          tx.execute(sql.raw(attestationSql(phase))),
+        ).rejects.toMatchObject({
+          cause: expect.objectContaining({
+            message: expect.stringMatching(
+              /authenticated has INSERT column privilege on public\.users\./,
+            ),
+          }),
+        });
+      });
+    }
+  });
+
+  it('rejects column-only writes on application and server-owned tables', async () => {
+    await runInRolledBackTransaction(async (tx) => {
+      await tx.execute(sql`
+        REVOKE INSERT ON TABLE "learning_plans" FROM anon;
+        GRANT INSERT (topic) ON TABLE "learning_plans" TO anon;
+        REVOKE UPDATE ON TABLE "learning_plans" FROM authenticated;
+        GRANT UPDATE (generation_status) ON TABLE "learning_plans" TO authenticated;
+      `);
+
+      await expect(tx.execute(sql.raw(attestationSql()))).rejects.toMatchObject(
+        {
+          cause: expect.objectContaining({
+            message: expect.stringMatching(
+              /anon has INSERT column privilege on public\.learning_plans\./,
+            ),
+          }),
+        },
+      );
+    });
+
+    await runInRolledBackTransaction(async (tx) => {
+      await tx.execute(sql`
+        REVOKE UPDATE ON TABLE "learning_plans" FROM authenticated;
+        GRANT UPDATE (generation_status) ON TABLE "learning_plans" TO authenticated;
+      `);
+
+      await expect(tx.execute(sql.raw(attestationSql()))).rejects.toMatchObject(
+        {
+          cause: expect.objectContaining({
+            message: expect.stringMatching(
+              /authenticated has UPDATE column privilege on server-owned public\.learning_plans\.generation_status/,
+            ),
+          }),
+        },
+      );
     });
   });
 });

--- a/tests/security/effective-privileges-attestation.spec.ts
+++ b/tests/security/effective-privileges-attestation.spec.ts
@@ -24,6 +24,21 @@ function sqlArray(values: readonly string[]): string {
   return `ARRAY['${values.join("', '")}']`;
 }
 
+const ROLLBACK = Symbol('rollback effective privileges test transaction');
+
+async function runInRolledBackTransaction(
+  callback: (tx: Pick<typeof db, 'execute'>) => Promise<void>,
+): Promise<void> {
+  try {
+    await db.transaction(async (tx) => {
+      await callback(tx);
+      throw ROLLBACK;
+    });
+  } catch (error) {
+    if (error !== ROLLBACK) throw error;
+  }
+}
+
 describe('effective database privilege attestation', () => {
   it('uses the canonical client privilege allowlists and passes the migrated database', async () => {
     expect(ATTESTATION_SQL).toContain(
@@ -65,5 +80,55 @@ describe('effective database privilege attestation', () => {
     );
 
     await expect(db.execute(sql.raw(ATTESTATION_SQL))).resolves.toBeDefined();
+  });
+
+  it('rejects a service-only column grant when table-level privileges are absent', async () => {
+    await runInRolledBackTransaction(async (tx) => {
+      await tx.execute(sql`
+        REVOKE ALL ON TABLE "clerk_webhook_events" FROM authenticated;
+        GRANT SELECT ("event_id") ON TABLE "clerk_webhook_events" TO authenticated;
+      `);
+
+      const tablePrivilegeRows = (await tx.execute(sql`
+        SELECT has_table_privilege(
+          'authenticated',
+          'public.clerk_webhook_events',
+          'SELECT'
+        ) AS has_table_select
+      `)) as Array<{ has_table_select: boolean }>;
+      expect(tablePrivilegeRows[0]?.has_table_select).toBe(false);
+
+      await expect(tx.execute(sql.raw(ATTESTATION_SQL))).rejects.toThrow(
+        /authenticated has SELECT column privilege on service-only public\.clerk_webhook_events\./,
+      );
+    });
+  });
+
+  it('requires mandatory webhook and email ledgers while tolerating the optional archive absence', async () => {
+    await runInRolledBackTransaction(async (tx) => {
+      await tx.execute(sql`
+        ALTER TABLE "email_notification_delivery_runs"
+        RENAME TO "effective_privileges_attestation_missing_email_runs";
+      `);
+
+      await expect(tx.execute(sql.raw(ATTESTATION_SQL))).rejects.toThrow(
+        /required service-only public\.email_notification_delivery_runs table is missing/,
+      );
+    });
+
+    await runInRolledBackTransaction(async (tx) => {
+      const archiveRows = (await tx.execute(sql`
+        SELECT to_regclass('public.legacy_stripe_entitlement_archive') AS table_name
+      `)) as Array<{ table_name: string | null }>;
+
+      if (archiveRows[0]?.table_name !== null) {
+        await tx.execute(sql`
+          ALTER TABLE "legacy_stripe_entitlement_archive"
+          RENAME TO "effective_privileges_attestation_missing_archive";
+        `);
+      }
+
+      await expect(tx.execute(sql.raw(ATTESTATION_SQL))).resolves.toBeDefined();
+    });
   });
 });

--- a/tests/security/effective-privileges-attestation.spec.ts
+++ b/tests/security/effective-privileges-attestation.spec.ts
@@ -37,6 +37,10 @@ describe('effective database privilege attestation', () => {
     expect(ATTESTATION_SQL).toContain(
       sqlArray(USERS_AUTHENTICATED_UPDATE_COLUMNS),
     );
+    expect(ATTESTATION_SQL).toContain('authenticated has INSERT on public.%I');
+    expect(ATTESTATION_SQL).toContain(
+      "namespace.nspname IN ('public', 'private')",
+    );
     expect(ATTESTATION_SQL).toContain(
       sqlArray(USER_PREFERENCES_AUTHENTICATED_INSERT_COLUMNS),
     );

--- a/tests/security/rls.policies.spec.ts
+++ b/tests/security/rls.policies.spec.ts
@@ -341,9 +341,9 @@ describe('RLS Policy Verification', () => {
       ];
 
       for (const client of clients) {
-        await expect(
+        await expectRlsBlocked(() =>
           client.select().from(clerkWebhookEventClaims),
-        ).resolves.toEqual([]);
+        );
         await expectRlsBlocked(() =>
           client
             .insert(clerkWebhookEventClaims)

--- a/tests/security/rls.policies.spec.ts
+++ b/tests/security/rls.policies.spec.ts
@@ -427,6 +427,24 @@ describe('RLS Policy Verification', () => {
       expect(crossTenantUpdate).toHaveLength(0);
     });
 
+    it('does not grant authenticated users direct INSERT on user rows', async () => {
+      const deniedAuthUserId = 'user_insert_denied';
+      const deniedDb = await createRlsDbForUser(deniedAuthUserId);
+      await expectRlsBlocked(() =>
+        deniedDb.insert(users).values({
+          authUserId: deniedAuthUserId,
+          email: 'insert-denied@test.com',
+          clerkUserUpdatedAt: new Date('2026-08-11T10:00:00.000Z'),
+        }),
+      );
+      await expect(
+        db
+          .select({ id: users.id })
+          .from(users)
+          .where(eq(users.authUserId, deniedAuthUserId)),
+      ).resolves.toEqual([]);
+    });
+
     // Transitive ownership: `job_queue_select_own` only returns rows for plans
     // owned by the current user. Anonymous has no `job_queue` visibility.
     it('authenticated can read own job_queue rows, cannot forge/change rows; anonymous cannot read or write', async () => {

--- a/tests/unit/api/auth.spec.ts
+++ b/tests/unit/api/auth.spec.ts
@@ -12,13 +12,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   getUserByAuthId: vi.fn(),
-  getOrCreateUser: vi.fn(),
+  provisionUser: vi.fn(),
   getSession: vi.fn(),
 }));
 
 vi.mock('@/lib/db/queries/users', () => ({
   getUserByAuthId: mocks.getUserByAuthId,
-  getOrCreateUser: mocks.getOrCreateUser,
+}));
+
+vi.mock('@/features/auth/user-provisioning', () => ({
+  provisionUserFromVerifiedAuthSession: mocks.provisionUser,
 }));
 
 vi.mock('@/lib/auth/server', () => ({
@@ -28,14 +31,14 @@ vi.mock('@/lib/auth/server', () => ({
 }));
 
 const mockGetUserByAuthId = mocks.getUserByAuthId;
-const mockGetOrCreateUser = mocks.getOrCreateUser;
+const mockProvisionUser = mocks.provisionUser;
 const mockGetSession = mocks.getSession;
 
 describe('auth helpers', () => {
   beforeEach(() => {
     vi.stubEnv('LOCAL_PRODUCT_TESTING', 'false');
     mockGetUserByAuthId.mockReset();
-    mockGetOrCreateUser.mockReset();
+    mockProvisionUser.mockReset();
     mockGetSession.mockReset();
     clearTestUser();
   });
@@ -59,7 +62,7 @@ describe('auth helpers', () => {
     mockGetUserByAuthId.mockResolvedValue(user);
 
     await expect(requireCurrentUserRecord()).resolves.toEqual(user);
-    expect(mockGetOrCreateUser).not.toHaveBeenCalled();
+    expect(mockProvisionUser).not.toHaveBeenCalled();
   });
 
   it('requireCurrentUserRecord rejects a tombstoned local user', async () => {
@@ -75,7 +78,7 @@ describe('auth helpers', () => {
       'Auth user has been deleted.',
     );
     expect(mockGetSession).not.toHaveBeenCalled();
-    expect(mockGetOrCreateUser).not.toHaveBeenCalled();
+    expect(mockProvisionUser).not.toHaveBeenCalled();
   });
 
   it('requireCurrentUserRecord provisions a missing user from Clerk session data', async () => {
@@ -98,18 +101,15 @@ describe('auth helpers', () => {
         },
       },
     });
-    mockGetOrCreateUser.mockResolvedValue(created);
+    mockProvisionUser.mockResolvedValue(created);
 
     await expect(requireCurrentUserRecord()).resolves.toEqual(created);
-    expect(mockGetOrCreateUser).toHaveBeenCalledWith(
-      {
-        authUserId: 'auth_created',
-        email: 'created@example.com',
-        name: 'Created User',
-        clerkUserUpdatedAt: new Date('2026-08-05T00:00:00.000Z'),
-      },
-      undefined,
-    );
+    expect(mockProvisionUser).toHaveBeenCalledWith({
+      authUserId: 'auth_created',
+      email: 'created@example.com',
+      name: 'Created User',
+      clerkUserUpdatedAt: new Date('2026-08-05T00:00:00.000Z'),
+    });
   });
 
   it('requireCurrentUserRecord fails closed when Clerk user data is unavailable', async () => {
@@ -118,7 +118,27 @@ describe('auth helpers', () => {
     mockGetSession.mockResolvedValue({ data: null });
 
     await expect(requireCurrentUserRecord()).rejects.toBeInstanceOf(AuthError);
-    expect(mockGetOrCreateUser).not.toHaveBeenCalled();
+    expect(mockProvisionUser).not.toHaveBeenCalled();
+  });
+
+  it('requireCurrentUserRecord rejects a Clerk session identity change before provisioning', async () => {
+    setTestUser('auth_original');
+    mockGetUserByAuthId.mockResolvedValue(null);
+    mockGetSession.mockResolvedValue({
+      data: {
+        user: {
+          id: 'auth_replaced',
+          email: 'replaced@example.com',
+          name: 'Replaced User',
+          clerkUserUpdatedAt: new Date('2026-08-05T00:00:00.000Z'),
+        },
+      },
+    });
+
+    await expect(requireCurrentUserRecord()).rejects.toThrow(
+      'Auth user changed during provisioning.',
+    );
+    expect(mockProvisionUser).not.toHaveBeenCalled();
   });
 
   it('requireCurrentUserRecord fails closed when the Clerk user has no email', async () => {
@@ -135,7 +155,7 @@ describe('auth helpers', () => {
     });
 
     await expect(requireCurrentUserRecord()).rejects.toBeInstanceOf(AuthError);
-    expect(mockGetOrCreateUser).not.toHaveBeenCalled();
+    expect(mockProvisionUser).not.toHaveBeenCalled();
   });
 
   it('withServerComponentContext installs request context in test mode', async () => {

--- a/tests/unit/api/plans.bulk-delete-route.spec.ts
+++ b/tests/unit/api/plans.bulk-delete-route.spec.ts
@@ -62,4 +62,27 @@ describe('POST /api/v1/plans/bulk-delete', () => {
       code: 'INTERNAL_ERROR',
     });
   });
+
+  it('normalizes and deduplicates mixed-case plan IDs before bulk deletion', async () => {
+    const canonicalPlanId = 'a0000000-0000-4000-8000-000000000000';
+    removePlansForWrite.mockResolvedValue([
+      { planId: canonicalPlanId, success: true },
+    ]);
+
+    const response = await POST(
+      new Request('http://localhost/api/v1/plans/bulk-delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          planIds: [canonicalPlanId.toUpperCase(), canonicalPlanId],
+        }),
+      }),
+    );
+
+    expect(removePlansForWrite).toHaveBeenCalledWith({
+      planIds: [canonicalPlanId],
+      userId: 'user-1',
+    });
+    expect(response.status).toBe(200);
+  });
 });

--- a/tests/unit/api/plans.bulk-delete-route.spec.ts
+++ b/tests/unit/api/plans.bulk-delete-route.spec.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const removePlansForWrite = vi.hoisted(() => vi.fn());
+
+vi.mock('@/features/plans/write-service', () => ({
+  removePlansForWrite,
+}));
+
+vi.mock('@/lib/api/request-boundary', async () => {
+  const { withErrorBoundary } = await vi.importActual<
+    typeof import('@/lib/api/route-wrappers')
+  >('@/lib/api/route-wrappers');
+
+  return {
+    requestBoundary: {
+      route: (
+        _options: unknown,
+        handler: (scope: {
+          req: Request;
+          actor: { id: string };
+          db: unknown;
+          owned: { userId: string; dbClient: unknown };
+          correlationId: string;
+        }) => Promise<Response>,
+      ) =>
+        withErrorBoundary((req) =>
+          handler({
+            req,
+            actor: { id: 'user-1' },
+            db: {},
+            owned: { userId: 'user-1', dbClient: {} },
+            correlationId: 'test-correlation-id',
+          }),
+        ),
+    },
+  };
+});
+
+import { POST } from '@/app/api/v1/plans/bulk-delete/route';
+
+describe('POST /api/v1/plans/bulk-delete', () => {
+  beforeEach(() => {
+    removePlansForWrite.mockReset();
+  });
+
+  it('returns the canonical 500 response when bulk deletion faults', async () => {
+    removePlansForWrite.mockRejectedValue(new Error('database unavailable'));
+
+    const response = await POST(
+      new Request('http://localhost/api/v1/plans/bulk-delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          planIds: ['00000000-0000-4000-8000-000000000001'],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Internal Server Error',
+      code: 'INTERNAL_ERROR',
+    });
+  });
+});

--- a/tests/unit/architecture/ci-pr-candidate-count.spec.ts
+++ b/tests/unit/architecture/ci-pr-candidate-count.spec.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const CI_PR_WORKFLOW = readFileSync(
+  join(
+    import.meta.dirname,
+    '..',
+    '..',
+    '..',
+    '.github',
+    'workflows',
+    'ci-pr.yml',
+  ),
+  'utf8',
+);
+const CANDIDATE_COUNT =
+  "COUNT=$(printf '%s\\n' \"${FILES}\" | awk 'NF { count += 1 } END { print count + 0 }')";
+
+describe('PR CI candidate file counting', () => {
+  it('treats an empty filtered file list as zero candidates in every consumer', () => {
+    expect(CI_PR_WORKFLOW.split(CANDIDATE_COUNT)).toHaveLength(3);
+    expect(CI_PR_WORKFLOW).not.toContain('echo "${FILES}" | wc -l');
+  });
+});

--- a/tests/unit/architecture/db-migration-workflows.spec.ts
+++ b/tests/unit/architecture/db-migration-workflows.spec.ts
@@ -128,14 +128,25 @@ describe('Supabase migration workflows', () => {
     );
 
     expect(script).toMatch(
-      /expand\)[\s\S]*apply_expand_migrations[\s\S]*attest_effective_privileges/,
+      /expand\)[\s\S]*apply_expand_migrations[\s\S]*attest_effective_privileges expand/,
     );
     expect(script).toMatch(
-      /contract\)[\s\S]*apply_contract_migrations[\s\S]*attest_effective_privileges/,
+      /contract\)[\s\S]*apply_contract_migrations[\s\S]*attest_effective_privileges contract/,
     );
     expect(attestation).toContain('supabase db query --linked');
+    expect(attestation).toContain('--file "$ATTESTATION_SQL_FILE"');
+    expect(attestation).toContain("ATTESTATION_PHASE='contract'");
+    expect(attestation).toContain('expand|contract)');
     expect(attestation).toContain(
-      '--file "$SCRIPT_DIR/attest-effective-privileges.sql"',
+      "set_config('app.atlaris_migration_phase', '%s', false)",
+    );
+    expect(
+      readFileSync(
+        join(REPO_ROOT, 'scripts', 'db', 'attest-effective-privileges.sql'),
+        'utf8',
+      ),
+    ).toContain(
+      "migration_phase IS NULL OR migration_phase NOT IN ('expand', 'contract')",
     );
   });
 

--- a/tests/unit/architecture/db-migration-workflows.spec.ts
+++ b/tests/unit/architecture/db-migration-workflows.spec.ts
@@ -11,6 +11,12 @@ const PHASED_MIGRATION_SCRIPT = join(
   'db',
   'run-phased-migrations.sh',
 );
+const EFFECTIVE_PRIVILEGES_ATTESTATION_SCRIPT = join(
+  REPO_ROOT,
+  'scripts',
+  'db',
+  'attest-effective-privileges.sh',
+);
 
 const migrationWorkflows = [
   {
@@ -104,6 +110,25 @@ describe('Supabase migration workflows', () => {
     );
     expect(script).not.toContain('supabase migration repair');
     expect(script).not.toContain('db query --linked --file');
+  });
+
+  it('attests effective privileges after each successful migration phase', () => {
+    const script = readFileSync(PHASED_MIGRATION_SCRIPT, 'utf8');
+    const attestation = readFileSync(
+      EFFECTIVE_PRIVILEGES_ATTESTATION_SCRIPT,
+      'utf8',
+    );
+
+    expect(script).toMatch(
+      /expand\)[\s\S]*apply_expand_migrations[\s\S]*attest_effective_privileges/,
+    );
+    expect(script).toMatch(
+      /contract\)[\s\S]*apply_contract_migrations[\s\S]*attest_effective_privileges/,
+    );
+    expect(attestation).toContain('supabase db query --linked');
+    expect(attestation).toContain(
+      '--file "$SCRIPT_DIR/attest-effective-privileges.sql"',
+    );
   });
 
   it('keeps authenticated task-progress deletion revoked after the broad grant', () => {

--- a/tests/unit/architecture/db-migration-workflows.spec.ts
+++ b/tests/unit/architecture/db-migration-workflows.spec.ts
@@ -89,6 +89,14 @@ describe('Supabase migration workflows', () => {
 
   it('applies each expand migration and its history record atomically', () => {
     const script = readFileSync(PHASED_MIGRATION_SCRIPT, 'utf8');
+    const expandMigrations = script.match(
+      /readonly -a EXPAND_MIGRATIONS=\(([\s\S]*?)\n\)/,
+    )?.[1];
+
+    expect(expandMigrations).toBeDefined();
+    expect(expandMigrations).not.toContain(
+      '20260811100400_revoke_users_authenticated_insert.sql',
+    );
 
     expect(script).toContain(
       '20260706221000_archive_legacy_stripe_entitlements.sql',

--- a/tests/unit/db/users-authenticated-update-columns.spec.ts
+++ b/tests/unit/db/users-authenticated-update-columns.spec.ts
@@ -72,6 +72,37 @@ describe('authenticated users UPDATE allowlist sync', () => {
     );
   });
 
+  it('keeps the final migration and test bootstraps revoking users INSERT', () => {
+    const migrationsDir = resolve(TEST_DIR, '../../../supabase/migrations');
+    const journal = JSON.parse(
+      readFileSync(resolve(migrationsDir, 'meta/_journal.json'), 'utf8'),
+    ) as MigrationJournal;
+    const migrationContents = journal.entries
+      .map((entry) =>
+        readFileSync(resolve(migrationsDir, `${entry.tag}.sql`), 'utf8'),
+      )
+      .join('\n');
+
+    const sharedBootstrap = readFileSync(
+      resolve(TEST_DIR, '../../helpers/db/bootstrap.ts'),
+      'utf8',
+    );
+    const rlsBootstrap = readFileSync(
+      resolve(TEST_DIR, '../../helpers/db/rls-bootstrap.ts'),
+      'utf8',
+    );
+
+    expect(migrationContents).toMatch(
+      /REVOKE INSERT ON "users" FROM authenticated;/,
+    );
+    expect(sharedBootstrap).toContain(
+      'REVOKE INSERT ON "users" FROM authenticated;',
+    );
+    expect(rlsBootstrap).toContain(
+      'REVOKE INSERT ON "users" FROM authenticated;',
+    );
+  });
+
   it('installs auth.jwt from the shared bootstrap module and rls-bootstrap', () => {
     const sharedBootstrap = readFileSync(
       resolve(TEST_DIR, '../../helpers/db/bootstrap.ts'),

--- a/tests/unit/features/auth/clerk-user-projection.spec.ts
+++ b/tests/unit/features/auth/clerk-user-projection.spec.ts
@@ -2,6 +2,7 @@ import type { WebhookEvent } from '@clerk/nextjs/webhooks';
 
 import {
   applyClerkUserProjectionSource,
+  clerkUserProjectionSourceFromBackendUser,
   clerkUserProjectionSourceFromWebhook,
   reconcileClerkUserIdentities,
 } from '@/features/auth/clerk-user-projection';
@@ -14,12 +15,13 @@ function userUpdatedEvent(
     verification: { status: string };
   }[],
   primaryEmailAddressId: string | null,
+  updatedAt = new Date('2026-08-11T10:00:00.000Z').getTime(),
 ): WebhookEvent {
   return {
     type: 'user.updated',
     data: {
       id: 'user_identity_fixture',
-      updated_at: new Date('2026-08-11T10:00:00.000Z').getTime(),
+      updated_at: updatedAt,
       primary_email_address_id: primaryEmailAddressId,
       email_addresses: emailAddresses,
     },
@@ -46,6 +48,30 @@ function dryRunDb(
   };
 }
 
+function applyDb(localUser: {
+  id: string;
+  authUserId: string;
+  email: string | null;
+  clerkUserUpdatedAt: Date | null;
+  clerkDeletedAt: Date | null;
+}) {
+  const selectLimit = vi.fn().mockResolvedValue([localUser]);
+  const selectWhere = vi.fn().mockReturnValue({ limit: selectLimit });
+  const selectFrom = vi.fn().mockReturnValue({ where: selectWhere });
+  const updateReturning = vi.fn().mockResolvedValue([{ id: localUser.id }]);
+  const updateWhere = vi.fn().mockReturnValue({ returning: updateReturning });
+  const updateSet = vi.fn().mockReturnValue({ where: updateWhere });
+
+  return {
+    db: {
+      select: vi.fn().mockReturnValue({ from: selectFrom }),
+      update: vi.fn().mockReturnValue({ set: updateSet }),
+    },
+    updateSet,
+    updateWhere,
+  };
+}
+
 describe('clerkUserProjectionSourceFromWebhook', () => {
   it('uses only the exact verified primary email', () => {
     const source = clerkUserProjectionSourceFromWebhook(
@@ -68,6 +94,7 @@ describe('clerkUserProjectionSourceFromWebhook', () => {
 
     expect(source).toEqual({
       kind: 'upsert',
+      origin: 'webhook',
       type: 'user.updated',
       authUserId: 'user_identity_fixture',
       email: null,
@@ -202,6 +229,7 @@ describe('clerkUserProjectionSourceFromWebhook', () => {
       applyClerkUserProjectionSource(
         {
           kind: 'upsert',
+          origin: 'reconciliation',
           type: 'user.updated',
           authUserId: localUser.authUserId,
           email: localUser.email,
@@ -214,5 +242,167 @@ describe('clerkUserProjectionSourceFromWebhook', () => {
       ),
     ).resolves.toBe('ignored');
     expect(applyDb.update).not.toHaveBeenCalled();
+  });
+});
+
+function webhookSource(email: string, updatedAt: Date) {
+  const source = clerkUserProjectionSourceFromWebhook(
+    userUpdatedEvent(
+      [
+        {
+          id: 'primary',
+          email_address: email,
+          verification: { status: 'verified' },
+        },
+      ],
+      'primary',
+      updatedAt.getTime(),
+    ),
+  );
+  if (source === null || source.kind !== 'upsert') {
+    throw new Error('Expected a webhook upsert source');
+  }
+  return source;
+}
+
+describe('source-aware equal-watermark projection', () => {
+  it('reports and repairs authoritative equal-watermark email drift', async () => {
+    const clerkUserUpdatedAt = new Date('2026-08-11T10:10:00.000Z');
+    const localUser = {
+      id: 'local_user',
+      authUserId: 'user_current',
+      email: 'stale@example.com',
+      clerkUserUpdatedAt,
+      clerkDeletedAt: null,
+    };
+    const backendUser = {
+      id: localUser.authUserId,
+      updatedAt: clerkUserUpdatedAt.getTime(),
+      primaryEmailAddressId: 'primary',
+      emailAddresses: [
+        {
+          id: 'primary',
+          emailAddress: 'current@example.com',
+          verification: { status: 'verified' },
+        },
+      ],
+    };
+    const dryRun = dryRunDb([localUser]);
+
+    await expect(
+      reconcileClerkUserIdentities({
+        apply: false,
+        clerkClient: {
+          users: { getUser: vi.fn().mockResolvedValue(backendUser) },
+        },
+        db: dryRun as never,
+        logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+      }),
+    ).resolves.toMatchObject({
+      checked: 1,
+      wouldUpdate: 1,
+      ignored: 0,
+    });
+
+    const applied = applyDb(localUser);
+    await expect(
+      applyClerkUserProjectionSource(
+        clerkUserProjectionSourceFromBackendUser(backendUser),
+        {
+          db: applied.db as never,
+          logger: { info: vi.fn(), warn: vi.fn() },
+        },
+      ),
+    ).resolves.toBe('updated');
+    expect(applied.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'current@example.com',
+        clerkUserUpdatedAt,
+      }),
+    );
+  });
+
+  it('ignores an equal-watermark webhook email change', async () => {
+    const clerkUserUpdatedAt = new Date('2026-08-11T10:10:00.000Z');
+    const localUser = {
+      id: 'local_user',
+      authUserId: 'user_current',
+      email: 'current@example.com',
+      clerkUserUpdatedAt,
+      clerkDeletedAt: null,
+    };
+    const applied = applyDb(localUser);
+
+    await expect(
+      applyClerkUserProjectionSource(
+        webhookSource('drifted@example.com', clerkUserUpdatedAt),
+        {
+          db: applied.db as never,
+          logger: { info: vi.fn(), warn: vi.fn() },
+        },
+      ),
+    ).resolves.toBe('ignored');
+    expect(applied.db.update).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['first@example.com', 'second@example.com'],
+    ['second@example.com', 'first@example.com'],
+  ])(
+    'rejects equal-watermark webhook payloads in either arrival order',
+    async (firstEmail, secondEmail) => {
+      const clerkUserUpdatedAt = new Date('2026-08-11T10:10:00.000Z');
+      const localUser = {
+        id: 'local_user',
+        authUserId: 'user_current',
+        email: 'authoritative@example.com',
+        clerkUserUpdatedAt,
+        clerkDeletedAt: null,
+      };
+      const applied = applyDb(localUser);
+
+      for (const email of [firstEmail, secondEmail]) {
+        await expect(
+          applyClerkUserProjectionSource(
+            webhookSource(email, clerkUserUpdatedAt),
+            {
+              db: applied.db as never,
+              logger: { info: vi.fn(), warn: vi.fn() },
+            },
+          ),
+        ).resolves.toBe('ignored');
+      }
+
+      expect(applied.db.update).not.toHaveBeenCalled();
+    },
+  );
+
+  it('allows a strictly newer webhook email update', async () => {
+    const clerkUserUpdatedAt = new Date('2026-08-11T10:10:00.000Z');
+    const newerUpdatedAt = new Date(clerkUserUpdatedAt.getTime() + 1);
+    const localUser = {
+      id: 'local_user',
+      authUserId: 'user_current',
+      email: 'current@example.com',
+      clerkUserUpdatedAt,
+      clerkDeletedAt: null,
+    };
+    const applied = applyDb(localUser);
+
+    await expect(
+      applyClerkUserProjectionSource(
+        webhookSource('newer@example.com', newerUpdatedAt),
+        {
+          db: applied.db as never,
+          logger: { info: vi.fn(), warn: vi.fn() },
+        },
+      ),
+    ).resolves.toBe('updated');
+    expect(applied.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'newer@example.com',
+        clerkUserUpdatedAt: newerUpdatedAt,
+      }),
+    );
   });
 });

--- a/tests/unit/features/auth/clerk-user-projection.spec.ts
+++ b/tests/unit/features/auth/clerk-user-projection.spec.ts
@@ -1,6 +1,7 @@
 import type { WebhookEvent } from '@clerk/nextjs/webhooks';
 
 import {
+  applyClerkUserProjectionSource,
   clerkUserProjectionSourceFromWebhook,
   reconcileClerkUserIdentities,
 } from '@/features/auth/clerk-user-projection';
@@ -29,6 +30,7 @@ function dryRunDb(
   localUsers: readonly {
     id: string;
     authUserId: string;
+    email: string | null;
     clerkUserUpdatedAt: Date | null;
     clerkDeletedAt: Date | null;
   }[],
@@ -96,12 +98,14 @@ describe('clerkUserProjectionSourceFromWebhook', () => {
       {
         id: 'local_user',
         authUserId: 'user_current',
+        email: null,
         clerkUserUpdatedAt: null,
         clerkDeletedAt: null,
       },
       {
         id: 'local_deleted_user',
         authUserId: 'user_missing_in_clerk',
+        email: null,
         clerkUserUpdatedAt: null,
         clerkDeletedAt: null,
       },
@@ -143,5 +147,72 @@ describe('clerkUserProjectionSourceFromWebhook', () => {
       nextCursor: null,
     });
     expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('ignores an equal Clerk watermark when the projected email already matches', async () => {
+    const clerkUserUpdatedAt = new Date('2026-08-11T10:10:00.000Z');
+    const localUser = {
+      id: 'local_user',
+      authUserId: 'user_current',
+      email: 'current@example.com',
+      clerkUserUpdatedAt,
+      clerkDeletedAt: null,
+    };
+    const db = dryRunDb([localUser]);
+    const getUser = vi.fn().mockResolvedValue({
+      id: localUser.authUserId,
+      updatedAt: clerkUserUpdatedAt.getTime(),
+      primaryEmailAddressId: 'primary',
+      emailAddresses: [
+        {
+          id: 'primary',
+          emailAddress: localUser.email,
+          verification: { status: 'verified' },
+        },
+      ],
+    });
+
+    await expect(
+      reconcileClerkUserIdentities({
+        apply: false,
+        clerkClient: { users: { getUser } },
+        db: db as never,
+        logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+      }),
+    ).resolves.toEqual({
+      checked: 1,
+      updated: 0,
+      tombstoned: 0,
+      wouldUpdate: 0,
+      wouldTombstone: 0,
+      skipped: 0,
+      ignored: 1,
+      failed: 0,
+      nextCursor: null,
+    });
+
+    const limit = vi.fn().mockResolvedValue([localUser]);
+    const where = vi.fn().mockReturnValue({ limit });
+    const from = vi.fn().mockReturnValue({ where });
+    const applyDb = {
+      select: vi.fn().mockReturnValue({ from }),
+      update: vi.fn(),
+    };
+    await expect(
+      applyClerkUserProjectionSource(
+        {
+          kind: 'upsert',
+          type: 'user.updated',
+          authUserId: localUser.authUserId,
+          email: localUser.email,
+          clerkUserUpdatedAt,
+        },
+        {
+          db: applyDb as never,
+          logger: { info: vi.fn(), warn: vi.fn() },
+        },
+      ),
+    ).resolves.toBe('ignored');
+    expect(applyDb.update).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/features/auth/user-provisioning.spec.ts
+++ b/tests/unit/features/auth/user-provisioning.spec.ts
@@ -1,0 +1,30 @@
+import { provisionUserFromVerifiedAuthSession } from '@/features/auth/user-provisioning';
+import { getOrCreateUser } from '@/lib/db/queries/users';
+import { db as serviceDb } from '@supabase/service-role';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/db/queries/users', () => ({
+  getOrCreateUser: vi.fn(),
+}));
+
+const mockGetOrCreateUser = vi.mocked(getOrCreateUser);
+
+describe('provisionUserFromVerifiedAuthSession', () => {
+  beforeEach(() => {
+    mockGetOrCreateUser.mockReset();
+  });
+
+  it('uses the service role after the auth boundary has verified Clerk data', async () => {
+    const userData = {
+      authUserId: 'auth_created',
+      email: 'created@example.com',
+      name: 'Created User',
+      clerkUserUpdatedAt: new Date('2026-08-05T00:00:00.000Z'),
+    };
+    mockGetOrCreateUser.mockResolvedValue(undefined);
+
+    await provisionUserFromVerifiedAuthSession(userData);
+
+    expect(mockGetOrCreateUser).toHaveBeenCalledWith(userData, serviceDb);
+  });
+});

--- a/tests/unit/features/billing/clerk-billing/reconciliation.spec.ts
+++ b/tests/unit/features/billing/clerk-billing/reconciliation.spec.ts
@@ -34,6 +34,34 @@ function makeBillingEventWithoutUserPayer(): WebhookEvent {
   } as unknown as WebhookEvent;
 }
 
+function makeUserIdentityEvent(
+  type: 'user.created' | 'user.updated',
+): WebhookEvent {
+  return {
+    type,
+    data: {
+      id: 'user_missing',
+      updated_at: new Date('2026-08-11T10:00:00.000Z').getTime(),
+      primary_email_address_id: 'email_primary',
+      email_addresses: [
+        {
+          id: 'email_primary',
+          email_address: 'updated@example.com',
+          verification: { status: 'verified' },
+        },
+      ],
+    },
+  } as unknown as WebhookEvent;
+}
+
+function makeUserCreatedEvent(): WebhookEvent {
+  return makeUserIdentityEvent('user.created');
+}
+
+function makeUserUpdatedEvent(): WebhookEvent {
+  return makeUserIdentityEvent('user.updated');
+}
+
 function makeFailedPaymentAttemptEvent(): WebhookEvent {
   return {
     type: 'paymentAttempt.failed',
@@ -298,6 +326,42 @@ describe('applyVerifiedClerkBillingEvent', () => {
       'user_missing',
     );
     expect(db.transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves missing local user.updated events retryable', async () => {
+    const db = makeDb({ selectResults: [[], []] });
+
+    await expect(
+      applyVerifiedClerkBillingEvent(
+        makeUserUpdatedEvent(),
+        'evt_user_updated_missing',
+        {
+          db,
+          logger: makeLogger(),
+        },
+      ),
+    ).rejects.toThrow('No local user found for Clerk update event');
+
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+    expect(db.delete).toHaveBeenCalledTimes(2);
+  });
+
+  it('acknowledges missing local user.created events', async () => {
+    const db = makeDb({ selectResults: [[], []] });
+
+    await expect(
+      applyVerifiedClerkBillingEvent(
+        makeUserCreatedEvent(),
+        'evt_user_created_missing',
+        {
+          db,
+          logger: makeLogger(),
+        },
+      ),
+    ).resolves.toEqual({ status: 'inserted', result: 'skipped_no_user' });
+
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+    expect(db.delete).toHaveBeenCalledTimes(1);
   });
 
   it('does not claim the event when the Clerk refresh fails', async () => {

--- a/tests/unit/features/notifications/email/delivery-service.spec.ts
+++ b/tests/unit/features/notifications/email/delivery-service.spec.ts
@@ -10,6 +10,7 @@ import { countMetric } from '@/lib/observability/metrics';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const listRecipients = vi.hoisted(() => vi.fn());
+const isRecipientCurrent = vi.hoisted(() => vi.fn());
 const getPrefs = vi.hoisted(() => vi.fn());
 const getUserPrefs = vi.hoisted(() => vi.fn());
 const listDayKeys = vi.hoisted(() => vi.fn());
@@ -22,6 +23,7 @@ const markManualReview = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/db/queries/email-delivery-recipients', () => ({
   listEmailDeliveryRecipients: listRecipients,
+  isEmailDeliveryRecipientCurrent: isRecipientCurrent,
 }));
 
 vi.mock('@/lib/db/queries/user-preferences', () => ({
@@ -74,9 +76,16 @@ describe('runEmailNotificationDelivery', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     listRecipients.mockResolvedValue({
-      recipients: [{ userId: 'u1', email: 'u@example.com' }],
+      recipients: [
+        {
+          userId: 'u1',
+          email: 'u@example.com',
+          clerkUserUpdatedAt: new Date('2026-08-05T12:00:00.000Z'),
+        },
+      ],
       nextCursor: null,
     });
+    isRecipientCurrent.mockResolvedValue(true);
     getPrefs.mockResolvedValue({
       unsubscribeAllOptionalEmails: false,
       categories: {
@@ -115,7 +124,13 @@ describe('runEmailNotificationDelivery', () => {
 
   it('passes cursorUserId to recipients and preserves nextCursor', async () => {
     listRecipients.mockResolvedValue({
-      recipients: [{ userId: 'u1', email: 'u@example.com' }],
+      recipients: [
+        {
+          userId: 'u1',
+          email: 'u@example.com',
+          clerkUserUpdatedAt: new Date('2026-08-05T12:00:00.000Z'),
+        },
+      ],
       nextCursor: 'u1',
     });
     const sender = createSender();
@@ -263,11 +278,26 @@ describe('runEmailNotificationDelivery', () => {
     const logger = { error: vi.fn(), info: vi.fn() };
     listRecipients.mockResolvedValue({
       recipients: [
-        { userId: 'u1', email: 'u1@example.com' },
-        { userId: 'u2', email: 'u2@example.com' },
+        {
+          userId: 'u1',
+          email: 'u1@example.com',
+          clerkUserUpdatedAt: new Date('2026-08-05T12:00:00.000Z'),
+        },
+        {
+          userId: 'u2',
+          email: 'u2@example.com',
+          clerkUserUpdatedAt: new Date('2026-08-05T12:00:00.000Z'),
+        },
       ],
       nextCursor: 'u2',
     });
+    claim.mockImplementation(async ({ providerRequest }) => ({
+      outcome: 'claimed',
+      deliveryId: 'd1',
+      claimToken: 'claim-1',
+      providerRequest,
+      reusedProviderRequest: false,
+    }));
     getPrefs.mockRejectedValueOnce(error);
     const sender = createSender();
 
@@ -627,11 +657,26 @@ describe('runEmailNotificationDelivery', () => {
   it('continues after a recipient-specific provider rejection', async () => {
     listRecipients.mockResolvedValue({
       recipients: [
-        { userId: 'u1', email: 'invalid@example.com' },
-        { userId: 'u2', email: 'valid@example.com' },
+        {
+          userId: 'u1',
+          email: 'invalid@example.com',
+          clerkUserUpdatedAt: new Date('2026-08-05T12:00:00.000Z'),
+        },
+        {
+          userId: 'u2',
+          email: 'valid@example.com',
+          clerkUserUpdatedAt: new Date('2026-08-05T12:00:00.000Z'),
+        },
       ],
       nextCursor: 'u2',
     });
+    claim.mockImplementation(async ({ providerRequest }) => ({
+      outcome: 'claimed',
+      deliveryId: 'd1',
+      claimToken: 'claim-1',
+      providerRequest,
+      reusedProviderRequest: false,
+    }));
     const sendResolved = vi
       .fn()
       .mockRejectedValueOnce(
@@ -785,5 +830,184 @@ describe('runEmailNotificationDelivery', () => {
     expect(sender.sendResolved).not.toHaveBeenCalled();
     expect(result.examined).toBe(1);
     expect(result.sent).toBe(0);
+  });
+
+  it('skips a newly claimed delivery when the recipient identity changes before send', async () => {
+    isRecipientCurrent.mockResolvedValue(false);
+    const sender = createSender();
+
+    const result = await runEmailNotificationDelivery(
+      {
+        categories: ['daily_reminder'],
+        schedulerDateUtc: '2026-07-09',
+      },
+      {
+        db: {} as never,
+        sender,
+        unsubscribeSecret: 'secret',
+        appUrl: 'https://atlaris.app',
+        now: new Date('2026-07-09T15:00:00.000Z'),
+      },
+    );
+
+    expect(sender.sendResolved).not.toHaveBeenCalled();
+    expect(markSkipped).toHaveBeenCalledWith(
+      {
+        deliveryId: 'd1',
+        claimToken: 'claim-1',
+        failureClass: 'recipient_identity_changed',
+      },
+      expect.anything(),
+    );
+    expect(result).toMatchObject({ claimed: 1, skipped: 1, sent: 0 });
+  });
+
+  it('requires manual review when a reused request no longer matches the recipient', async () => {
+    claim.mockResolvedValue({
+      outcome: 'claimed',
+      deliveryId: 'd1',
+      claimToken: 'claim-1',
+      providerRequest: {
+        from: 'Atlaris <notifications@mail.atlaris.app>',
+        to: 'stale@example.com',
+        subject: 'Keep your learning streak alive',
+        html: '<p>streak</p>',
+        text: 'streak',
+        idempotencyKey: 'u1:streak_reminder:2026-07-09',
+      },
+      reusedProviderRequest: true,
+    });
+    const sender = createSender();
+
+    const result = await runEmailNotificationDelivery(
+      {
+        categories: ['streak_reminder'],
+        schedulerDateUtc: '2026-07-09',
+      },
+      {
+        db: {} as never,
+        sender,
+        unsubscribeSecret: 'secret',
+        appUrl: 'https://atlaris.app',
+        now: new Date('2026-07-09T15:00:00.000Z'),
+      },
+    );
+
+    expect(sender.sendResolved).not.toHaveBeenCalled();
+    expect(markManualReview).toHaveBeenCalledWith(
+      {
+        deliveryId: 'd1',
+        claimToken: 'claim-1',
+        failureClass: 'recipient_changed_since_claim',
+      },
+      expect.anything(),
+    );
+    expect(result).toMatchObject({ claimed: 1, manualReview: 1, sent: 0 });
+  });
+
+  it('rechecks preferences immediately before provider delivery', async () => {
+    getPrefs
+      .mockResolvedValueOnce({
+        unsubscribeAllOptionalEmails: false,
+        categories: {
+          weekly_summary: false,
+          daily_reminder: true,
+          streak_reminder: false,
+        },
+      })
+      .mockResolvedValueOnce({
+        unsubscribeAllOptionalEmails: true,
+        categories: {
+          weekly_summary: true,
+          daily_reminder: true,
+          streak_reminder: true,
+        },
+      });
+    const sender = createSender();
+
+    const result = await runEmailNotificationDelivery(
+      {
+        categories: ['daily_reminder'],
+        schedulerDateUtc: '2026-07-09',
+      },
+      {
+        db: {} as never,
+        sender,
+        unsubscribeSecret: 'secret',
+        appUrl: 'https://atlaris.app',
+        now: new Date('2026-07-09T15:00:00.000Z'),
+      },
+    );
+
+    expect(sender.sendResolved).not.toHaveBeenCalled();
+    expect(markSkipped).toHaveBeenCalledWith(
+      {
+        deliveryId: 'd1',
+        claimToken: 'claim-1',
+        failureClass: 'preference_disabled_before_delivery',
+      },
+      expect.anything(),
+    );
+    expect(result).toMatchObject({ claimed: 1, skipped: 1, sent: 0 });
+  });
+
+  it('preserves a reused request for review when preferences changed after an ambiguous claim', async () => {
+    claim.mockResolvedValue({
+      outcome: 'claimed',
+      deliveryId: 'd1',
+      claimToken: 'claim-1',
+      providerRequest: {
+        from: 'Atlaris <notifications@mail.atlaris.app>',
+        to: 'u@example.com',
+        subject: 'Keep your learning streak alive',
+        html: '<p>streak</p>',
+        text: 'streak',
+        idempotencyKey: 'u1:streak_reminder:2026-07-09',
+      },
+      reusedProviderRequest: true,
+    });
+    getPrefs
+      .mockResolvedValueOnce({
+        unsubscribeAllOptionalEmails: false,
+        categories: {
+          weekly_summary: false,
+          daily_reminder: false,
+          streak_reminder: true,
+        },
+      })
+      .mockResolvedValueOnce({
+        unsubscribeAllOptionalEmails: true,
+        categories: {
+          weekly_summary: true,
+          daily_reminder: true,
+          streak_reminder: true,
+        },
+      });
+    const sender = createSender();
+
+    const result = await runEmailNotificationDelivery(
+      {
+        categories: ['streak_reminder'],
+        schedulerDateUtc: '2026-07-09',
+      },
+      {
+        db: {} as never,
+        sender,
+        unsubscribeSecret: 'secret',
+        appUrl: 'https://atlaris.app',
+        now: new Date('2026-07-09T15:00:00.000Z'),
+      },
+    );
+
+    expect(sender.sendResolved).not.toHaveBeenCalled();
+    expect(markManualReview).toHaveBeenCalledWith(
+      {
+        deliveryId: 'd1',
+        claimToken: 'claim-1',
+        failureClass: 'preferences_disabled_after_ambiguous_claim',
+      },
+      expect.anything(),
+    );
+    expect(result).toMatchObject({ claimed: 1, manualReview: 1, sent: 0 });
   });
 });

--- a/tests/unit/features/notifications/email/delivery-service.spec.ts
+++ b/tests/unit/features/notifications/email/delivery-service.spec.ts
@@ -49,6 +49,14 @@ vi.mock('@/lib/db/queries/email-notification-deliveries', () => ({
       this.name = 'EmailDeliveryLostLeaseError';
     }
   },
+  EMAIL_DELIVERY_FAILURE_CLASS: {
+    recipientIdentityChangedBeforeDelivery: 'recipient_identity_changed',
+    recipientIdentityChangedAfterAmbiguousClaim:
+      'recipient_changed_since_claim',
+    preferencesDisabledBeforeDelivery: 'preference_disabled_before_delivery',
+    preferencesDisabledAfterAmbiguousClaim:
+      'preferences_disabled_after_ambiguous_claim',
+  },
 }));
 
 vi.mock('@/lib/observability/metrics', () => ({
@@ -80,7 +88,6 @@ describe('runEmailNotificationDelivery', () => {
         {
           userId: 'u1',
           email: 'u@example.com',
-          clerkUserUpdatedAt: new Date('2026-08-05T12:00:00.000Z'),
         },
       ],
       nextCursor: null,
@@ -118,6 +125,7 @@ describe('runEmailNotificationDelivery', () => {
         idempotencyKey: 'u1:streak_reminder:2026-07-09',
       },
       reusedProviderRequest: false,
+      reclaimedExpiredPending: false,
     });
     markSent.mockResolvedValue(undefined);
   });
@@ -128,7 +136,6 @@ describe('runEmailNotificationDelivery', () => {
         {
           userId: 'u1',
           email: 'u@example.com',
-          clerkUserUpdatedAt: new Date('2026-08-05T12:00:00.000Z'),
         },
       ],
       nextCursor: 'u1',
@@ -281,12 +288,10 @@ describe('runEmailNotificationDelivery', () => {
         {
           userId: 'u1',
           email: 'u1@example.com',
-          clerkUserUpdatedAt: new Date('2026-08-05T12:00:00.000Z'),
         },
         {
           userId: 'u2',
           email: 'u2@example.com',
-          clerkUserUpdatedAt: new Date('2026-08-05T12:00:00.000Z'),
         },
       ],
       nextCursor: 'u2',
@@ -297,6 +302,7 @@ describe('runEmailNotificationDelivery', () => {
       claimToken: 'claim-1',
       providerRequest,
       reusedProviderRequest: false,
+      reclaimedExpiredPending: false,
     }));
     getPrefs.mockRejectedValueOnce(error);
     const sender = createSender();
@@ -413,6 +419,7 @@ describe('runEmailNotificationDelivery', () => {
           idempotencyKey: 'u1:daily_reminder:2026-07-09',
         },
         reusedProviderRequest: false,
+        reclaimedExpiredPending: false,
       });
     const sender = createSender();
 
@@ -464,6 +471,7 @@ describe('runEmailNotificationDelivery', () => {
           idempotencyKey: 'u1:daily_reminder:2026-07-09',
         },
         reusedProviderRequest: false,
+        reclaimedExpiredPending: false,
       });
     const sender = createSender();
 
@@ -506,6 +514,7 @@ describe('runEmailNotificationDelivery', () => {
           idempotencyKey: 'u1:streak_reminder:2026-07-09',
         },
         reusedProviderRequest: false,
+        reclaimedExpiredPending: false,
       })
       .mockResolvedValueOnce({
         outcome: 'claimed',
@@ -520,6 +529,7 @@ describe('runEmailNotificationDelivery', () => {
           idempotencyKey: 'u1:daily_reminder:2026-07-09',
         },
         reusedProviderRequest: false,
+        reclaimedExpiredPending: false,
       });
     const sender = createSender();
 
@@ -660,12 +670,10 @@ describe('runEmailNotificationDelivery', () => {
         {
           userId: 'u1',
           email: 'invalid@example.com',
-          clerkUserUpdatedAt: new Date('2026-08-05T12:00:00.000Z'),
         },
         {
           userId: 'u2',
           email: 'valid@example.com',
-          clerkUserUpdatedAt: new Date('2026-08-05T12:00:00.000Z'),
         },
       ],
       nextCursor: 'u2',
@@ -676,6 +684,7 @@ describe('runEmailNotificationDelivery', () => {
       claimToken: 'claim-1',
       providerRequest,
       reusedProviderRequest: false,
+      reclaimedExpiredPending: false,
     }));
     const sendResolved = vi
       .fn()
@@ -862,7 +871,7 @@ describe('runEmailNotificationDelivery', () => {
     expect(result).toMatchObject({ claimed: 1, skipped: 1, sent: 0 });
   });
 
-  it('requires manual review when a reused request no longer matches the recipient', async () => {
+  it('requires manual review when an expired pending request no longer matches the recipient', async () => {
     claim.mockResolvedValue({
       outcome: 'claimed',
       deliveryId: 'd1',
@@ -876,6 +885,7 @@ describe('runEmailNotificationDelivery', () => {
         idempotencyKey: 'u1:streak_reminder:2026-07-09',
       },
       reusedProviderRequest: true,
+      reclaimedExpiredPending: true,
     });
     const sender = createSender();
 
@@ -948,10 +958,98 @@ describe('runEmailNotificationDelivery', () => {
       },
       expect.anything(),
     );
+    expect(getPrefs).toHaveBeenCalledTimes(2);
     expect(result).toMatchObject({ claimed: 1, skipped: 1, sent: 0 });
   });
 
-  it('preserves a reused request for review when preferences changed after an ambiguous claim', async () => {
+  it('rechecks preferences before every claimed category delivery', async () => {
+    getPrefs
+      .mockResolvedValueOnce({
+        unsubscribeAllOptionalEmails: false,
+        categories: {
+          weekly_summary: true,
+          daily_reminder: true,
+          streak_reminder: false,
+        },
+      })
+      .mockResolvedValueOnce({
+        unsubscribeAllOptionalEmails: false,
+        categories: {
+          weekly_summary: true,
+          daily_reminder: true,
+          streak_reminder: false,
+        },
+      })
+      .mockResolvedValueOnce({
+        unsubscribeAllOptionalEmails: true,
+        categories: {
+          weekly_summary: true,
+          daily_reminder: true,
+          streak_reminder: true,
+        },
+      });
+    listDayKeys.mockResolvedValue(['2026-07-07']);
+    claim
+      .mockResolvedValueOnce({
+        outcome: 'claimed',
+        deliveryId: 'd1',
+        claimToken: 'claim-1',
+        providerRequest: {
+          from: 'Atlaris <notifications@mail.atlaris.app>',
+          to: 'u@example.com',
+          subject: "A quick nudge for today's learning",
+          html: '<p>daily</p>',
+          text: 'daily',
+          idempotencyKey: 'u1:daily_reminder:2026-07-13',
+        },
+        reusedProviderRequest: false,
+        reclaimedExpiredPending: false,
+      })
+      .mockResolvedValueOnce({
+        outcome: 'claimed',
+        deliveryId: 'd2',
+        claimToken: 'claim-2',
+        providerRequest: {
+          from: 'Atlaris <notifications@mail.atlaris.app>',
+          to: 'u@example.com',
+          subject: 'Your weekly learning summary',
+          html: '<p>weekly</p>',
+          text: 'weekly',
+          idempotencyKey: 'u1:weekly_summary:2026-07-06',
+        },
+        reusedProviderRequest: false,
+        reclaimedExpiredPending: false,
+      });
+
+    const sender = createSender();
+    const result = await runEmailNotificationDelivery(
+      {
+        categories: ['daily_reminder', 'weekly_summary'],
+        schedulerDateUtc: '2026-07-13',
+      },
+      {
+        db: {} as never,
+        sender,
+        unsubscribeSecret: 'secret',
+        appUrl: 'https://atlaris.app',
+        now: new Date('2026-07-13T15:00:00.000Z'),
+      },
+    );
+
+    expect(sender.sendResolved).toHaveBeenCalledTimes(1);
+    expect(markSkipped).toHaveBeenCalledWith(
+      {
+        deliveryId: 'd2',
+        claimToken: 'claim-2',
+        failureClass: 'preference_disabled_before_delivery',
+      },
+      expect.anything(),
+    );
+    expect(getPrefs).toHaveBeenCalledTimes(3);
+    expect(result).toMatchObject({ claimed: 2, skipped: 1, sent: 1 });
+  });
+
+  it('skips a confirmed failed retry when preferences change before delivery', async () => {
     claim.mockResolvedValue({
       outcome: 'claimed',
       deliveryId: 'd1',
@@ -965,6 +1063,67 @@ describe('runEmailNotificationDelivery', () => {
         idempotencyKey: 'u1:streak_reminder:2026-07-09',
       },
       reusedProviderRequest: true,
+      reclaimedExpiredPending: false,
+    });
+    getPrefs
+      .mockResolvedValueOnce({
+        unsubscribeAllOptionalEmails: false,
+        categories: {
+          weekly_summary: false,
+          daily_reminder: false,
+          streak_reminder: true,
+        },
+      })
+      .mockResolvedValueOnce({
+        unsubscribeAllOptionalEmails: true,
+        categories: {
+          weekly_summary: true,
+          daily_reminder: true,
+          streak_reminder: true,
+        },
+      });
+
+    const result = await runEmailNotificationDelivery(
+      {
+        categories: ['streak_reminder'],
+        schedulerDateUtc: '2026-07-09',
+      },
+      {
+        db: {} as never,
+        sender: createSender(),
+        unsubscribeSecret: 'secret',
+        appUrl: 'https://atlaris.app',
+        now: new Date('2026-07-09T15:00:00.000Z'),
+      },
+    );
+
+    expect(markSkipped).toHaveBeenCalledWith(
+      {
+        deliveryId: 'd1',
+        claimToken: 'claim-1',
+        failureClass: 'preference_disabled_before_delivery',
+      },
+      expect.anything(),
+    );
+    expect(markManualReview).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ claimed: 1, skipped: 1, sent: 0 });
+  });
+
+  it('preserves an expired pending request for review when preferences change', async () => {
+    claim.mockResolvedValue({
+      outcome: 'claimed',
+      deliveryId: 'd1',
+      claimToken: 'claim-1',
+      providerRequest: {
+        from: 'Atlaris <notifications@mail.atlaris.app>',
+        to: 'u@example.com',
+        subject: 'Keep your learning streak alive',
+        html: '<p>streak</p>',
+        text: 'streak',
+        idempotencyKey: 'u1:streak_reminder:2026-07-09',
+      },
+      reusedProviderRequest: true,
+      reclaimedExpiredPending: true,
     });
     getPrefs
       .mockResolvedValueOnce({

--- a/tests/unit/features/notifications/email/delivery-service.spec.ts
+++ b/tests/unit/features/notifications/email/delivery-service.spec.ts
@@ -452,6 +452,62 @@ describe('runEmailNotificationDelivery', () => {
     );
   });
 
+  it('preserves a reclaimed pending daily delivery for review when streak was already sent', async () => {
+    claim
+      .mockResolvedValueOnce({
+        outcome: 'already_terminal',
+        status: 'sent',
+      })
+      .mockResolvedValueOnce({
+        outcome: 'claimed',
+        deliveryId: 'd2',
+        claimToken: 'claim-2',
+        providerRequest: {
+          from: 'Atlaris <notifications@mail.atlaris.app>',
+          to: 'u@example.com',
+          subject: "A quick nudge for today's learning",
+          html: '<p>daily</p>',
+          text: 'daily',
+          idempotencyKey: 'u1:daily_reminder:2026-07-09',
+        },
+        reusedProviderRequest: true,
+        reclaimedExpiredPending: true,
+      });
+    const sender = createSender();
+
+    const result = await runEmailNotificationDelivery(
+      {
+        categories: ['daily_reminder', 'streak_reminder'],
+        schedulerDateUtc: '2026-07-09',
+      },
+      {
+        db: {} as never,
+        sender,
+        unsubscribeSecret: 'secret',
+        appUrl: 'https://atlaris.app',
+        now: new Date('2026-07-09T15:00:00.000Z'),
+      },
+    );
+
+    expect(sender.sendResolved).not.toHaveBeenCalled();
+    expect(markSkipped).not.toHaveBeenCalled();
+    expect(markManualReview).toHaveBeenCalledWith(
+      {
+        deliveryId: 'd2',
+        claimToken: 'claim-2',
+        failureClass: 'provider_acceptance_ambiguous',
+      },
+      expect.anything(),
+    );
+    expect(result).toMatchObject({
+      claimed: 1,
+      manualReview: 1,
+      needsReview: true,
+      skipped: 0,
+      sent: 0,
+    });
+  });
+
   it('sends daily when streak is already terminal for a non-sent status', async () => {
     claim
       .mockResolvedValueOnce({
@@ -869,6 +925,93 @@ describe('runEmailNotificationDelivery', () => {
       expect.anything(),
     );
     expect(result).toMatchObject({ claimed: 1, skipped: 1, sent: 0 });
+  });
+
+  it('finalizes a fresh claim when the pre-send identity check fails', async () => {
+    isRecipientCurrent.mockRejectedValue(new Error('identity unavailable'));
+    const sender = createSender();
+
+    const result = await runEmailNotificationDelivery(
+      {
+        categories: ['daily_reminder'],
+        schedulerDateUtc: '2026-07-09',
+      },
+      {
+        db: {} as never,
+        sender,
+        unsubscribeSecret: 'secret',
+        appUrl: 'https://atlaris.app',
+        now: new Date('2026-07-09T15:00:00.000Z'),
+      },
+    );
+
+    expect(sender.sendResolved).not.toHaveBeenCalled();
+    expect(markFailed).toHaveBeenCalledWith(
+      {
+        deliveryId: 'd1',
+        claimToken: 'claim-1',
+        failureClass: 'recipient_processing_error',
+      },
+      expect.anything(),
+    );
+    expect(result).toMatchObject({
+      claimed: 1,
+      failed: 1,
+      recipientErrors: 0,
+      pageFailure: {
+        kind: 'retryable',
+        failureClass: 'recipient_processing_error',
+        retryAfterMs: 60_000,
+      },
+    });
+  });
+
+  it('finalizes a fresh claim when the final preference check fails', async () => {
+    getPrefs
+      .mockResolvedValueOnce({
+        unsubscribeAllOptionalEmails: false,
+        categories: {
+          weekly_summary: false,
+          daily_reminder: true,
+          streak_reminder: false,
+        },
+      })
+      .mockRejectedValueOnce(new Error('preferences unavailable'));
+    const sender = createSender();
+
+    const result = await runEmailNotificationDelivery(
+      {
+        categories: ['daily_reminder'],
+        schedulerDateUtc: '2026-07-09',
+      },
+      {
+        db: {} as never,
+        sender,
+        unsubscribeSecret: 'secret',
+        appUrl: 'https://atlaris.app',
+        now: new Date('2026-07-09T15:00:00.000Z'),
+      },
+    );
+
+    expect(sender.sendResolved).not.toHaveBeenCalled();
+    expect(markFailed).toHaveBeenCalledWith(
+      {
+        deliveryId: 'd1',
+        claimToken: 'claim-1',
+        failureClass: 'recipient_processing_error',
+      },
+      expect.anything(),
+    );
+    expect(result).toMatchObject({
+      claimed: 1,
+      failed: 1,
+      recipientErrors: 0,
+      pageFailure: {
+        kind: 'retryable',
+        failureClass: 'recipient_processing_error',
+        retryAfterMs: 60_000,
+      },
+    });
   });
 
   it('requires manual review when an expired pending request no longer matches the recipient', async () => {

--- a/tests/unit/features/plans/write-service.spec.ts
+++ b/tests/unit/features/plans/write-service.spec.ts
@@ -53,8 +53,8 @@ describe('removePlanForWrite', () => {
 
 describe('removePlansForWrite', () => {
   const userId = createId('user');
-  const firstPlanId = createId('plan');
-  const secondPlanId = createId('plan');
+  const firstPlanId = '00000000-0000-4000-8000-000000000001';
+  const secondPlanId = '00000000-0000-4000-8000-000000000002';
 
   beforeEach(() => {
     mockDeletePlan.mockReset();
@@ -119,6 +119,41 @@ describe('removePlansForWrite', () => {
         reason: 'not_found',
         message: 'Learning plan not found.',
       },
+    ]);
+  });
+
+  it('acquires plan locks in canonical UUID order while preserving result order', async () => {
+    const laterPlanId = 'f0000000-0000-4000-8000-000000000000';
+    const earlierPlanId = 'A0000000-0000-4000-8000-000000000000';
+    mockDeletePlan
+      .mockResolvedValueOnce({ success: true })
+      .mockResolvedValueOnce({ success: false, reason: 'not_found' });
+
+    const results = await removePlansForWrite({
+      planIds: [laterPlanId, earlierPlanId],
+      userId,
+    });
+
+    expect(mockDeletePlan).toHaveBeenNthCalledWith(
+      1,
+      earlierPlanId,
+      userId,
+      serviceRoleDb,
+    );
+    expect(mockDeletePlan).toHaveBeenNthCalledWith(
+      2,
+      laterPlanId,
+      userId,
+      serviceRoleDb,
+    );
+    expect(results).toEqual([
+      {
+        planId: laterPlanId,
+        success: false,
+        reason: 'not_found',
+        message: 'Learning plan not found.',
+      },
+      { planId: earlierPlanId, success: true },
     ]);
   });
 

--- a/tests/unit/features/plans/write-service.spec.ts
+++ b/tests/unit/features/plans/write-service.spec.ts
@@ -115,25 +115,29 @@ describe('removePlansForWrite', () => {
     ]);
   });
 
-  it('returns per-plan unknown failures when deletePlan throws', async () => {
+  it('propagates unexpected delete errors instead of converting them to conflicts', async () => {
+    const error = new Error('database unavailable');
+    mockDeletePlan.mockRejectedValueOnce(error);
+
+    await expect(
+      removePlansForWrite({
+        planIds: [firstPlanId, secondPlanId],
+        userId,
+      }),
+    ).rejects.toBe(error);
+  });
+
+  it('propagates a later unexpected delete error after an earlier success', async () => {
+    const error = new Error('database unavailable');
     mockDeletePlan
-      .mockRejectedValueOnce(new Error('database unavailable'))
-      .mockResolvedValueOnce({ success: true });
+      .mockResolvedValueOnce({ success: true })
+      .mockRejectedValueOnce(error);
 
-    const results = await removePlansForWrite({
-      planIds: [firstPlanId, secondPlanId],
-      userId,
-    });
-
-    expect(mockDeletePlan).toHaveBeenCalledTimes(2);
-    expect(results).toEqual([
-      {
-        planId: firstPlanId,
-        success: false,
-        reason: 'unknown',
-        message: 'Cannot delete learning plan in its current state.',
-      },
-      { planId: secondPlanId, success: true },
-    ]);
+    await expect(
+      removePlansForWrite({
+        planIds: [firstPlanId, secondPlanId],
+        userId,
+      }),
+    ).rejects.toBe(error);
   });
 });

--- a/tests/unit/features/plans/write-service.spec.ts
+++ b/tests/unit/features/plans/write-service.spec.ts
@@ -3,6 +3,7 @@ import {
   removePlansForWrite,
 } from '@/features/plans/write-service';
 import { deletePlan } from '@/lib/db/queries/plans';
+import { db as serviceRoleDb } from '@supabase/service-role';
 import { createId } from '@tests/fixtures/ids';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -11,6 +12,7 @@ vi.mock('@/lib/db/queries/plans', () => ({
 }));
 
 const mockDeletePlan = vi.mocked(deletePlan);
+const mockTransaction = vi.mocked(serviceRoleDb.transaction);
 
 describe('removePlanForWrite', () => {
   const planId = createId('plan');
@@ -18,6 +20,7 @@ describe('removePlanForWrite', () => {
 
   beforeEach(() => {
     mockDeletePlan.mockReset();
+    mockTransaction.mockClear();
   });
 
   it('delegates to deletePlan with ownership context only', async () => {
@@ -55,6 +58,7 @@ describe('removePlansForWrite', () => {
 
   beforeEach(() => {
     mockDeletePlan.mockReset();
+    mockTransaction.mockClear();
   });
 
   it('returns all successes when every plan deletes', async () => {
@@ -69,6 +73,19 @@ describe('removePlansForWrite', () => {
       { planId: firstPlanId, success: true },
       { planId: secondPlanId, success: true },
     ]);
+    expect(mockTransaction).toHaveBeenCalledTimes(1);
+    expect(mockDeletePlan).toHaveBeenNthCalledWith(
+      1,
+      firstPlanId,
+      userId,
+      serviceRoleDb,
+    );
+    expect(mockDeletePlan).toHaveBeenNthCalledWith(
+      2,
+      secondPlanId,
+      userId,
+      serviceRoleDb,
+    );
   });
 
   it('returns per-plan success and failure results without throwing', async () => {
@@ -81,8 +98,19 @@ describe('removePlansForWrite', () => {
       userId,
     });
 
-    expect(mockDeletePlan).toHaveBeenNthCalledWith(1, firstPlanId, userId);
-    expect(mockDeletePlan).toHaveBeenNthCalledWith(2, secondPlanId, userId);
+    expect(mockTransaction).toHaveBeenCalledTimes(1);
+    expect(mockDeletePlan).toHaveBeenNthCalledWith(
+      1,
+      firstPlanId,
+      userId,
+      serviceRoleDb,
+    );
+    expect(mockDeletePlan).toHaveBeenNthCalledWith(
+      2,
+      secondPlanId,
+      userId,
+      serviceRoleDb,
+    );
     expect(results).toEqual([
       { planId: firstPlanId, success: true },
       {
@@ -127,7 +155,7 @@ describe('removePlansForWrite', () => {
     ).rejects.toBe(error);
   });
 
-  it('propagates a later unexpected delete error after an earlier success', async () => {
+  it('propagates a later unexpected delete error from the shared transaction', async () => {
     const error = new Error('database unavailable');
     mockDeletePlan
       .mockResolvedValueOnce({ success: true })
@@ -139,5 +167,18 @@ describe('removePlansForWrite', () => {
         userId,
       }),
     ).rejects.toBe(error);
+    expect(mockTransaction).toHaveBeenCalledTimes(1);
+    expect(mockDeletePlan).toHaveBeenNthCalledWith(
+      1,
+      firstPlanId,
+      userId,
+      serviceRoleDb,
+    );
+    expect(mockDeletePlan).toHaveBeenNthCalledWith(
+      2,
+      secondPlanId,
+      userId,
+      serviceRoleDb,
+    );
   });
 });

--- a/tests/unit/helpers/db/server-owned-write-privilege-bootstrap-sync.spec.ts
+++ b/tests/unit/helpers/db/server-owned-write-privilege-bootstrap-sync.spec.ts
@@ -63,4 +63,28 @@ describe('server-owned write privilege bootstrap sync', () => {
       /REVOKE INSERT, UPDATE, DELETE ON[\s\S]*AUTHENTICATED_SERVER_OWNED_WRITE_TABLES_SQL[\s\S]*FROM authenticated/,
     );
   });
+
+  it('mirrors the production default-write revoke in both bootstraps', () => {
+    const defaultWriteRevoke =
+      /ALTER DEFAULT PRIVILEGES IN SCHEMA public\s+REVOKE INSERT, UPDATE, DELETE ON TABLES FROM authenticated/;
+    const migration = readFileSync(
+      resolve(
+        REPO_ROOT,
+        'supabase/migrations/20260520194501_harden_authenticated_server_owned_writes.sql',
+      ),
+      'utf8',
+    );
+    const bootstrap = readFileSync(
+      resolve(TEST_DIR, '../../../helpers/db/bootstrap.ts'),
+      'utf8',
+    );
+    const rlsBootstrap = readFileSync(
+      resolve(TEST_DIR, '../../../helpers/db/rls-bootstrap.ts'),
+      'utf8',
+    );
+
+    expect(migration).toMatch(defaultWriteRevoke);
+    expect(bootstrap).toMatch(defaultWriteRevoke);
+    expect(rlsBootstrap).toMatch(defaultWriteRevoke);
+  });
 });


### PR DESCRIPTION
## Summary

- Completes the remaining I1-I8 security hardening directly above #458.
- Inherits I3 and I7, plus verified foundations of I4, I6, and I8, from the parent layer.
- Adds zero-candidate CI handling, correct bulk-delete failure boundaries, last-moment recipient identity/freshness/preference checks, resolved-delivery payload scrubbing, and effective-privilege attestation.

## Verification

- Focused unit: 6 files / 48 tests
- Focused integration: 3 files / 25 tests
- Security suite: 5 files / 40 tests
- Full lint and TypeScript checks passed on push.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Unable to generate summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f6cf1bdae4c5fdbeeb7712963c07bde1ca4b4f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->