### PR TITLE
fix(db): revoke browser access to security definers

### DIFF
--- a/scripts/db/run-phased-migrations.sh
+++ b/scripts/db/run-phased-migrations.sh
@@ -19,6 +19,7 @@ readonly -a EXPAND_MIGRATIONS=(
   supabase/migrations/20260811100100_add_clerk_user_identity_projection.sql
   supabase/migrations/20260811100200_enforce_resolved_email_delivery_payload_minimization.sql
   supabase/migrations/20260811100700_revoke_anon_unsafe_table_privileges.sql
+  supabase/migrations/20260811100800_revoke_security_definer_execute.sql
 )
 
 # Keep the users INSERT revoke contract-only until service-role provisioning is live.

--- a/supabase/migrations/20260811100800_revoke_security_definer_execute.sql
+++ b/supabase/migrations/20260811100800_revoke_security_definer_execute.sql
@@ -1,0 +1,29 @@
+-- SECURITY DEFINER functions must never inherit browser-role EXECUTE.
+-- Limit the existing-object sweep so ordinary client-callable RPCs keep their grants.
+DO $$
+DECLARE
+  function_identity regprocedure;
+BEGIN
+  FOR function_identity IN
+    SELECT procedure.oid::regprocedure
+    FROM pg_proc AS procedure
+    JOIN pg_namespace AS namespace
+      ON namespace.oid = procedure.pronamespace
+    WHERE procedure.prosecdef
+      AND namespace.nspname IN ('public', 'private')
+  LOOP
+    EXECUTE format(
+      'REVOKE ALL PRIVILEGES ON FUNCTION %s FROM PUBLIC, anon, authenticated',
+      function_identity
+    );
+  END LOOP;
+END;
+$$;
+
+-- Migrations create functions as postgres. Remove PostgreSQL's default EXECUTE
+-- grant globally and clear the existing public-schema override for later functions.
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres
+  REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC, anon, authenticated;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+  REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC, anon, authenticated;

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -386,6 +386,13 @@
       "when": 1786442820000,
       "tag": "20260811100700_revoke_anon_unsafe_table_privileges",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1786442880000,
+      "tag": "20260811100800_revoke_security_definer_execute",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/security/effective-privileges-attestation.spec.ts
+++ b/tests/security/effective-privileges-attestation.spec.ts
@@ -19,6 +19,15 @@ const ATTESTATION_SQL = readFileSync(
   join(REPO_ROOT, 'scripts', 'db', 'attest-effective-privileges.sql'),
   'utf8',
 );
+const SECURITY_DEFINER_EXECUTE_REPAIR_SQL = readFileSync(
+  join(
+    REPO_ROOT,
+    'supabase',
+    'migrations',
+    '20260811100800_revoke_security_definer_execute.sql',
+  ),
+  'utf8',
+);
 
 function attestationSql(phase: 'expand' | 'contract' = 'contract'): string {
   return `SELECT set_config('app.atlaris_migration_phase', '${phase}', true);\n${ATTESTATION_SQL}`;
@@ -101,6 +110,44 @@ describe('effective database privilege attestation', () => {
           }),
         },
       );
+    });
+  });
+
+  it('repairs browser execution inherited by security-definer functions', async () => {
+    await runInRolledBackTransaction(async (tx) => {
+      await tx.execute(sql`
+        GRANT EXECUTE ON FUNCTION private.cleanup_retained_db_rows(timestamptz)
+        TO PUBLIC, anon, authenticated;
+      `);
+
+      await expect(tx.execute(sql.raw(attestationSql()))).rejects.toMatchObject(
+        {
+          cause: expect.objectContaining({
+            message: expect.stringMatching(
+              /can execute security-definer function private\.cleanup_retained_db_rows/,
+            ),
+          }),
+        },
+      );
+
+      await tx.execute(sql.raw(SECURITY_DEFINER_EXECUTE_REPAIR_SQL));
+
+      const privilegeRows = (await tx.execute(sql`
+        SELECT role_name,
+          has_function_privilege(
+            role_name,
+            'private.cleanup_retained_db_rows(timestamptz)',
+            'EXECUTE'
+          ) AS can_execute
+        FROM unnest(ARRAY['anon', 'authenticated']) AS role_name
+      `)) as Array<{ role_name: string; can_execute: boolean }>;
+      expect(privilegeRows).toEqual([
+        { role_name: 'anon', can_execute: false },
+        { role_name: 'authenticated', can_execute: false },
+      ]);
+      await expect(
+        tx.execute(sql.raw(attestationSql())),
+      ).resolves.toBeDefined();
     });
   });
 

--- a/tests/security/effective-privileges-attestation.spec.ts
+++ b/tests/security/effective-privileges-attestation.spec.ts
@@ -129,7 +129,13 @@ describe('effective database privilege attestation', () => {
           }),
         },
       );
+    });
 
+    await runInRolledBackTransaction(async (tx) => {
+      await tx.execute(sql`
+        GRANT EXECUTE ON FUNCTION private.cleanup_retained_db_rows(timestamptz)
+        TO PUBLIC, anon, authenticated;
+      `);
       await tx.execute(sql.raw(SECURITY_DEFINER_EXECUTE_REPAIR_SQL));
 
       const privilegeRows = (await tx.execute(sql`

--- a/tests/unit/architecture/db-migration-workflows.spec.ts
+++ b/tests/unit/architecture/db-migration-workflows.spec.ts
@@ -114,6 +114,9 @@ describe('Supabase migration workflows', () => {
     expect(script).toContain(
       '20260811100700_revoke_anon_unsafe_table_privileges.sql',
     );
+    expect(script).toContain(
+      '20260811100800_revoke_security_definer_execute.sql',
+    );
     expect(script).not.toContain(
       '20260811100000_clear_module_lesson_generation_errors.sql',
     );
@@ -143,6 +146,29 @@ describe('Supabase migration workflows', () => {
       'ALTER DEFAULT PRIVILEGES IN SCHEMA public\n  REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLES\n  FROM PUBLIC, anon;',
     );
     expect(migration).not.toMatch(/REVOKE SELECT/i);
+  });
+
+  it('revokes browser execution of security-definer functions only', () => {
+    const migration = readFileSync(
+      join(
+        MIGRATIONS_DIR,
+        '20260811100800_revoke_security_definer_execute.sql',
+      ),
+      'utf8',
+    );
+
+    expect(migration).toContain('procedure.prosecdef');
+    expect(migration).toContain("namespace.nspname IN ('public', 'private')");
+    expect(migration).toContain(
+      "'REVOKE ALL PRIVILEGES ON FUNCTION %s FROM PUBLIC, anon, authenticated'",
+    );
+    expect(migration).toContain(
+      'ALTER DEFAULT PRIVILEGES FOR ROLE postgres\n  REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC, anon, authenticated;',
+    );
+    expect(migration).toContain(
+      'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public\n  REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC, anon, authenticated;',
+    );
+    expect(migration).not.toMatch(/ON ALL FUNCTIONS/i);
   });
 
   it('attests effective privileges after each successful migration phase', () => {
@@ -266,7 +292,7 @@ describe('Supabase migration workflows', () => {
     const targetEntries = journal.entries.filter((entry) =>
       entry.tag.startsWith('20260811100'),
     );
-    expect(targetEntries.slice(-4)).toEqual([
+    expect(targetEntries.slice(-5)).toEqual([
       {
         idx: 51,
         version: '7',
@@ -295,8 +321,15 @@ describe('Supabase migration workflows', () => {
         tag: '20260811100700_revoke_anon_unsafe_table_privileges',
         breakpoints: true,
       },
+      {
+        idx: 55,
+        version: '7',
+        when: 1786442880000,
+        tag: '20260811100800_revoke_security_definer_execute',
+        breakpoints: true,
+      },
     ]);
-    for (const entry of targetEntries.slice(-4)) {
+    for (const entry of targetEntries.slice(-5)) {
       expect(migrationFiles).toContain(`${entry.tag}.sql`);
     }
 


### PR DESCRIPTION
## Summary
- revoke PUBLIC, anon, and authenticated EXECUTE from existing public/private SECURITY DEFINER functions
- remove postgres default browser-role EXECUTE grants for future functions
- add the forward-only repair to the explicit EXPAND allowlist and migration ledger

## Verification
- pnpm vitest run --project unit tests/unit/architecture/db-migration-workflows.spec.ts (16 passed)
- pnpm check:type
- oxlint + oxfmt focused checks
- bash -n scripts/db/run-phased-migrations.sh
- database integration spec added; local execution is blocked only by the unavailable container runtime and will run in hosted CI

## Release context
This repairs the second pre-existing privilege issue exposed by the Production EXPAND attestation for #428. It does not change Production workflow switches and does not run CONTRACT migrations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches database privilege defaults and all SECURITY DEFINER functions in public/private; mis-scoping could break intended client RPCs, but the targeted prosecdef-only approach limits blast radius.
> 
> **Overview**
> Adds an **EXPAND** migration that strips `PUBLIC`, `anon`, and `authenticated` **EXECUTE** from existing `SECURITY DEFINER` routines in `public` and `private`, and sets **postgres** default privileges so new functions no longer auto-grant browser execution. The sweep is limited to `prosecdef` functions (not a blanket `ON ALL FUNCTIONS` revoke) so normal client RPCs keep their grants.
> 
> The migration is registered in the phased deploy allowlist, Drizzle journal, and architecture tests; a security integration test simulates a bad grant on `private.cleanup_retained_db_rows`, expects attestation failure, then confirms the repair SQL restores compliance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c8445f265d184b80287dc6af5b4bb83241a8e6b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->