### PR TITLE
ci(release): bootstrap PR #428 production expand

### DIFF
--- a/.github/workflows/production-db-migrations.yaml
+++ b/.github/workflows/production-db-migrations.yaml
@@ -1,4 +1,4 @@
-name: Deploy PR #428 EXPAND Migrations to Production
+name: 'Deploy PR #428 EXPAND Migrations to Production'
 
 on:
   workflow_dispatch:
@@ -23,7 +23,7 @@ jobs:
       SUPABASE_PROJECT_ID: ${{ secrets.PRODUCTION_PROJECT_ID }}
 
     steps:
-      - name: Checkout frozen PR #428 release
+      - name: 'Checkout frozen PR #428 release'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: f701907509915d6acb0fdd6fc1e09bfb4e704dbf

--- a/.github/workflows/production-db-migrations.yaml
+++ b/.github/workflows/production-db-migrations.yaml
@@ -1,9 +1,6 @@
-name: Deploy Migrations to Production
+name: Deploy PR #428 EXPAND Migrations to Production
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions:
@@ -14,11 +11,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  deploy:
-    name: Push Supabase migrations to production
+  deploy-expand:
+    name: Apply reviewed EXPAND migrations
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    environment: production
+    environment: Production – atlaris
 
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
@@ -26,18 +23,24 @@ jobs:
       SUPABASE_PROJECT_ID: ${{ secrets.PRODUCTION_PROJECT_ID }}
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Checkout frozen PR #428 release
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: main
+          ref: f701907509915d6acb0fdd6fc1e09bfb4e704dbf
 
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@v1
+        uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf # v2.1.1
         with:
-          version: latest
+          version: 2.98.1
+
+      - name: Print Supabase CLI version
+        run: supabase --version
 
       - name: Link production project
         run: supabase link --project-ref "$SUPABASE_PROJECT_ID"
 
-      - name: Push database migrations
-        run: supabase db push
+      - name: Apply reviewed EXPAND migrations
+        env:
+          MIGRATION_PHASE: expand
+        shell: bash
+        run: bash scripts/db/run-phased-migrations.sh


### PR DESCRIPTION
## Purpose

Install a temporary, manual-only Production workflow that applies the reviewed EXPAND migration set from frozen `develop` SHA `f701907509915d6acb0fdd6fc1e09bfb4e704dbf` before PR #428 deploys the application.

## Safety boundary

- no push trigger
- no workflow inputs
- no CONTRACT path
- immutable release SHA
- Production environment restricted to `main`
- pinned checkout, Supabase action, and CLI versions

## Verification

- one-file workflow diff
- actionlint/format/diff checks pass
- full lint and typecheck pass
- required Production repository secrets and `main` deployment policy confirmed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how production schema is applied (manual EXPAND-only path on a frozen SHA); mistakes or wrong timing could affect live database state before PR #428 ships.
> 
> **Overview**
> **Replaces** the production DB workflow that ran on every `main` push (`supabase db push`) with a **manual-only** (`workflow_dispatch`) job scoped to PR #428.
> 
> The job checks out immutable commit `f701907509915d6acb0fdd6fc1e09bfb4e704dbf`, pins checkout/Supabase setup/CLI versions, gates on `refs/heads/main` and the **Production – atlaris** environment, and runs `scripts/db/run-phased-migrations.sh` with `MIGRATION_PHASE=expand` instead of a full push—so only the reviewed EXPAND set runs before the app deploy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1476677447d6ccfc1c4b0339355c70bfa08c79b8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->