### PR TITLE
fix(ci): run PR workflow for stacked bases

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -2,7 +2,6 @@ name: CI - PR (trunk)
 
 on:
   pull_request:
-    branches: [main, develop]
     paths-ignore:
       - '**/*.md'
       - 'docs/**'


### PR DESCRIPTION
## Summary

- run PR CI for stacked pull requests whose base is another feature branch
- preserve the existing path-ignore rules and manual dispatch inputs

## Verification

- exact one-line workflow trigger diff
- hosted PR checks will validate the workflow on this branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line trigger change in CI only; it may increase workflow runs for PRs against other branches but does not alter application or security logic.
> 
> **Overview**
> **PR CI** in `ci-pr.yml` no longer limits `pull_request` to bases `main` and `develop`, so the trunk PR workflow runs when the base is another feature branch (stacked PRs).
> 
> Existing **`paths-ignore`** rules and **`workflow_dispatch`** inputs are unchanged; only the base-branch filter is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d168e0c5f5c7e3e717b0fa1782826cf5ba282c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->