### PR TITLE
fix(deps): patch undici and fast-uri advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,9 +13,9 @@ overrides:
   minimatch: ^10.2.3
   tar: ^7.5.19
   rollup: ^4.59.0
-  fast-uri: ^3.1.4
+  fast-uri: ^3.1.5
   kysely: ^0.28.17
-  undici: ^7.28.0
+  undici: ^7.29.0
   devalue: ^5.8.1
   shell-quote: ^1.8.5
   protobufjs: ^7.6.3
@@ -4612,8 +4612,8 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
@@ -6575,8 +6575,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.1.0:
@@ -10028,7 +10028,7 @@ snapshots:
       '@workflow/world': 4.1.2(zod@4.3.6)
       async-sema: 3.1.1
       ulid: 3.0.2
-      undici: 7.28.0
+      undici: 7.29.0
       zod: 4.3.6
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -10040,7 +10040,7 @@ snapshots:
       '@workflow/errors': 4.1.2
       '@workflow/world': 4.1.2(zod@4.3.6)
       cbor-x: 1.6.0
-      undici: 7.28.0
+      undici: 7.29.0
       zod: 4.3.6
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -10193,7 +10193,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -11114,7 +11114,7 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-xml-builder@1.2.0:
     dependencies:
@@ -13204,7 +13204,7 @@ snapshots:
       ssh-remote-port-forward: 1.0.4
       tar-fs: 3.1.2
       tmp: 0.2.5
-      undici: 7.28.0
+      undici: 7.29.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -13328,7 +13328,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unicorn-magic@0.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,9 +36,9 @@ overrides:
   minimatch: ^10.2.3
   tar: ^7.5.19
   rollup: ^4.59.0
-  fast-uri: ^3.1.4
+  fast-uri: ^3.1.5
   kysely: ^0.28.17
-  undici: ^7.28.0
+  undici: ^7.29.0
   devalue: ^5.8.1
   shell-quote: ^1.8.5
   protobufjs: ^7.6.3


### PR DESCRIPTION
## Summary

- raise the existing `undici` override to `^7.29.0` for GHSA-4cwx-7wf7-3272
- raise the existing `fast-uri` override to `^3.1.5` for GHSA-7p8r-x3mc-p8w7
- update only the matching lockfile package and snapshot references

## Verification

- `pnpm install --lockfile-only --frozen-lockfile`
- `pnpm audit --prod --audit-level=high` (passes; only 3 low and 1 moderate remain)
- `pnpm why undici --prod` (single 7.29.0 version)
- `pnpm why fast-uri --prod` (single 3.1.5 version)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only patch bumps via existing overrides; no application source changes.
> 
> **Overview**
> Bumps **pnpm overrides** for `undici` (`^7.28.0` → `^7.29.0`, GHSA-4cwx-7wf7-3272) and `fast-uri` (`^3.1.4` → `^3.1.5`, GHSA-7p8r-x3mc-p8w7) in `pnpm-workspace.yaml`, with matching lockfile resolution updates so dependents (e.g. workflow world packages, `ajv`, testcontainers) resolve the patched versions only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9533a67074846e120f99f96c50dba6ce2f4311a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->