### PR TITLE
autofix: superseded — past-due active item already fixed on target branch

### DIFF
--- a/src/features/billing/clerk-billing/projection.ts
+++ b/src/features/billing/clerk-billing/projection.ts
@@ -294,14 +294,21 @@ export function projectClerkBillingSource(
     return null;
   }
 
+  const paidItems = source.items.filter((item) => isPaidTier(item.tier));
+  const activePaidItem = chooseHighestTierItem(
+    paidItems.filter((item) => ACTIVE_ITEM_STATUSES.has(item.status)),
+  );
+  const hasPastDuePaidItemWithoutActive =
+    paidItems.some((item) => item.status === 'past_due') &&
+    activePaidItem === null;
+
   if (
     source.paymentAttemptStatus === 'failed' ||
     source.subscriptionStatus === 'past_due' ||
-    source.items.some(
-      (item) => isPaidTier(item.tier) && item.status === 'past_due',
-    )
+    hasPastDuePaidItemWithoutActive
   ) {
-    // Failed payments can include paid items; never use them to promote a tier.
+    // Failed/past-due payloads must not promote free users. Item-level past_due
+    // alone is included only when no active paid item exists to project.
     if (!isPaidTier(current.subscriptionTier)) {
       return null;
     }
@@ -314,11 +321,6 @@ export function projectClerkBillingSource(
       cancelAtPeriodEnd: current.cancelAtPeriodEnd,
     };
   }
-
-  const paidItems = source.items.filter((item) => isPaidTier(item.tier));
-  const activePaidItem = chooseHighestTierItem(
-    paidItems.filter((item) => ACTIVE_ITEM_STATUSES.has(item.status)),
-  );
 
   if (activePaidItem?.tier) {
     return {

--- a/tests/unit/features/billing/clerk-billing/projection.spec.ts
+++ b/tests/unit/features/billing/clerk-billing/projection.spec.ts
@@ -287,6 +287,38 @@ describe('projectClerkBillingSource', () => {
     });
   });
 
+  it('projects an active paid item when a separate past-due upgrade item is present', () => {
+    expect(
+      projectClerkBillingSource(
+        source({
+          type: 'reconciliation.subscription',
+          subscriptionStatus: 'active',
+          items: [
+            item({
+              id: 'item_starter',
+              status: 'active',
+              tier: 'starter',
+              planSlug: 'starter_plan',
+              amountInCents: 1_000,
+            }),
+            item({
+              id: 'item_pro_past_due',
+              status: 'past_due',
+              tier: 'pro',
+            }),
+          ],
+        }),
+        currentFreeState,
+        now,
+      ),
+    ).toEqual({
+      subscriptionTier: 'starter',
+      subscriptionStatus: 'active',
+      subscriptionPeriodEnd: futurePeriodEnd,
+      cancelAtPeriodEnd: false,
+    });
+  });
+
   it('maps Clerk webhook item timestamps and trial state from the payload', () => {
     const sourceFromWebhook = clerkBillingSourceFromWebhook({
       type: 'subscriptionItem.active',


### PR DESCRIPTION
## Summary
Temporary PR so required checks/Preview can attach to the autofix SHA, then the same commit can be pushed onto `fix/release-428-production-blockers` (branch ruleset requires green `All Checks Passed (PR)` + Preview before push).

## Change
- Item-level past_due early return only applies when no active paid item exists.
- Regression test for free user with active starter + past_due pro.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes entitlement projection logic used by webhooks and reconciliation; incorrect behavior would affect who gets paid tier access, though the change is narrowly scoped and covered by a new unit test.
> 
> **Overview**
> Fixes **Clerk billing projection** when reconciliation payloads include both an **active paid subscription item** and a separate **past_due** item (e.g. a failed upgrade).
> 
> Previously, **any** paid `past_due` line item triggered the early past-due/failed-payment branch, which could block normal projection—most notably leaving **free** local state unchanged instead of promoting to an active **starter** tier when starter is active alongside a past-due pro item.
> 
> The guard now runs only when item-level `past_due` exists **and** there is **no** active paid item to project (`hasPastDuePaidItemWithoutActive`). Paid-item selection is computed **before** that branch so active entitlements are still applied. A regression test covers active starter + past_due pro on an active subscription.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4514571f68447d61ec9b53193aeab6b7a802ccc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->