### PR TITLE
fix(lessons): start polling after workflow enqueue

### DIFF
--- a/src/app/(app)/plans/[id]/components/GenerationStatusContent.tsx
+++ b/src/app/(app)/plans/[id]/components/GenerationStatusContent.tsx
@@ -40,7 +40,12 @@ export function GenerationStatusContent({
         />
       );
     case 'processing':
-      return <ProcessingPanel attempts={viewState.attempts} />;
+      return (
+        <ProcessingPanel
+          attempts={viewState.attempts}
+          attemptCap={viewState.attemptCap}
+        />
+      );
     case 'pending':
       return <PendingPanel />;
     case 'ready':

--- a/src/app/(app)/plans/[id]/components/GenerationStatusPanels.tsx
+++ b/src/app/(app)/plans/[id]/components/GenerationStatusPanels.tsx
@@ -3,10 +3,7 @@ import {
   ExhaustedRetriesMessage,
   RetryAction,
 } from './generation-retry-actions';
-import {
-  MAX_RETRY_ATTEMPTS,
-  type PlanPendingViewState,
-} from './plan-pending-view-state';
+import { type PlanPendingViewState } from './plan-pending-view-state';
 import { Button } from '@/components/ui/button';
 import { Loader2, RefreshCw } from 'lucide-react';
 
@@ -34,7 +31,7 @@ export function FailurePanel({
       meta={
         viewState.attempts > 0 ? (
           <p className='text-sm text-muted-foreground'>
-            Attempt {viewState.attempts} of {MAX_RETRY_ATTEMPTS}
+            Attempt {viewState.attempts} of {viewState.attemptCap}
           </p>
         ) : null
       }
@@ -44,6 +41,7 @@ export function FailurePanel({
         ) : (
           <RetryAction
             attempts={viewState.attempts}
+            attemptCap={viewState.attemptCap}
             isRetrying={viewState.isRetrying}
             isRetryDisabled={isRetryDisabled}
             onRetry={onRetry}
@@ -76,7 +74,13 @@ export function ConnectionIssuePanel({
   );
 }
 
-export function ProcessingPanel({ attempts }: { attempts: number }) {
+export function ProcessingPanel({
+  attempts,
+  attemptCap,
+}: {
+  attempts: number;
+  attemptCap: number;
+}) {
   return (
     <div className='flex items-start gap-3 rounded-lg bg-primary/5 p-4'>
       <Loader2 className='mt-0.5 size-5 shrink-0 animate-spin text-primary motion-reduce:animate-none' />
@@ -88,7 +92,7 @@ export function ProcessingPanel({ attempts }: { attempts: number }) {
         </p>
         {attempts > 1 ? (
           <p className='text-sm text-muted-foreground'>
-            Attempt {attempts} of {MAX_RETRY_ATTEMPTS}
+            Attempt {attempts} of {attemptCap}
           </p>
         ) : null}
       </div>

--- a/src/app/(app)/plans/[id]/components/PlanDetails.tsx
+++ b/src/app/(app)/plans/[id]/components/PlanDetails.tsx
@@ -55,10 +55,9 @@ export function PlanDetails({ plan }: PlanDetailClientProps): ReactElement {
 
   const overviewStats = computeOverviewStats(plan, statuses);
 
-  const isPendingOrProcessing =
+  const isGenerating =
     plan.status === 'pending' || plan.status === 'processing';
-
-  const isGenerating = isPendingOrProcessing;
+  const shouldShowPendingState = isGenerating || plan.status === 'failed';
 
   return (
     <div className='pb-12 md:pb-20'>
@@ -90,7 +89,7 @@ export function PlanDetails({ plan }: PlanDetailClientProps): ReactElement {
         </div>
       </header>
 
-      {isPendingOrProcessing ? (
+      {shouldShowPendingState ? (
         <PlanPendingState plan={plan} />
       ) : (
         <>

--- a/src/app/(app)/plans/[id]/components/PlanPendingState.tsx
+++ b/src/app/(app)/plans/[id]/components/PlanPendingState.tsx
@@ -26,6 +26,7 @@ export function PlanPendingState({ plan }: PlanPendingStateProps) {
   const planGenerationSession = usePlanGenerationSession();
   const { status, attempts, error, pollingError, isPolling, revalidate } =
     usePlanStatus(plan.id, plan.status ?? 'pending');
+  const currentAttempts = plan.status === 'failed' ? plan.attempts : attempts;
 
   const {
     status: retryStatus,
@@ -35,7 +36,7 @@ export function PlanPendingState({ plan }: PlanPendingStateProps) {
   } = useRetryGeneration(
     plan.id,
     MAX_RETRY_ATTEMPTS,
-    attempts,
+    currentAttempts,
     planGenerationSession,
   );
 
@@ -48,7 +49,7 @@ export function PlanPendingState({ plan }: PlanPendingStateProps) {
   const viewState = buildPlanPendingViewState({
     status,
     retryStatus,
-    attempts,
+    attempts: currentAttempts,
     error,
     pollingError,
     retryError,

--- a/src/app/(app)/plans/[id]/components/PlanPendingState.tsx
+++ b/src/app/(app)/plans/[id]/components/PlanPendingState.tsx
@@ -4,10 +4,7 @@ import type { ClientPlanDetail } from '@/shared/types/client.types';
 
 import { GenerationStatusContent } from './GenerationStatusContent';
 import { PendingPlanDetails } from './PendingPlanDetails';
-import {
-  buildPlanPendingViewState,
-  MAX_RETRY_ATTEMPTS,
-} from './plan-pending-view-state';
+import { buildPlanPendingViewState } from './plan-pending-view-state';
 import { PlanStatusHeader } from './PlanStatusHeader';
 import { Card, CardContent } from '@/components/ui/card';
 import { usePlanGenerationSession } from '@/features/plans/session/usePlanGenerationSession';
@@ -35,7 +32,7 @@ export function PlanPendingState({ plan }: PlanPendingStateProps) {
     retryGeneration,
   } = useRetryGeneration(
     plan.id,
-    MAX_RETRY_ATTEMPTS,
+    plan.attemptCap,
     currentAttempts,
     planGenerationSession,
   );
@@ -50,6 +47,7 @@ export function PlanPendingState({ plan }: PlanPendingStateProps) {
     status,
     retryStatus,
     attempts: currentAttempts,
+    attemptCap: plan.attemptCap,
     error,
     pollingError,
     retryError,

--- a/src/app/(app)/plans/[id]/components/generation-retry-actions.tsx
+++ b/src/app/(app)/plans/[id]/components/generation-retry-actions.tsx
@@ -1,15 +1,16 @@
-import { MAX_RETRY_ATTEMPTS } from './plan-pending-view-state';
 import { Button } from '@/components/ui/button';
 import { Loader2, RefreshCw } from 'lucide-react';
 import Link from 'next/link';
 
 export function RetryAction({
   attempts,
+  attemptCap,
   isRetrying,
   isRetryDisabled,
   onRetry,
 }: {
   attempts: number;
+  attemptCap: number;
   isRetrying: boolean;
   isRetryDisabled: boolean;
   onRetry: () => void;
@@ -24,7 +25,7 @@ export function RetryAction({
       ) : (
         <>
           <RefreshCw className='mr-2 size-4' />
-          Retry Generation ({MAX_RETRY_ATTEMPTS - attempts} attempts remaining)
+          Retry Generation ({attemptCap - attempts} attempts remaining)
         </>
       )}
     </Button>

--- a/src/app/(app)/plans/[id]/components/plan-pending-view-state.ts
+++ b/src/app/(app)/plans/[id]/components/plan-pending-view-state.ts
@@ -1,9 +1,6 @@
 import type { ClientPlanDetail, PlanStatus } from '@/shared/types/client.types';
 
-import { DEFAULT_ATTEMPT_CAP } from '@/features/ai/constants';
 import { PLAN_STATUSES } from '@/shared/types/client';
-
-export const MAX_RETRY_ATTEMPTS = DEFAULT_ATTEMPT_CAP;
 
 const ORIGIN_LABELS: Record<'ai' | 'manual' | 'template', string> = {
   ai: 'AI',
@@ -29,6 +26,7 @@ export interface PlanPendingViewState {
   status: PlanStatus | string;
   panelKind: PlanPendingPanelKind;
   attempts: number;
+  attemptCap: number;
   displayError: string | null;
   failedPlanMessage: string | null;
   hasExhaustedRetries: boolean;
@@ -84,6 +82,7 @@ export function buildPlanPendingViewState(params: {
   status: string;
   retryStatus: string;
   attempts: number;
+  attemptCap: number;
   error: string | null;
   pollingError: string | null;
   retryError: string | null;
@@ -114,9 +113,10 @@ export function buildPlanPendingViewState(params: {
     status,
     panelKind,
     attempts: params.attempts,
+    attemptCap: params.attemptCap,
     displayError,
     failedPlanMessage,
-    hasExhaustedRetries: params.attempts >= MAX_RETRY_ATTEMPTS,
+    hasExhaustedRetries: params.attempts >= params.attemptCap,
     isRetrying,
     retryInterrupted,
   };

--- a/src/app/(app)/plans/[id]/modules/[moduleId]/components/useModuleLessonGeneration.ts
+++ b/src/app/(app)/plans/[id]/modules/[moduleId]/components/useModuleLessonGeneration.ts
@@ -84,6 +84,8 @@ export function useModuleLessonGeneration({
   const [longGenerationKey, setLongGenerationKey] =
     useState<LongGenerationKey | null>(null);
   const generationPollCountRef = useRef(0);
+  // Distinguishes pre-claim queue latency from post-claim terminal rollbacks.
+  const hasObservedGeneratingRef = useRef(false);
   const generationRequested =
     requestedGenerationKey?.planId === planId &&
     requestedGenerationKey.moduleId === moduleId;
@@ -94,6 +96,10 @@ export function useModuleLessonGeneration({
     longGenerationKey.moduleId === moduleId;
 
   useEffect(() => {
+    if (status === 'generating') {
+      hasObservedGeneratingRef.current = true;
+    }
+
     if (status !== 'generating' && !generationRequested) {
       generationPollCountRef.current = 0;
       return;
@@ -169,9 +175,18 @@ export function useModuleLessonGeneration({
           return 'error';
         }
 
+        if (parsed.data.status === 'generating') {
+          hasObservedGeneratingRef.current = true;
+          return 'continue';
+        }
+
+        // Pre-claim only: workflow may still show not_generated/failed until CAS.
+        // After generating was observed, those statuses are terminal (e.g. quota rollback).
         if (
-          parsed.data.status === 'generating' ||
-          (generationRequested && parsed.data.status === 'not_generated')
+          generationRequested &&
+          !hasObservedGeneratingRef.current &&
+          (parsed.data.status === 'not_generated' ||
+            parsed.data.status === 'failed')
         ) {
           return 'continue';
         }
@@ -266,6 +281,7 @@ export function useModuleLessonGeneration({
     setQuotaMessage(null);
     setRequestedGenerationKey(null);
     setLongGenerationKey(null);
+    hasObservedGeneratingRef.current = false;
     startTransition(async () => {
       try {
         const response = await fetch(

--- a/src/app/(app)/plans/[id]/modules/[moduleId]/components/useModuleLessonGeneration.ts
+++ b/src/app/(app)/plans/[id]/modules/[moduleId]/components/useModuleLessonGeneration.ts
@@ -17,12 +17,13 @@ const MODULE_LESSON_GENERATION_STATUS_TIMEOUT_MS = 10_000;
 type LongGenerationKey = {
   planId: string;
   moduleId: string;
+  workflowRunId?: string;
 };
 
 function applyModuleLessonGenerationResponse(
   body: ModuleLessonGenerationApiResponse,
   params: {
-    markGenerating: () => void;
+    markGenerating: (workflowRunId?: string) => void;
     setQuotaMessage: (value: string | null) => void;
     refresh: () => void;
   },
@@ -52,7 +53,7 @@ function applyModuleLessonGenerationResponse(
       refresh();
       return;
     case 'generating':
-      markGenerating();
+      markGenerating(body.workflowRunId);
       refresh();
       return;
     case 'ready':
@@ -89,6 +90,7 @@ export function useModuleLessonGeneration({
   const generationRequested =
     requestedGenerationKey?.planId === planId &&
     requestedGenerationKey.moduleId === moduleId;
+  const requestedWorkflowRunId = requestedGenerationKey?.workflowRunId;
   const generationTakingLong =
     (status === 'generating' || generationRequested) &&
     previousModulesComplete &&
@@ -180,15 +182,23 @@ export function useModuleLessonGeneration({
           return 'continue';
         }
 
-        // Pre-claim only: workflow may still show not_generated/failed until CAS.
-        // After generating was observed, those statuses are terminal (e.g. quota rollback).
+        // A matching workflow run proves the queued request claimed and settled.
+        // Otherwise, wait for a visible claim before treating it as terminal.
         if (
           generationRequested &&
-          !hasObservedGeneratingRef.current &&
           (parsed.data.status === 'not_generated' ||
             parsed.data.status === 'failed')
         ) {
-          return 'continue';
+          if (
+            requestedWorkflowRunId !== undefined &&
+            requestedWorkflowRunId === parsed.data.workflowRunId
+          ) {
+            return 'terminal';
+          }
+
+          if (!hasObservedGeneratingRef.current) {
+            return 'continue';
+          }
         }
 
         return 'terminal';
@@ -270,6 +280,7 @@ export function useModuleLessonGeneration({
     planId,
     previousModulesComplete,
     refresh,
+    requestedWorkflowRunId,
     status,
   ]);
 
@@ -329,7 +340,8 @@ export function useModuleLessonGeneration({
         }
 
         applyModuleLessonGenerationResponse(parsed.data, {
-          markGenerating: () => setRequestedGenerationKey({ planId, moduleId }),
+          markGenerating: (workflowRunId) =>
+            setRequestedGenerationKey({ planId, moduleId, workflowRunId }),
           setQuotaMessage,
           refresh,
         });

--- a/src/app/(app)/plans/[id]/modules/[moduleId]/components/useModuleLessonGeneration.ts
+++ b/src/app/(app)/plans/[id]/modules/[moduleId]/components/useModuleLessonGeneration.ts
@@ -169,7 +169,10 @@ export function useModuleLessonGeneration({
           return 'error';
         }
 
-        if (parsed.data.status === 'generating') {
+        if (
+          parsed.data.status === 'generating' ||
+          (generationRequested && parsed.data.status === 'not_generated')
+        ) {
           return 'continue';
         }
 

--- a/src/app/(app)/plans/[id]/modules/[moduleId]/components/useModuleLessonGeneration.ts
+++ b/src/app/(app)/plans/[id]/modules/[moduleId]/components/useModuleLessonGeneration.ts
@@ -22,11 +22,12 @@ type LongGenerationKey = {
 function applyModuleLessonGenerationResponse(
   body: ModuleLessonGenerationApiResponse,
   params: {
+    markGenerating: () => void;
     setQuotaMessage: (value: string | null) => void;
     refresh: () => void;
   },
 ): void {
-  const { setQuotaMessage, refresh } = params;
+  const { markGenerating, setQuotaMessage, refresh } = params;
 
   switch (body.state) {
     case 'quota_denied':
@@ -50,8 +51,11 @@ function applyModuleLessonGenerationResponse(
       toast.error('Plan or module was not found.');
       refresh();
       return;
-    case 'ready':
     case 'generating':
+      markGenerating();
+      refresh();
+      return;
+    case 'ready':
       refresh();
       return;
     default: {
@@ -75,17 +79,22 @@ export function useModuleLessonGeneration({
   const { refresh } = useRouter();
   const [isPending, startTransition] = useTransition();
   const [quotaMessage, setQuotaMessage] = useState<string | null>(null);
+  const [requestedGenerationKey, setRequestedGenerationKey] =
+    useState<LongGenerationKey | null>(null);
   const [longGenerationKey, setLongGenerationKey] =
     useState<LongGenerationKey | null>(null);
   const generationPollCountRef = useRef(0);
+  const generationRequested =
+    requestedGenerationKey?.planId === planId &&
+    requestedGenerationKey.moduleId === moduleId;
   const generationTakingLong =
-    status === 'generating' &&
+    (status === 'generating' || generationRequested) &&
     previousModulesComplete &&
     longGenerationKey?.planId === planId &&
     longGenerationKey.moduleId === moduleId;
 
   useEffect(() => {
-    if (status !== 'generating') {
+    if (status !== 'generating' && !generationRequested) {
       generationPollCountRef.current = 0;
       return;
     }
@@ -204,6 +213,7 @@ export function useModuleLessonGeneration({
               return;
             }
             if (outcome === 'terminal') {
+              setRequestedGenerationKey(null);
               refresh();
               return;
             }
@@ -236,7 +246,14 @@ export function useModuleLessonGeneration({
         window.clearTimeout(timeoutId);
       }
     };
-  }, [moduleId, planId, previousModulesComplete, refresh, status]);
+  }, [
+    generationRequested,
+    moduleId,
+    planId,
+    previousModulesComplete,
+    refresh,
+    status,
+  ]);
 
   const generateLessons = (): void => {
     if (!previousModulesComplete) {
@@ -244,6 +261,7 @@ export function useModuleLessonGeneration({
     }
 
     setQuotaMessage(null);
+    setRequestedGenerationKey(null);
     setLongGenerationKey(null);
     startTransition(async () => {
       try {
@@ -292,6 +310,7 @@ export function useModuleLessonGeneration({
         }
 
         applyModuleLessonGenerationResponse(parsed.data, {
+          markGenerating: () => setRequestedGenerationKey({ planId, moduleId }),
           setQuotaMessage,
           refresh,
         });
@@ -309,7 +328,7 @@ export function useModuleLessonGeneration({
   return {
     generateLessons,
     generationTakingLong,
-    isPending,
+    isPending: isPending || generationRequested,
     quotaMessage,
   };
 }

--- a/src/app/api/v1/clerk/billing/webhook/route.ts
+++ b/src/app/api/v1/clerk/billing/webhook/route.ts
@@ -2,7 +2,7 @@ import type { PlainHandler } from '@/lib/api/auth';
 import type { WebhookEvent } from '@clerk/nextjs/webhooks';
 
 import { applyVerifiedClerkBillingEvent } from '@/features/billing/clerk-billing/reconciliation';
-import { RateLimitError } from '@/lib/api/errors';
+import { RateLimitError, toErrorResponse } from '@/lib/api/errors';
 import { checkIpRateLimit } from '@/lib/api/ip-rate-limit';
 import { withErrorBoundary } from '@/lib/api/route-wrappers';
 import { clerkAuthEnv } from '@/lib/config/env';
@@ -58,7 +58,7 @@ export const POST: PlainHandler = withErrorBoundary(async (req: Request) => {
         { event: 'clerk_billing_webhook_rate_limited', requestId },
         'Clerk Billing webhook rate limited',
       );
-      return respond('rate limited', { status: 429 });
+      return attachRequestIdHeader(toErrorResponse(error), requestId);
     }
     throw error;
   }

--- a/src/app/api/v1/plans/[planId]/modules/[moduleId]/lesson-content/generate/handler.ts
+++ b/src/app/api/v1/plans/[planId]/modules/[moduleId]/lesson-content/generate/handler.ts
@@ -71,6 +71,15 @@ function mapModuleLessonGenerationResult(
 ) {
   switch (result.kind) {
     case 'workflow_started':
+      return json(
+        ModuleLessonGenerationApiResponseSchema.parse({
+          state: 'generating',
+          planId,
+          moduleId,
+          workflowRunId: result.runId,
+        }),
+        { status: 202 },
+      );
     case 'in_flight':
       return json(
         ModuleLessonGenerationApiResponseSchema.parse({

--- a/src/features/plans/lifecycle/generation-finalization/store.ts
+++ b/src/features/plans/lifecycle/generation-finalization/store.ts
@@ -136,6 +136,7 @@ export async function commitPlanGenerationFailure(
   const metadata = buildMetadata({
     sanitized: input.preparation.sanitized,
     providerMetadata: input.providerMetadata,
+    workflowMetadata: input.workflowMetadata,
     modulesClamped: false,
     tasksClamped: false,
     startedAt: input.preparation.startedAt,

--- a/src/features/plans/lifecycle/generation-finalization/types.ts
+++ b/src/features/plans/lifecycle/generation-finalization/types.ts
@@ -48,6 +48,7 @@ export type FinalizeGenerationFailureWithAttemptInput = {
   readonly timedOut: boolean;
   readonly extendedTimeout: boolean;
   readonly providerMetadata?: ProviderMetadata;
+  readonly workflowMetadata?: AttemptWorkflowMetadata;
   readonly usage?: CanonicalAIUsage;
   readonly usageKind: 'plan';
   readonly retryable: boolean;

--- a/src/features/plans/lifecycle/service.ts
+++ b/src/features/plans/lifecycle/service.ts
@@ -386,6 +386,17 @@ export class PlanLifecycleService {
           timedOut: generationResult.timedOut ?? false,
           extendedTimeout: generationResult.extendedTimeout ?? false,
           providerMetadata: generationResult.metadata,
+          ...(input.workflowMetadata
+            ? {
+                workflowMetadata: {
+                  ...input.workflowMetadata,
+                  completedAt: deterministicCompletedAt(
+                    reservation.startedAt,
+                    generationResult.durationMs,
+                  ),
+                },
+              }
+            : {}),
         });
       } else {
         logger.error(

--- a/src/features/plans/read-projection/detail-dto.ts
+++ b/src/features/plans/read-projection/detail-dto.ts
@@ -179,6 +179,7 @@ export function toClientPlanDetail(
     completedMinutes: detail.completedMinutes,
     completedModules: detail.completedModules,
     attempts: detail.attemptsCount,
+    attemptCap: statusSnapshot.attemptCap,
     status: statusSnapshot.status,
     latestAttempt: detail.latestAttempt
       ? toClientAttempt(detail.latestAttempt)

--- a/src/features/plans/read-projection/detail-dto.ts
+++ b/src/features/plans/read-projection/detail-dto.ts
@@ -178,6 +178,7 @@ export function toClientPlanDetail(
     totalMinutes: detail.totalMinutes,
     completedMinutes: detail.completedMinutes,
     completedModules: detail.completedModules,
+    attempts: detail.attemptsCount,
     status: statusSnapshot.status,
     latestAttempt: detail.latestAttempt
       ? toClientAttempt(detail.latestAttempt)

--- a/src/features/plans/read-projection/detail-status.ts
+++ b/src/features/plans/read-projection/detail-status.ts
@@ -26,6 +26,7 @@ export type PlanDetailStatusSnapshot = {
   planId: string;
   status: ClientPlanStatus;
   attempts: number;
+  attemptCap: number;
   latestClassification: FailureClassification | 'unknown' | null;
   createdAt: string | undefined;
   updatedAt: string | undefined;
@@ -41,6 +42,7 @@ export function buildPlanDetailStatusSnapshot(params: {
   latestAttempt: Pick<GenerationAttempt, 'classification'> | null;
 }): PlanDetailStatusSnapshot {
   const { plan, hasModules, attemptsCount, latestAttempt } = params;
+  const attemptCap = getGenerationAttemptCap();
 
   return {
     planId: plan.id,
@@ -48,9 +50,10 @@ export function buildPlanDetailStatusSnapshot(params: {
       generationStatus: plan.generationStatus,
       hasModules,
       attemptsCount,
-      attemptCap: getGenerationAttemptCap(),
+      attemptCap,
     }),
     attempts: attemptsCount,
+    attemptCap,
     latestClassification: toStatusClassification(latestAttempt?.classification),
     createdAt: plan.createdAt?.toISOString(),
     updatedAt: plan.updatedAt?.toISOString(),

--- a/src/features/plans/read-projection/service.ts
+++ b/src/features/plans/read-projection/service.ts
@@ -235,22 +235,23 @@ export async function getModuleLessonGenerationStatusForRead(params: {
   planId: string;
   moduleId: string;
   status: 'not_generated' | 'generating' | 'ready' | 'failed';
+  workflowRunId?: string;
 } | null> {
-  const status = await getModuleLessonGenerationStatus(
+  const snapshot = await getModuleLessonGenerationStatus(
     params.planId,
     params.moduleId,
     params.userId,
     params.dbClient,
   );
 
-  if (!status) {
+  if (!snapshot) {
     return null;
   }
 
   return {
     planId: params.planId,
     moduleId: params.moduleId,
-    status,
+    ...snapshot,
   };
 }
 

--- a/src/hooks/useRetryGeneration.ts
+++ b/src/hooks/useRetryGeneration.ts
@@ -82,13 +82,14 @@ export function useRetryGeneration(
     }, RETRY_COOLDOWN_MS);
 
     try {
-      const result = await startSession({ kind: 'retry', planId });
-      if (result.status === 'completed') {
-        router.refresh();
-      }
+      // Refresh on any settle so failed-plan SSR `plan.attempts` rehydrates
+      // (terminal usePlanStatus keeps poller attempts at 0).
+      await startSession({ kind: 'retry', planId });
+      router.refresh();
     } catch (error) {
       if (!(error instanceof DOMException && error.name === 'AbortError')) {
         clientLogger.error('Retry generation failed:', error);
+        router.refresh();
       }
     }
 

--- a/src/lib/db/queries/modules.ts
+++ b/src/lib/db/queries/modules.ts
@@ -103,12 +103,16 @@ export async function getModuleLessonGenerationStatus(
   moduleId: string,
   userId: string,
   dbClient?: ModulesDbClient,
-): Promise<'not_generated' | 'generating' | 'ready' | 'failed' | null> {
+): Promise<{
+  status: 'not_generated' | 'generating' | 'ready' | 'failed';
+  workflowRunId?: string;
+} | null> {
   const client = dbClient ?? getDb();
 
   const [row] = await client
     .select({
       status: modules.lessonGenerationStatus,
+      metadata: modules.lessonGenerationMetadata,
     })
     .from(modules)
     .innerJoin(learningPlans, eq(modules.planId, learningPlans.id))
@@ -125,5 +129,10 @@ export async function getModuleLessonGenerationStatus(
     return null;
   }
 
-  return row.status;
+  return {
+    status: row.status,
+    ...(row.metadata?.workflow?.runId
+      ? { workflowRunId: row.metadata.workflow.runId }
+      : {}),
+  };
 }

--- a/src/shared/schemas/lesson-content.schemas.ts
+++ b/src/shared/schemas/lesson-content.schemas.ts
@@ -96,6 +96,7 @@ export const ModuleLessonGenerationApiResponseSchema = z.discriminatedUnion(
     }),
     ModuleLessonGenerationApiBaseSchema.extend({
       state: z.literal('generating'),
+      workflowRunId: z.string().min(1).optional(),
     }),
     ModuleLessonGenerationApiBaseSchema.extend({
       state: z.literal('disabled'),
@@ -121,4 +122,5 @@ export const ModuleLessonGenerationApiResponseSchema = z.discriminatedUnion(
 export const ModuleLessonGenerationStatusResponseSchema =
   ModuleLessonGenerationApiBaseSchema.extend({
     status: z.enum(['not_generated', 'generating', 'ready', 'failed']),
+    workflowRunId: z.string().min(1).optional(),
   });

--- a/src/shared/types/client.types.ts
+++ b/src/shared/types/client.types.ts
@@ -77,6 +77,7 @@ export type ClientPlanDetail = {
   completedMinutes: number;
   completedModules: number;
   attempts: number;
+  attemptCap: number;
   status?: PlanStatus;
   latestAttempt?: ClientGenerationAttempt | null;
 };

--- a/src/shared/types/client.types.ts
+++ b/src/shared/types/client.types.ts
@@ -76,6 +76,7 @@ export type ClientPlanDetail = {
   totalMinutes: number;
   completedMinutes: number;
   completedModules: number;
+  attempts: number;
   status?: PlanStatus;
   latestAttempt?: ClientGenerationAttempt | null;
 };

--- a/tests/fixtures/plans.ts
+++ b/tests/fixtures/plans.ts
@@ -6,6 +6,7 @@
 import type { ClientPlanDetail } from '@/shared/types/client.types';
 import type { InferInsertModel, InferSelectModel } from 'drizzle-orm';
 
+import { DEFAULT_ATTEMPT_CAP } from '@/shared/constants/generation';
 import { learningPlans } from '@supabase/schema';
 import { db } from '@supabase/service-role';
 import { randomUUID } from 'node:crypto';
@@ -160,6 +161,7 @@ export function createTestPlanDetail(
     completedMinutes: 45,
     completedModules: 0,
     attempts: 0,
+    attemptCap: DEFAULT_ATTEMPT_CAP,
     status: 'ready',
     latestAttempt: null,
     modules: [

--- a/tests/fixtures/plans.ts
+++ b/tests/fixtures/plans.ts
@@ -159,6 +159,7 @@ export function createTestPlanDetail(
     totalMinutes: 90,
     completedMinutes: 45,
     completedModules: 0,
+    attempts: 0,
     status: 'ready',
     latestAttempt: null,
     modules: [

--- a/tests/integration/api/plans.module-lesson-content.generate.spec.ts
+++ b/tests/integration/api/plans.module-lesson-content.generate.spec.ts
@@ -150,6 +150,7 @@ describe('POST /api/v1/plans/:planId/modules/:moduleId/lesson-content/generate',
       state: 'generating',
       planId: VALID_PLAN_ID,
       moduleId: VALID_MODULE_ID,
+      workflowRunId: 'wrun_test123',
     });
   });
 

--- a/tests/integration/api/plans.module-lesson-content.status.spec.ts
+++ b/tests/integration/api/plans.module-lesson-content.status.spec.ts
@@ -38,6 +38,7 @@ async function seedOwnedPlanForStatusApi(userId: string): Promise<void> {
 async function seedOwnedModule(
   status: LessonGenerationStatus,
   moduleId = VALID_MODULE_ID,
+  workflowRunId?: string,
 ): Promise<void> {
   await db.insert(modules).values({
     id: moduleId,
@@ -47,6 +48,18 @@ async function seedOwnedModule(
     description: 'Module for lesson status API tests',
     estimatedMinutes: 30,
     lessonGenerationStatus: status,
+    ...(workflowRunId
+      ? {
+          lessonGenerationMetadata: {
+            version: 1,
+            workflow: {
+              provider: 'workflow-sdk',
+              runId: workflowRunId,
+              startedAt: '2026-08-08T00:00:00.000Z',
+            },
+          },
+        }
+      : {}),
   });
 }
 
@@ -102,6 +115,27 @@ describe('GET /api/v1/plans/:planId/modules/:moduleId/lesson-content/status', ()
       });
     },
   );
+
+  it('returns the persisted workflow run ID when available', async () => {
+    const userId = await authenticateTestUser('workflow-run-id');
+    await seedOwnedPlanForStatusApi(userId);
+    await seedOwnedModule('not_generated', VALID_MODULE_ID, 'wrun_current');
+
+    const response = await GET(
+      createRequest(),
+      buildRouteHandlerContext({
+        planId: VALID_PLAN_ID,
+        moduleId: VALID_MODULE_ID,
+      }),
+    );
+
+    expect(await response.json()).toEqual({
+      planId: VALID_PLAN_ID,
+      moduleId: VALID_MODULE_ID,
+      status: 'not_generated',
+      workflowRunId: 'wrun_current',
+    });
+  });
 
   it('returns 404 for a missing module', async () => {
     const userId = await authenticateTestUser('missing-module');

--- a/tests/integration/api/plans/plans-read.contract.spec.ts
+++ b/tests/integration/api/plans/plans-read.contract.spec.ts
@@ -83,6 +83,7 @@ const clientPlanDetailSchema = z.strictObject({
   totalMinutes: z.number(),
   completedMinutes: z.number(),
   completedModules: z.number(),
+  attempts: z.number(),
   status: z.string().optional(),
   latestAttempt: z.unknown().nullable(),
 });

--- a/tests/integration/api/plans/plans-read.contract.spec.ts
+++ b/tests/integration/api/plans/plans-read.contract.spec.ts
@@ -84,6 +84,7 @@ const clientPlanDetailSchema = z.strictObject({
   completedMinutes: z.number(),
   completedModules: z.number(),
   attempts: z.number(),
+  attemptCap: z.number(),
   status: z.string().optional(),
   latestAttempt: z.unknown().nullable(),
 });

--- a/tests/integration/db/generation-finalization.spec.ts
+++ b/tests/integration/db/generation-finalization.spec.ts
@@ -189,6 +189,12 @@ describe('plan generation finalization (single transaction)', () => {
       extendedTimeout: false,
       usageKind: 'plan',
       retryable: true,
+      workflowMetadata: {
+        provider: 'workflow-sdk',
+        runId: 'run-plan-generation-failure-1',
+        startedAt: '2026-03-02T08:00:00.000Z',
+        completedAt: '2026-03-02T08:00:01.000Z',
+      },
       now: () => new Date('2026-03-02T08:00:02.000Z'),
     });
 
@@ -203,6 +209,13 @@ describe('plan generation finalization (single transaction)', () => {
     });
     expect(attempt?.status).toBe('failure');
     expect(attempt?.classification).toBe('timeout');
+    const attemptMetadata = attempt?.metadata as AttemptMetadata | undefined;
+    expect(attemptMetadata?.workflow).toEqual({
+      provider: 'workflow-sdk',
+      runId: 'run-plan-generation-failure-1',
+      startedAt: '2026-03-02T08:00:00.000Z',
+      completedAt: '2026-03-02T08:00:01.000Z',
+    });
 
     const usageRows = await db
       .select()

--- a/tests/unit/api/clerk-billing-webhook-route.spec.ts
+++ b/tests/unit/api/clerk-billing-webhook-route.spec.ts
@@ -64,13 +64,44 @@ describe('Clerk billing webhook POST', () => {
 
   it('returns 429 when rate limited', async () => {
     mocks.checkIpRateLimit.mockImplementation(() => {
-      throw new RateLimitError('limited');
+      throw new RateLimitError('limited', {
+        retryAfter: 42,
+        limit: 100,
+        remaining: 0,
+        reset: 1234567890,
+      });
     });
 
     const response = await POST(request({ 'svix-id': 'evt_1' }));
 
     expect(response.status).toBe(429);
+    expect(response.headers.get('retry-after')).toBe('42');
+    expect(response.headers.get('x-ratelimit-limit')).toBe('100');
+    expect(response.headers.get('x-ratelimit-remaining')).toBe('0');
+    expect(response.headers.get('x-ratelimit-reset')).toBe('1234567890');
+    expect(response.headers.get('x-correlation-id')).toBe('req_webhook_test');
+    expect(response.headers.get('content-type')).toContain('application/json');
+    await expect(response.json()).resolves.toEqual({
+      error: 'limited',
+      code: 'RATE_LIMITED',
+      classification: 'rate_limit',
+      details: {
+        retryAfter: 42,
+        limit: 100,
+        remaining: 0,
+        reset: 1234567890,
+      },
+      retryAfter: 42,
+    });
+    expect(mocks.logger.warn).toHaveBeenCalledWith(
+      {
+        event: 'clerk_billing_webhook_rate_limited',
+        requestId: 'req_webhook_test',
+      },
+      'Clerk Billing webhook rate limited',
+    );
     expect(mocks.verifyWebhook).not.toHaveBeenCalled();
+    expect(mocks.applyVerifiedClerkBillingEvent).not.toHaveBeenCalled();
   });
 
   it('returns 400 without a svix-id', async () => {

--- a/tests/unit/app/plans/components/PlanPendingState.spec.tsx
+++ b/tests/unit/app/plans/components/PlanPendingState.spec.tsx
@@ -115,6 +115,26 @@ describe('PlanPendingState', () => {
     ).toBeInTheDocument();
   });
 
+  it('uses the persisted attempt count for a reloaded failed plan', () => {
+    mockPlanStatus({ status: 'failed', attempts: 0 });
+    const plan = createTestPlanDetail({ status: 'failed', attempts: 1 });
+
+    render(<PlanPendingState plan={plan} />);
+
+    expect(screen.getByText('Attempt 1 of 3')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'Retry Generation (2 attempts remaining)',
+      }),
+    ).toBeInTheDocument();
+    expect(mockUseRetryGeneration).toHaveBeenLastCalledWith(
+      plan.id,
+      MAX_RETRY_ATTEMPTS,
+      1,
+      expect.anything(),
+    );
+  });
+
   it('keeps the interrupted fallback when a retry session is cancelled', () => {
     mockRetryGeneration({
       status: 'cancelled',
@@ -162,7 +182,12 @@ describe('PlanPendingState', () => {
     });
 
     render(
-      <PlanPendingState plan={createTestPlanDetail({ status: 'failed' })} />,
+      <PlanPendingState
+        plan={createTestPlanDetail({
+          status: 'failed',
+          attempts: MAX_RETRY_ATTEMPTS,
+        })}
+      />,
     );
 
     expect(

--- a/tests/unit/app/plans/components/PlanPendingState.spec.tsx
+++ b/tests/unit/app/plans/components/PlanPendingState.spec.tsx
@@ -1,6 +1,5 @@
 import type { UsePlanGenerationSessionResult } from '@/features/plans/session/usePlanGenerationSession';
 
-import { MAX_RETRY_ATTEMPTS } from '@/app/(app)/plans/[id]/components/plan-pending-view-state';
 import { PlanPendingState } from '@/app/(app)/plans/[id]/components/PlanPendingState';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -115,13 +114,17 @@ describe('PlanPendingState', () => {
     ).toBeInTheDocument();
   });
 
-  it('uses the persisted attempt count for a reloaded failed plan', () => {
+  it('uses the configured attempt cap for a reloaded failed plan', () => {
     mockPlanStatus({ status: 'failed', attempts: 0 });
-    const plan = createTestPlanDetail({ status: 'failed', attempts: 1 });
+    const plan = createTestPlanDetail({
+      status: 'failed',
+      attempts: 3,
+      attemptCap: 5,
+    });
 
     render(<PlanPendingState plan={plan} />);
 
-    expect(screen.getByText('Attempt 1 of 3')).toBeInTheDocument();
+    expect(screen.getByText('Attempt 3 of 5')).toBeInTheDocument();
     expect(
       screen.getByRole('button', {
         name: 'Retry Generation (2 attempts remaining)',
@@ -129,8 +132,8 @@ describe('PlanPendingState', () => {
     ).toBeInTheDocument();
     expect(mockUseRetryGeneration).toHaveBeenLastCalledWith(
       plan.id,
-      MAX_RETRY_ATTEMPTS,
-      1,
+      5,
+      3,
       expect.anything(),
     );
   });
@@ -177,7 +180,7 @@ describe('PlanPendingState', () => {
   it('shows a create-plan link instead of retry when retries are exhausted', () => {
     mockPlanStatus({
       status: 'failed',
-      attempts: MAX_RETRY_ATTEMPTS,
+      attempts: 2,
       error: 'Generation failed',
     });
 
@@ -185,7 +188,8 @@ describe('PlanPendingState', () => {
       <PlanPendingState
         plan={createTestPlanDetail({
           status: 'failed',
-          attempts: MAX_RETRY_ATTEMPTS,
+          attempts: 2,
+          attemptCap: 2,
         })}
       />,
     );

--- a/tests/unit/app/plans/components/plan-pending-view-state.spec.ts
+++ b/tests/unit/app/plans/components/plan-pending-view-state.spec.ts
@@ -4,7 +4,6 @@ import {
   buildPlanPendingViewState,
   formatOrigin,
   getStatusBadgeVariant,
-  MAX_RETRY_ATTEMPTS,
 } from '@/app/(app)/plans/[id]/components/plan-pending-view-state';
 import { describe, expect, it } from 'vitest';
 
@@ -33,6 +32,7 @@ describe('buildPlanPendingViewState', () => {
         status: 'failed' as const,
         retryStatus: 'idle' as const,
         attempts: 1,
+        attemptCap: 3,
         error: 'Generation failed',
         pollingError: null,
         retryError: null,
@@ -46,6 +46,7 @@ describe('buildPlanPendingViewState', () => {
         status: 'processing' as const,
         retryStatus: 'idle' as const,
         attempts: 0,
+        attemptCap: 3,
         error: null,
         pollingError: 'Unable to reach the server',
         retryError: null,
@@ -58,6 +59,7 @@ describe('buildPlanPendingViewState', () => {
         status: 'processing' as const,
         retryStatus: 'idle' as const,
         attempts: 2,
+        attemptCap: 3,
         error: null,
         pollingError: null,
         retryError: null,
@@ -70,6 +72,7 @@ describe('buildPlanPendingViewState', () => {
         status: 'pending' as const,
         retryStatus: 'idle' as const,
         attempts: 0,
+        attemptCap: 3,
         error: null,
         pollingError: null,
         retryError: null,
@@ -82,6 +85,7 @@ describe('buildPlanPendingViewState', () => {
         status: 'ready' as const,
         retryStatus: 'idle' as const,
         attempts: 0,
+        attemptCap: 3,
         error: null,
         pollingError: null,
         retryError: null,
@@ -94,6 +98,7 @@ describe('buildPlanPendingViewState', () => {
         status: 'archived' as const,
         retryStatus: 'idle' as const,
         attempts: 0,
+        attemptCap: 3,
         error: null,
         pollingError: null,
         retryError: null,
@@ -118,6 +123,7 @@ describe('buildPlanPendingViewState', () => {
       status: 'failed',
       retryStatus: 'retrying',
       attempts: 1,
+      attemptCap: 3,
       error: null,
       pollingError: null,
       retryError: null,
@@ -133,6 +139,7 @@ describe('buildPlanPendingViewState', () => {
       status: 'failed',
       retryStatus: 'cancelled',
       attempts: 1,
+      attemptCap: 3,
       error: null,
       pollingError: null,
       retryError: null,
@@ -150,6 +157,7 @@ describe('buildPlanPendingViewState', () => {
       status: 'processing',
       retryStatus: 'idle',
       attempts: 0,
+      attemptCap: 3,
       error: 'Plan error',
       pollingError: 'Polling error',
       retryError: 'Retry error',
@@ -163,6 +171,7 @@ describe('buildPlanPendingViewState', () => {
       status: 'processing',
       retryStatus: 'idle',
       attempts: 0,
+      attemptCap: 3,
       error: 'Plan error',
       pollingError: 'Polling error',
       retryError: null,
@@ -176,6 +185,7 @@ describe('buildPlanPendingViewState', () => {
       status: 'failed',
       retryStatus: 'idle',
       attempts: 1,
+      attemptCap: 3,
       error: 'Plan error',
       pollingError: null,
       retryError: null,
@@ -185,16 +195,23 @@ describe('buildPlanPendingViewState', () => {
     expect(viewState.failedPlanMessage).toBe('Plan error');
   });
 
-  it('marks retries as exhausted at the attempt cap', () => {
-    const viewState = buildPlanPendingViewState({
-      status: 'failed',
-      retryStatus: 'idle',
-      attempts: MAX_RETRY_ATTEMPTS,
-      error: 'Generation failed',
-      pollingError: null,
-      retryError: null,
-    });
+  it.each([
+    { attempts: 3, attemptCap: 5, hasExhaustedRetries: false },
+    { attempts: 2, attemptCap: 2, hasExhaustedRetries: true },
+  ])(
+    'uses the supplied cap when attempts=$attempts and cap=$attemptCap',
+    ({ attempts, attemptCap, hasExhaustedRetries }) => {
+      const viewState = buildPlanPendingViewState({
+        status: 'failed',
+        retryStatus: 'idle',
+        attempts,
+        attemptCap,
+        error: 'Generation failed',
+        pollingError: null,
+        retryError: null,
+      });
 
-    expect(viewState.hasExhaustedRetries).toBe(true);
-  });
+      expect(viewState.hasExhaustedRetries).toBe(hasExhaustedRetries);
+    },
+  );
 });

--- a/tests/unit/components/ModuleLessonsClient.spec.tsx
+++ b/tests/unit/components/ModuleLessonsClient.spec.tsx
@@ -1,7 +1,13 @@
 import type { ModuleDetailTask } from '@/features/plans/read-projection/types';
 
 import { ModuleLessonsClient } from '@/app/(app)/plans/[id]/modules/[moduleId]/components/ModuleLessonsClient';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createId } from '@tests/fixtures/ids';
 import { createDeferredPromise } from '@tests/helpers/deferred-promise';
@@ -195,6 +201,54 @@ describe('ModuleLessonsClient', () => {
       }),
     );
     expect(refreshMock).not.toHaveBeenCalled();
+  });
+
+  it('polls after a workflow starts before refreshed server state becomes generating', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        mockJsonFetchResponse(
+          {
+            state: 'generating',
+            planId: PLAN_ID,
+            moduleId: MODULE_ID,
+          },
+          { status: 202 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        mockJsonFetchResponse({
+          planId: PLAN_ID,
+          moduleId: MODULE_ID,
+          status: 'ready',
+        }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderClient();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Generate lessons' }));
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(GENERATE_URL, { method: 'POST' });
+    expect(
+      screen.getByRole('button', { name: 'Generating...' }),
+    ).toBeDisabled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      STATUS_URL,
+      expect.objectContaining({
+        cache: 'no-store',
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(refreshMock).toHaveBeenCalledTimes(2);
   });
 
   it('refreshes once when status polling returns ready', async () => {

--- a/tests/unit/components/ModuleLessonsClient.spec.tsx
+++ b/tests/unit/components/ModuleLessonsClient.spec.tsx
@@ -311,6 +311,212 @@ describe('ModuleLessonsClient', () => {
     expect(refreshMock).toHaveBeenCalledTimes(2);
   });
 
+  it('stops polling when not_generated returns after generating (quota rollback)', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        mockJsonFetchResponse(
+          {
+            state: 'generating',
+            planId: PLAN_ID,
+            moduleId: MODULE_ID,
+          },
+          { status: 202 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        mockJsonFetchResponse({
+          planId: PLAN_ID,
+          moduleId: MODULE_ID,
+          status: 'generating',
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockJsonFetchResponse({
+          planId: PLAN_ID,
+          moduleId: MODULE_ID,
+          status: 'not_generated',
+        }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderClient();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Generate lessons' }));
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(
+      screen.getByRole('button', { name: 'Generating...' }),
+    ).toBeDisabled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(refreshMock).toHaveBeenCalledTimes(2);
+    expect(
+      screen.getByRole('button', { name: 'Generate lessons' }),
+    ).not.toBeDisabled();
+
+    const callsAfterTerminal = fetchMock.mock.calls.length;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+    expect(fetchMock.mock.calls.length).toBe(callsAfterTerminal);
+  });
+
+  it('keeps polling while a failed-module retry has not been claimed yet', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        mockJsonFetchResponse(
+          {
+            state: 'generating',
+            planId: PLAN_ID,
+            moduleId: MODULE_ID,
+          },
+          { status: 202 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        mockJsonFetchResponse({
+          planId: PLAN_ID,
+          moduleId: MODULE_ID,
+          status: 'failed',
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockJsonFetchResponse({
+          planId: PLAN_ID,
+          moduleId: MODULE_ID,
+          status: 'ready',
+        }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderClient({
+      lessonGeneration: {
+        status: 'failed',
+        startedAt: null,
+        completedAt: null,
+        failedAt: new Date('2025-06-01T00:00:00.000Z'),
+        error: null,
+      },
+    });
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Retry lesson generation' }),
+      );
+    });
+
+    expect(
+      screen.getByRole('button', { name: 'Generating...' }),
+    ).toBeDisabled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      STATUS_URL,
+      expect.objectContaining({
+        cache: 'no-store',
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(
+      screen.getByRole('button', { name: 'Generating...' }),
+    ).toBeDisabled();
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(refreshMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops polling when failed returns after generating (post-work failure)', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        mockJsonFetchResponse(
+          {
+            state: 'generating',
+            planId: PLAN_ID,
+            moduleId: MODULE_ID,
+          },
+          { status: 202 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        mockJsonFetchResponse({
+          planId: PLAN_ID,
+          moduleId: MODULE_ID,
+          status: 'generating',
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockJsonFetchResponse({
+          planId: PLAN_ID,
+          moduleId: MODULE_ID,
+          status: 'failed',
+        }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderClient({
+      lessonGeneration: {
+        status: 'failed',
+        startedAt: null,
+        completedAt: null,
+        failedAt: new Date('2025-06-01T00:00:00.000Z'),
+        error: null,
+      },
+    });
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Retry lesson generation' }),
+      );
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(
+      screen.getByRole('button', { name: 'Generating...' }),
+    ).toBeDisabled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(refreshMock).toHaveBeenCalledTimes(2);
+    expect(
+      screen.getByRole('button', { name: 'Retry lesson generation' }),
+    ).not.toBeDisabled();
+
+    const callsAfterTerminal = fetchMock.mock.calls.length;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+    expect(fetchMock.mock.calls.length).toBe(callsAfterTerminal);
+  });
+
   it('refreshes once when status polling returns ready', async () => {
     vi.useFakeTimers();
     const fetchMock = vi.fn().mockResolvedValue(

--- a/tests/unit/components/ModuleLessonsClient.spec.tsx
+++ b/tests/unit/components/ModuleLessonsClient.spec.tsx
@@ -251,6 +251,66 @@ describe('ModuleLessonsClient', () => {
     expect(refreshMock).toHaveBeenCalledTimes(2);
   });
 
+  it('keeps polling while a queued workflow has not claimed the module yet', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        mockJsonFetchResponse(
+          {
+            state: 'generating',
+            planId: PLAN_ID,
+            moduleId: MODULE_ID,
+          },
+          { status: 202 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        mockJsonFetchResponse({
+          planId: PLAN_ID,
+          moduleId: MODULE_ID,
+          status: 'not_generated',
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockJsonFetchResponse({
+          planId: PLAN_ID,
+          moduleId: MODULE_ID,
+          status: 'ready',
+        }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderClient();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Generate lessons' }));
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      STATUS_URL,
+      expect.objectContaining({
+        cache: 'no-store',
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(
+      screen.getByRole('button', { name: 'Generating...' }),
+    ).toBeDisabled();
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(refreshMock).toHaveBeenCalledTimes(2);
+  });
+
   it('refreshes once when status polling returns ready', async () => {
     vi.useFakeTimers();
     const fetchMock = vi.fn().mockResolvedValue(

--- a/tests/unit/components/ModuleLessonsClient.spec.tsx
+++ b/tests/unit/components/ModuleLessonsClient.spec.tsx
@@ -213,6 +213,7 @@ describe('ModuleLessonsClient', () => {
             state: 'generating',
             planId: PLAN_ID,
             moduleId: MODULE_ID,
+            workflowRunId: 'wrun_current',
           },
           { status: 202 },
         ),
@@ -261,6 +262,7 @@ describe('ModuleLessonsClient', () => {
             state: 'generating',
             planId: PLAN_ID,
             moduleId: MODULE_ID,
+            workflowRunId: 'wrun_current',
           },
           { status: 202 },
         ),
@@ -270,6 +272,7 @@ describe('ModuleLessonsClient', () => {
           planId: PLAN_ID,
           moduleId: MODULE_ID,
           status: 'not_generated',
+          workflowRunId: 'wrun_previous',
         }),
       )
       .mockResolvedValueOnce(
@@ -311,7 +314,7 @@ describe('ModuleLessonsClient', () => {
     expect(refreshMock).toHaveBeenCalledTimes(2);
   });
 
-  it('stops polling when not_generated returns after generating (quota rollback)', async () => {
+  it('stops polling when the accepted workflow run rolls back before generating is observed', async () => {
     vi.useFakeTimers();
     const fetchMock = vi
       .fn()
@@ -321,6 +324,7 @@ describe('ModuleLessonsClient', () => {
             state: 'generating',
             planId: PLAN_ID,
             moduleId: MODULE_ID,
+            workflowRunId: 'wrun_current',
           },
           { status: 202 },
         ),
@@ -329,14 +333,8 @@ describe('ModuleLessonsClient', () => {
         mockJsonFetchResponse({
           planId: PLAN_ID,
           moduleId: MODULE_ID,
-          status: 'generating',
-        }),
-      )
-      .mockResolvedValueOnce(
-        mockJsonFetchResponse({
-          planId: PLAN_ID,
-          moduleId: MODULE_ID,
           status: 'not_generated',
+          workflowRunId: 'wrun_current',
         }),
       );
     vi.stubGlobal('fetch', fetchMock);
@@ -351,15 +349,6 @@ describe('ModuleLessonsClient', () => {
       await vi.advanceTimersByTimeAsync(2500);
     });
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(
-      screen.getByRole('button', { name: 'Generating...' }),
-    ).toBeDisabled();
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(2500);
-    });
-
-    expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(refreshMock).toHaveBeenCalledTimes(2);
     expect(
       screen.getByRole('button', { name: 'Generate lessons' }),

--- a/tests/unit/components/PlanDetails.spec.tsx
+++ b/tests/unit/components/PlanDetails.spec.tsx
@@ -53,6 +53,7 @@ function createMockPlan(status: ClientPlanDetail['status']): ClientPlanDetail {
     completedMinutes: 0,
     completedModules: 0,
     attempts: 0,
+    attemptCap: 3,
     modules: [],
   };
 }

--- a/tests/unit/components/PlanDetails.spec.tsx
+++ b/tests/unit/components/PlanDetails.spec.tsx
@@ -66,7 +66,7 @@ describe('PlanDetails', () => {
     cleanup();
   });
 
-  it.each(['pending', 'processing'] as const)(
+  it.each(['pending', 'processing', 'failed'] as const)(
     'renders pending state for %s plans',
     async (status) => {
       await renderPlanDetails(createMockPlan(status));

--- a/tests/unit/components/PlanDetails.spec.tsx
+++ b/tests/unit/components/PlanDetails.spec.tsx
@@ -52,6 +52,7 @@ function createMockPlan(status: ClientPlanDetail['status']): ClientPlanDetail {
     totalMinutes: 0,
     completedMinutes: 0,
     completedModules: 0,
+    attempts: 0,
     modules: [],
   };
 }

--- a/tests/unit/features/plans/lifecycle/process-generation.spec.ts
+++ b/tests/unit/features/plans/lifecycle/process-generation.spec.ts
@@ -225,6 +225,45 @@ describe('PlanLifecycleService.processGenerationAttempt', () => {
     );
   });
 
+  it('preserves workflow metadata when a reserved attempt fails', async () => {
+    const resv = makeAttemptReservation();
+    const workflowMetadata = {
+      provider: 'workflow-sdk' as const,
+      runId: 'run-provider-error',
+      startedAt: '2026-03-01T10:00:00.000Z',
+    };
+    ports = createMockPorts({
+      generation: {
+        runGeneration: vi.fn().mockResolvedValue({
+          status: 'failure',
+          classification: 'provider_error',
+          error: new Error('provider down'),
+          durationMs: 300,
+          reservation: resv,
+          timedOut: false,
+          extendedTimeout: false,
+        }),
+      },
+    });
+    service = new PlanLifecycleService(ports);
+
+    await service.processGenerationAttempt({
+      ...validGenerationInput,
+      workflowMetadata,
+    });
+
+    expect(
+      vi.mocked(ports.generationFinalization.finalizeFailure),
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflowMetadata: {
+          ...workflowMetadata,
+          completedAt: new Date(resv.startedAt.getTime() + 300).toISOString(),
+        },
+      }),
+    );
+  });
+
   it('does NOT record usage on retryable failure', async () => {
     const resv = makeAttemptReservation();
     ports = createMockPorts({

--- a/tests/unit/hooks/useRetryGeneration.spec.tsx
+++ b/tests/unit/hooks/useRetryGeneration.spec.tsx
@@ -61,6 +61,38 @@ describe('useRetryGeneration', () => {
     expect(refresh).toHaveBeenCalledTimes(1);
   });
 
+  it('refreshes the router when a retry stream fails', async () => {
+    const startSession = vi.fn().mockRejectedValue(new Error('provider down'));
+    const session = createMockSession({ startSession });
+
+    const { result } = renderHook(() =>
+      useRetryGeneration('plan-1', 3, 1, session),
+    );
+
+    await act(async () => {
+      await expect(result.current.retryGeneration()).resolves.toBeUndefined();
+    });
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not refresh the router when retry is aborted', async () => {
+    const startSession = vi
+      .fn()
+      .mockRejectedValue(new DOMException('Aborted', 'AbortError'));
+    const session = createMockSession({ startSession });
+
+    const { result } = renderHook(() =>
+      useRetryGeneration('plan-1', 3, 1, session),
+    );
+
+    await act(async () => {
+      await expect(result.current.retryGeneration()).resolves.toBeUndefined();
+    });
+
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
   it('disables retry while session is generating', () => {
     const session = createMockSession({
       state: {

--- a/tests/unit/mappers/detailToClient.spec.ts
+++ b/tests/unit/mappers/detailToClient.spec.ts
@@ -18,6 +18,7 @@ import {
   buildTask,
   buildTaskResource,
 } from '../../fixtures/plan-detail';
+import { getGenerationAttemptCap } from '@/features/ai/generation-policy';
 import {
   toClientGenerationAttempts,
   toClientPlanDetail,
@@ -121,6 +122,7 @@ describe('mapDetailToClient', () => {
     expect(result?.modules[0].tasks[0].status).toBe('completed');
     expect(result?.modules[0].tasks[0].resources).toHaveLength(1);
     expect(result?.status).toBe('ready');
+    expect(result?.attemptCap).toBe(getGenerationAttemptCap());
     expect(result?.latestAttempt).toBeDefined();
     expect(result?.latestAttempt?.model).toBe('gpt-4');
     expect(result).not.toHaveProperty('extractedContext');

--- a/tests/unit/mappers/detailToClient.spec.ts
+++ b/tests/unit/mappers/detailToClient.spec.ts
@@ -313,10 +313,12 @@ describe('mapDetailToClient', () => {
   it('should derive status as "failed" when plan generation status is failed', () => {
     const detail = buildPlanDetail({
       plan: buildPlan({ generationStatus: 'failed', modules: [] }),
+      attemptsCount: 1,
     });
 
     const result = toClientPlanDetail(detail);
     expect(result?.status).toBe('failed');
+    expect(result).toMatchObject({ attempts: 1 });
   });
 
   it('should derive status as "processing" when generation is in progress with no modules', () => {

--- a/tests/unit/shared/lesson-content.schemas.spec.ts
+++ b/tests/unit/shared/lesson-content.schemas.spec.ts
@@ -190,8 +190,9 @@ describe('lesson content Zod contracts', () => {
         state: 'generating',
         planId,
         moduleId,
+        workflowRunId: 'wrun_current',
       }),
-    ).toMatchObject({ state: 'generating' });
+    ).toMatchObject({ state: 'generating', workflowRunId: 'wrun_current' });
 
     expect(
       ModuleLessonGenerationApiResponseSchema.parse({
@@ -294,6 +295,20 @@ describe('module lesson generation status response schema', () => {
         status: 'processing',
       }),
     ).toThrow();
+  });
+
+  it('accepts a workflow run ID with a persisted status', () => {
+    const planId = randomUUID();
+    const moduleId = randomUUID();
+
+    expect(
+      ModuleLessonGenerationStatusResponseSchema.parse({
+        planId,
+        moduleId,
+        status: 'not_generated',
+        workflowRunId: 'wrun_current',
+      }),
+    ).toMatchObject({ workflowRunId: 'wrun_current' });
   });
 
   it('rejects invalid UUID params', () => {


### PR DESCRIPTION
## Summary
- begin module lesson status polling from the asynchronous 202 response
- keep the generate action pending until polling observes a terminal status
- cover the refresh-before-workflow-claim race

## Why
The first route refresh could finish before the workflow claimed the module. The page would retain the previous status and never start its existing polling loop.

## Verification
- focused ModuleLessonsClient unit suite: 19 passed
- pre-push lint: passed with zero warnings
- pre-push TypeScript check: passed

Linear: JCS-45
Stack base: PR #463

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches async lesson-generation polling and plan retry/finalization paths where race handling mistakes could strand UI or mis-report attempts; billing webhook change is limited to rate-limit responses.
> 
> **Overview**
> Fixes **module lesson generation** getting stuck when a route refresh ran before the workflow claimed the module: a **202 `generating`** response (optionally with **`workflowRunId`**) now kicks off client polling immediately, the generate action stays pending until status polling hits a terminal state, and polling ignores stale **`not_generated` / `failed`** until the accepted run is observed or the matching **`workflowRunId`** settles.
> 
> **Plan generation UX** now uses server **`attempts`** and **`attemptCap`** on plan detail (replacing a client constant), shows the pending/failure UI for **`failed`** plans, rehydrates attempt counts after retry via **`router.refresh()`**, and persists **workflow metadata** on reserved-attempt failures.
> 
> The Clerk billing webhook returns the standard **`toErrorResponse`** shape for IP rate limits (429 headers/body).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c696ffcc42b5095fdb0fbb24613ac2088c719532. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->