### PR TITLE
fix(release): close production rollout blockers

### DIFF
--- a/.github/workflows/production-db-migrations.yaml
+++ b/.github/workflows/production-db-migrations.yaml
@@ -27,7 +27,7 @@ jobs:
     name: Push Supabase migrations to production
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    environment: production
+    environment: Production – atlaris
 
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/docs/ci-cd/pipeline-and-deployment-strategy.md
+++ b/docs/ci-cd/pipeline-and-deployment-strategy.md
@@ -120,22 +120,22 @@ For a true emergency that cannot wait for the normal `develop` promotion, open t
 
 ### GitHub environment gates
 
-Create protected GitHub environments named `staging` and `production`.
+Create protected GitHub environments named `staging` and `Production – atlaris`.
 
-| Environment  | Deployment branch rule | Required reviewers |
-| ------------ | ---------------------- | ------------------ |
-| `staging`    | `develop`              | Yes                |
-| `production` | `main`                 | Yes                |
+| Environment            | Deployment branch rule | Required reviewers |
+| ---------------------- | ---------------------- | ------------------ |
+| `staging`              | `develop`              | Yes                |
+| `Production – atlaris` | `main`                 | Yes                |
 
 Store the Supabase migration secrets below as environment secrets on the matching environment, not as broad repository secrets.
 
 ### GitHub environment secrets
 
-- `SUPABASE_ACCESS_TOKEN` (set separately on `staging` and `production`)
+- `SUPABASE_ACCESS_TOKEN` (set separately on `staging` and `Production – atlaris`)
 - `STAGING_PROJECT_ID` (set on `staging`)
 - `STAGING_DB_PASSWORD` (set on `staging`)
-- `PRODUCTION_PROJECT_ID` (set on `production`)
-- `PRODUCTION_DB_PASSWORD` (set on `production`)
+- `PRODUCTION_PROJECT_ID` (set on `Production – atlaris`)
+- `PRODUCTION_DB_PASSWORD` (set on `Production – atlaris`)
 
 ### GitHub repository secrets
 

--- a/src/features/billing/clerk-billing/projection.ts
+++ b/src/features/billing/clerk-billing/projection.ts
@@ -77,10 +77,7 @@ const PAID_TIER_RANK: Record<SubscriptionTier, number> = {
   pro: 2,
 };
 
-const ACTIVE_ITEM_STATUSES = new Set<ClerkSubscriptionItemStatus>([
-  'active',
-  'past_due',
-]);
+const ACTIVE_ITEM_STATUSES = new Set<ClerkSubscriptionItemStatus>(['active']);
 
 const TERMINAL_STATUSES = new Set<ClerkSubscriptionStatus>([
   'abandoned',
@@ -299,9 +296,12 @@ export function projectClerkBillingSource(
 
   if (
     source.paymentAttemptStatus === 'failed' ||
-    source.subscriptionStatus === 'past_due'
+    source.subscriptionStatus === 'past_due' ||
+    source.items.some(
+      (item) => isPaidTier(item.tier) && item.status === 'past_due',
+    )
   ) {
-    // Failed initial checkouts can include active paid items; never promote free users.
+    // Failed payments can include paid items; never use them to promote a tier.
     if (!isPaidTier(current.subscriptionTier)) {
       return null;
     }

--- a/src/features/billing/clerk-billing/projection.ts
+++ b/src/features/billing/clerk-billing/projection.ts
@@ -77,8 +77,6 @@ const PAID_TIER_RANK: Record<SubscriptionTier, number> = {
   pro: 2,
 };
 
-const ACTIVE_ITEM_STATUSES = new Set<ClerkSubscriptionItemStatus>(['active']);
-
 const TERMINAL_STATUSES = new Set<ClerkSubscriptionStatus>([
   'abandoned',
   'canceled',
@@ -294,14 +292,39 @@ export function projectClerkBillingSource(
     return null;
   }
 
-  if (
-    source.paymentAttemptStatus === 'failed' ||
-    source.subscriptionStatus === 'past_due' ||
-    source.items.some(
-      (item) => isPaidTier(item.tier) && item.status === 'past_due',
-    )
-  ) {
-    // Failed payments can include paid items; never use them to promote a tier.
+  const paidItems = source.items.filter((item) => isPaidTier(item.tier));
+
+  if (source.paymentAttemptStatus === 'failed') {
+    // Failed attempts can include active-looking items; never use them to promote a tier.
+    if (!isPaidTier(current.subscriptionTier)) {
+      return null;
+    }
+
+    return {
+      subscriptionTier: current.subscriptionTier,
+      subscriptionStatus: 'past_due',
+      subscriptionPeriodEnd: current.subscriptionPeriodEnd,
+      cancelAtPeriodEnd: current.cancelAtPeriodEnd,
+    };
+  }
+
+  const activePaidItem = chooseHighestTierItem(
+    paidItems.filter((item) => item.status === 'active'),
+  );
+
+  if (activePaidItem?.tier) {
+    return {
+      subscriptionTier: activePaidItem.tier,
+      subscriptionStatus: activePaidItem.isFreeTrial ? 'trialing' : 'active',
+      subscriptionPeriodEnd: activePaidItem.periodEnd,
+      cancelAtPeriodEnd: false,
+    };
+  }
+
+  const pastDuePaidItems = paidItems.filter(
+    (item) => item.status === 'past_due',
+  );
+  if (source.subscriptionStatus === 'past_due' || pastDuePaidItems.length > 0) {
     if (!isPaidTier(current.subscriptionTier)) {
       return null;
     }
@@ -310,27 +333,12 @@ export function projectClerkBillingSource(
       subscriptionTier: current.subscriptionTier,
       subscriptionStatus: 'past_due',
       subscriptionPeriodEnd:
-        latestPeriodEnd(source.items) ?? current.subscriptionPeriodEnd,
+        latestPeriodEnd(
+          pastDuePaidItems.filter(
+            (item) => item.tier === current.subscriptionTier,
+          ),
+        ) ?? current.subscriptionPeriodEnd,
       cancelAtPeriodEnd: current.cancelAtPeriodEnd,
-    };
-  }
-
-  const paidItems = source.items.filter((item) => isPaidTier(item.tier));
-  const activePaidItem = chooseHighestTierItem(
-    paidItems.filter((item) => ACTIVE_ITEM_STATUSES.has(item.status)),
-  );
-
-  if (activePaidItem?.tier) {
-    return {
-      subscriptionTier: activePaidItem.tier,
-      subscriptionStatus:
-        activePaidItem.status === 'past_due'
-          ? 'past_due'
-          : activePaidItem.isFreeTrial
-            ? 'trialing'
-            : 'active',
-      subscriptionPeriodEnd: activePaidItem.periodEnd,
-      cancelAtPeriodEnd: false,
     };
   }
 
@@ -361,13 +369,12 @@ export function projectClerkBillingSource(
   }
 
   const activeFreeItem = source.items.find(
-    (item) => item.tier === 'free' && ACTIVE_ITEM_STATUSES.has(item.status),
+    (item) => item.tier === 'free' && item.status === 'active',
   );
   if (activeFreeItem) {
     return {
       subscriptionTier: 'free',
-      subscriptionStatus:
-        activeFreeItem.status === 'past_due' ? 'past_due' : 'active',
+      subscriptionStatus: 'active',
       subscriptionPeriodEnd: activeFreeItem.periodEnd,
       cancelAtPeriodEnd: false,
     };

--- a/tests/unit/architecture/db-migration-workflows.spec.ts
+++ b/tests/unit/architecture/db-migration-workflows.spec.ts
@@ -26,7 +26,7 @@ const migrationWorkflows = [
     protectedBranch: 'develop',
   },
   {
-    environment: 'production',
+    environment: 'Production – atlaris',
     fileName: 'production-db-migrations.yaml',
     protectedBranch: 'main',
   },

--- a/tests/unit/features/billing/clerk-billing/projection.spec.ts
+++ b/tests/unit/features/billing/clerk-billing/projection.spec.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from 'vitest';
 
 const now = new Date('2026-07-06T12:00:00.000Z');
 const futurePeriodEnd = new Date('2026-08-06T12:00:00.000Z');
+const laterFreePeriodEnd = new Date('2026-09-06T12:00:00.000Z');
 const pastPeriodEnd = new Date('2026-06-06T12:00:00.000Z');
 
 const currentPaidState: CurrentBillingState = {
@@ -275,6 +276,65 @@ describe('projectClerkBillingSource', () => {
           type: 'reconciliation.subscription',
           subscriptionStatus: 'active',
           items: [item({ status: 'past_due', tier: 'pro' })],
+        }),
+        currentStarterState,
+        now,
+      ),
+    ).toEqual({
+      subscriptionTier: 'starter',
+      subscriptionStatus: 'past_due',
+      subscriptionPeriodEnd: futurePeriodEnd,
+      cancelAtPeriodEnd: false,
+    });
+  });
+
+  it('projects an active paid item while ignoring a separate past-due upgrade', () => {
+    expect(
+      projectClerkBillingSource(
+        source({
+          type: 'reconciliation.subscription',
+          subscriptionStatus: 'active',
+          items: [
+            item({
+              id: 'item_starter_active',
+              status: 'active',
+              tier: 'starter',
+              planSlug: 'starter_plan',
+            }),
+            item({
+              id: 'item_pro_past_due',
+              status: 'past_due',
+              tier: 'pro',
+            }),
+          ],
+        }),
+        currentFreeState,
+        now,
+      ),
+    ).toEqual({
+      subscriptionTier: 'starter',
+      subscriptionStatus: 'active',
+      subscriptionPeriodEnd: futurePeriodEnd,
+      cancelAtPeriodEnd: false,
+    });
+  });
+
+  it('does not extend a paid tier from an upcoming free item after a failed upgrade', () => {
+    expect(
+      projectClerkBillingSource(
+        source({
+          type: 'reconciliation.subscription',
+          subscriptionStatus: 'active',
+          items: [
+            item({ status: 'past_due', tier: 'pro' }),
+            item({
+              id: 'item_free_upcoming',
+              status: 'upcoming',
+              tier: 'free',
+              planSlug: 'free_user',
+              periodEnd: laterFreePeriodEnd,
+            }),
+          ],
         }),
         currentStarterState,
         now,

--- a/tests/unit/features/billing/clerk-billing/projection.spec.ts
+++ b/tests/unit/features/billing/clerk-billing/projection.spec.ts
@@ -254,6 +254,39 @@ describe('projectClerkBillingSource', () => {
     });
   });
 
+  it('does not promote a past-due paid item when reconciliation remains active', () => {
+    expect(
+      projectClerkBillingSource(
+        source({
+          type: 'reconciliation.subscription',
+          subscriptionStatus: 'active',
+          items: [item({ status: 'past_due', tier: 'pro' })],
+        }),
+        currentFreeState,
+        now,
+      ),
+    ).toBeNull();
+  });
+
+  it('keeps the existing paid tier when reconciliation includes a past-due upgrade', () => {
+    expect(
+      projectClerkBillingSource(
+        source({
+          type: 'reconciliation.subscription',
+          subscriptionStatus: 'active',
+          items: [item({ status: 'past_due', tier: 'pro' })],
+        }),
+        currentStarterState,
+        now,
+      ),
+    ).toEqual({
+      subscriptionTier: 'starter',
+      subscriptionStatus: 'past_due',
+      subscriptionPeriodEnd: futurePeriodEnd,
+      cancelAtPeriodEnd: false,
+    });
+  });
+
   it('maps Clerk webhook item timestamps and trial state from the payload', () => {
     const sourceFromWebhook = clerkBillingSourceFromWebhook({
       type: 'subscriptionItem.active',


### PR DESCRIPTION
## Summary

- prevent past-due Clerk Billing items from promoting paid entitlements
- add free and paid reconciliation regressions
- bind the durable Production migration workflow to the existing `Production – atlaris` environment
- align the architecture contract and deployment documentation

## Verification

- 49 focused unit tests passed
- `pnpm check:type` passed
- focused Oxlint and Oxfmt checks passed
- `bash -n scripts/db/run-phased-migrations.sh` passed
- `git diff --check` passed

## Release impact

This must land on `develop` before PR #428. After it lands, the final release SHA will be used by a one-time, EXPAND-only Production migration bootstrap before the application merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Billing projection changes affect entitlement logic for paid users; the environment rename must match GitHub configuration or production migrations will fail approval/secret lookup.
> 
> **Overview**
> **Clerk billing projection** no longer treats `past_due` subscription items as entitlements that can promote or extend paid tiers. Only **`active`** paid items drive upgrades; `past_due` paths keep the **current** paid tier (or return null for free users), including when reconciliation reports `subscriptionStatus: active` alongside a past-due upgrade item. Failed payment attempts no longer pull period end from Clerk items—they reuse the stored period end.
> 
> **CI/CD** renames the production GitHub Actions environment from `production` to **`Production – atlaris`** in the production DB migration workflow, deployment docs, and the architecture contract test so migrations use the same protected environment as other production jobs.
> 
> Regression tests cover reconciliation edge cases (active + past-due items, upcoming free after failed upgrade).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc591d9ee57002bc38e32c543055ffdb6cc0b3ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->