### PR TITLE
ci(release): repin PR #428 production expand

### DIFF
--- a/.github/workflows/production-db-migrations.yaml
+++ b/.github/workflows/production-db-migrations.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: 'Checkout frozen PR #428 release'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: f701907509915d6acb0fdd6fc1e09bfb4e704dbf
+          ref: 2e942c977c69a3d6d759d24a1849ed444bdef764
 
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf # v2.1.1


### PR DESCRIPTION
## Purpose

Repin the already-installed manual EXPAND-only Production bootstrap from `f701907509915d6acb0fdd6fc1e09bfb4e704dbf` to `2e942c977c69a3d6d759d24a1849ed444bdef764`, which adds the reviewed anonymous-privilege repair from #480.

This is a one-line workflow change. The bootstrap remains manual-only, no-input, main-gated, EXPAND-only, and pinned to immutable action/CLI versions.

## Evidence

- #480 is fully green, including hosted Security/RLS, integration, Supabase Preview migration, and Ready Vercel Preview
- the frozen SHA contains the new migration and phased runner
- local workflow format/diff assertions plus full lint and typecheck pass
- the prior Production run applied the original EXPAND set and failed only at the post-migration privilege attestation; retry will apply only the new migration, then rerun the full attestation

Old-main dependency audit and Stripe build failures remain inherited baseline behavior documented on #479; no CI policy is weakened. CONTRACT remains out of scope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the production database migration deploy pin; scope is a single SHA bump to already-reviewed EXPAND migrations, with no workflow policy changes.
> 
> **Overview**
> **Repins** the manual, main-only Production EXPAND migration workflow so checkout uses `2e942c977c69a3d6d759d24a1849ed444bdef764` instead of `f701907509915d6acb0fdd6fc1e09bfb4e704dbf`.
> 
> That new frozen commit carries the reviewed anonymous-privilege repair from #480 (new migration + phased runner). Everything else in the workflow—dispatch-only trigger, pinned actions/CLI, `MIGRATION_PHASE: expand`, and `run-phased-migrations.sh`—is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdcf7d2592e5a65b005042f544c889f752bee12c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->