### PR TITLE
fix(db): revoke unsafe anonymous table privileges

### DIFF
--- a/scripts/db/run-phased-migrations.sh
+++ b/scripts/db/run-phased-migrations.sh
@@ -18,6 +18,7 @@ readonly -a EXPAND_MIGRATIONS=(
   supabase/migrations/20260810120000_create_clerk_webhook_event_claims.sql
   supabase/migrations/20260811100100_add_clerk_user_identity_projection.sql
   supabase/migrations/20260811100200_enforce_resolved_email_delivery_payload_minimization.sql
+  supabase/migrations/20260811100700_revoke_anon_unsafe_table_privileges.sql
 )
 
 # Keep the users INSERT revoke contract-only until service-role provisioning is live.

--- a/supabase/migrations/20260811100700_revoke_anon_unsafe_table_privileges.sql
+++ b/supabase/migrations/20260811100700_revoke_anon_unsafe_table_privileges.sql
@@ -1,0 +1,15 @@
+-- RLS cannot protect tables from privileges that bypass row-level operations.
+-- Preserve anonymous reads while removing unsafe direct and PUBLIC-derived ACLs.
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
+ON ALL TABLES IN SCHEMA public
+FROM PUBLIC, anon;
+
+-- Clear both global and schema-specific defaults for tables created later by
+-- the migration role. Schema defaults cannot override a global grant.
+ALTER DEFAULT PRIVILEGES
+  REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLES
+  FROM PUBLIC, anon;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLES
+  FROM PUBLIC, anon;

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -379,6 +379,13 @@
       "when": 1786442760000,
       "tag": "20260811100600_drop_task_progress_delete_policy",
       "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "7",
+      "when": 1786442820000,
+      "tag": "20260811100700_revoke_anon_unsafe_table_privileges",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/security/effective-privileges-attestation.spec.ts
+++ b/tests/security/effective-privileges-attestation.spec.ts
@@ -86,6 +86,24 @@ describe('effective database privilege attestation', () => {
     await expect(db.execute(sql.raw(attestationSql()))).resolves.toBeDefined();
   });
 
+  it('rejects anon table privileges inherited from PUBLIC', async () => {
+    await runInRolledBackTransaction(async (tx) => {
+      await tx.execute(sql`
+        GRANT TRUNCATE ON TABLE "modules" TO PUBLIC;
+      `);
+
+      await expect(tx.execute(sql.raw(attestationSql()))).rejects.toMatchObject(
+        {
+          cause: expect.objectContaining({
+            message: expect.stringMatching(
+              /anon has TRUNCATE on public\.modules/,
+            ),
+          }),
+        },
+      );
+    });
+  });
+
   it('rejects a service-only column grant when table-level privileges are absent', async () => {
     await runInRolledBackTransaction(async (tx) => {
       await tx.execute(sql`

--- a/tests/unit/architecture/db-migration-workflows.spec.ts
+++ b/tests/unit/architecture/db-migration-workflows.spec.ts
@@ -111,6 +111,9 @@ describe('Supabase migration workflows', () => {
     expect(script).toContain(
       '20260811100200_enforce_resolved_email_delivery_payload_minimization.sql',
     );
+    expect(script).toContain(
+      '20260811100700_revoke_anon_unsafe_table_privileges.sql',
+    );
     expect(script).not.toContain(
       '20260811100000_clear_module_lesson_generation_errors.sql',
     );
@@ -119,6 +122,27 @@ describe('Supabase migration workflows', () => {
     );
     expect(script).not.toContain('supabase migration repair');
     expect(script).not.toContain('db query --linked --file');
+  });
+
+  it('revokes unsafe anonymous table privileges for existing and future tables', () => {
+    const migration = readFileSync(
+      join(
+        MIGRATIONS_DIR,
+        '20260811100700_revoke_anon_unsafe_table_privileges.sql',
+      ),
+      'utf8',
+    );
+
+    expect(migration).toContain(
+      'REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER\nON ALL TABLES IN SCHEMA public\nFROM PUBLIC, anon;',
+    );
+    expect(migration).toContain(
+      'ALTER DEFAULT PRIVILEGES\n  REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLES\n  FROM PUBLIC, anon;',
+    );
+    expect(migration).toContain(
+      'ALTER DEFAULT PRIVILEGES IN SCHEMA public\n  REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLES\n  FROM PUBLIC, anon;',
+    );
+    expect(migration).not.toMatch(/REVOKE SELECT/i);
   });
 
   it('attests effective privileges after each successful migration phase', () => {
@@ -242,7 +266,7 @@ describe('Supabase migration workflows', () => {
     const targetEntries = journal.entries.filter((entry) =>
       entry.tag.startsWith('20260811100'),
     );
-    expect(targetEntries.slice(-3)).toEqual([
+    expect(targetEntries.slice(-4)).toEqual([
       {
         idx: 51,
         version: '7',
@@ -264,8 +288,15 @@ describe('Supabase migration workflows', () => {
         tag: '20260811100600_drop_task_progress_delete_policy',
         breakpoints: true,
       },
+      {
+        idx: 54,
+        version: '7',
+        when: 1786442820000,
+        tag: '20260811100700_revoke_anon_unsafe_table_privileges',
+        breakpoints: true,
+      },
     ]);
-    for (const entry of targetEntries.slice(-3)) {
+    for (const entry of targetEntries.slice(-4)) {
       expect(migrationFiles).toContain(`${entry.tag}.sql`);
     }
 


### PR DESCRIPTION
## Root cause

Production EXPAND run 31421974498 applied the full reviewed additive set, then the effective-privilege gate found `anon` had inherited `TRUNCATE` on `public.modules`. The gate stops at the first violation, so a one-table revoke would leave sibling ACL drift.

## Fix

- revoke INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, and TRIGGER on all existing `public` tables from both `PUBLIC` and `anon`
- clear both global and public-schema defaults for future tables created by the migration role
- preserve intentional anonymous SELECT access
- add the repair to the EXPAND allowlist and migration journal
- cover PUBLIC-inherited TRUNCATE and the durable migration shape

## Verification

- 15 focused migration-workflow tests pass
- shell syntax, lint, formatting, diff checks, and TypeScript pass
- database-backed privilege test is included for hosted CI; local Testcontainers was unavailable because no container runtime is running

After this PR is green and merged, the Production bootstrap will be repinned to its exact develop SHA and rerun. CONTRACT remains out of scope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad ACL changes on all public tables for anon/PUBLIC affect every anonymous client path; scope is intentional hardening but mis-revocation could break expected anon writes if any existed outside RLS.
> 
> **Overview**
> Unblocks the **EXPAND** effective-privilege gate after production found `anon` with inherited **TRUNCATE** on `public.modules` (via `PUBLIC`), which RLS cannot mitigate.
> 
> Adds migration `20260811100700_revoke_anon_unsafe_table_privileges.sql` to **REVOKE** INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, and TRIGGER on all existing `public` tables from **`PUBLIC`** and **`anon`**, and to clear matching **default privileges** (global and `public` schema) for future tables—**without** revoking SELECT. The migration is registered in the journal and included in the phased **EXPAND** allowlist in `run-phased-migrations.sh`.
> 
> Tests assert the migration SQL shape, journal/allowlist wiring, and that granting TRUNCATE to `PUBLIC` on `modules` fails attestation with an `anon has TRUNCATE` message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a7f6689f87ee4ab97025ce4f06d9739a4782133. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->