### PR TITLE
chore(release): repin production expand repair

### DIFF
--- a/.github/workflows/production-db-migrations.yaml
+++ b/.github/workflows/production-db-migrations.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: 'Checkout frozen PR #428 release'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: 2e942c977c69a3d6d759d24a1849ed444bdef764
+          ref: da998eca6b70820ddc6ca15402848fa59050bcf3
 
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf # v2.1.1


### PR DESCRIPTION
## Summary
- repin the isolated Production EXPAND workflow from develop `2e942c977` to reviewed develop `da998eca6`
- keep the workflow manual, EXPAND-only, and protected by `Production – atlaris`

## Reviewed source
- #482 is merged into develop at `da998eca6b70820ddc6ca15402848fa59050bcf3`
- hosted CI, Security (RLS), Supabase Preview, Vercel, and automated reviews passed

## Release boundary
This one-line bootstrap change does not merge application code, alter Production workflow switches, or permit CONTRACT migrations. It only allows the already-authorized forward EXPAND repair to run from main.

## Main baseline exception
The current main baseline is expected to reproduce its inherited dependency-audit and missing legacy Stripe build-variable failures. Those failures are already fixed on develop by the release stack and will be cleared by #428. No policy or check is being weakened here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the commit used for production EXPAND migrations; scope stays EXPAND-only and environment-gated, but wrong ref would apply the wrong migration set.
> 
> **Overview**
> Updates the **manual, EXPAND-only** production DB migration workflow so checkout uses develop commit `da998eca` instead of `2e942c97`.
> 
> That repin points the isolated **Deploy PR #428 EXPAND Migrations to Production** job at the reviewed release stack (post-#482 on develop) before `run-phased-migrations.sh` runs with `MIGRATION_PHASE=expand`. Workflow guards are unchanged: `workflow_dispatch`, `main` only, and the **Production – atlaris** environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6dddf6368ad4d99878fad4a4e23c15cbb6144a3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->