### PR TITLE
fix(release): reconcile #428 migration gate

### DIFF
--- a/.github/workflows/production-db-migrations.yaml
+++ b/.github/workflows/production-db-migrations.yaml
@@ -1,9 +1,6 @@
-name: Deploy Migrations to Production
+name: 'Deploy PR #428 EXPAND Migrations to Production'
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions:
@@ -14,11 +11,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  deploy:
-    name: Push Supabase migrations to production
+  deploy-expand:
+    name: Apply reviewed EXPAND migrations
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    environment: production
+    environment: Production – atlaris
 
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
@@ -26,18 +23,24 @@ jobs:
       SUPABASE_PROJECT_ID: ${{ secrets.PRODUCTION_PROJECT_ID }}
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: 'Checkout frozen PR #428 release'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: main
+          ref: f701907509915d6acb0fdd6fc1e09bfb4e704dbf
 
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@v1
+        uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf # v2.1.1
         with:
-          version: latest
+          version: 2.98.1
+
+      - name: Print Supabase CLI version
+        run: supabase --version
 
       - name: Link production project
         run: supabase link --project-ref "$SUPABASE_PROJECT_ID"
 
-      - name: Push database migrations
-        run: supabase db push
+      - name: Apply reviewed EXPAND migrations
+        env:
+          MIGRATION_PHASE: expand
+        shell: bash
+        run: bash scripts/db/run-phased-migrations.sh

--- a/.github/workflows/production-db-migrations.yaml
+++ b/.github/workflows/production-db-migrations.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: 'Checkout frozen PR #428 release'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: f701907509915d6acb0fdd6fc1e09bfb4e704dbf
+          ref: 2e942c977c69a3d6d759d24a1849ed444bdef764
 
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf # v2.1.1

--- a/.github/workflows/production-db-migrations.yaml
+++ b/.github/workflows/production-db-migrations.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: 'Checkout frozen PR #428 release'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: 2e942c977c69a3d6d759d24a1849ed444bdef764
+          ref: da998eca6b70820ddc6ca15402848fa59050bcf3
 
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf # v2.1.1


### PR DESCRIPTION
## Summary

- merge current `main` into `develop` so PR #428 has one reconciled history
- keep the durable phased Production migration workflow from `develop`
- scope default-table ACL attestation to the actual migration object creator, `current_user`, instead of the unreachable Supabase internal `supabase_admin` role
- add the focused attestation contract assertion

## Root cause

Production EXPAND migration `20260811100800` applied successfully. The remaining attestation failure came from a `supabase_admin` schema-default ACL that grants `anon` INSERT/UPDATE/DELETE. Hosted migrations execute as `postgres`; Production confirms `postgres` is neither superuser nor a member of `supabase_admin`, so it cannot change that platform-owned default. Supabase documents `supabase_admin` as an internal automation role, while dashboard and external tools create objects as `postgres`.

PostgreSQL default ACLs apply only for the current object-creator role. Migration 007 already revoked unsafe table defaults for `postgres`; the attestation now enforces that same creator boundary.

## Verification

- revised `expand` attestation passed directly against Production through the linked Management API
- `SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm exec vitest run --project unit tests/unit/architecture/db-migration-workflows.spec.ts` — 16 passed
- pre-push lint and typecheck passed
- local containerized security test could not start because no container runtime is available; hosted Security (RLS) will execute it

No application behavior, Vercel environment value, workflow feature switch, or CONTRACT migration changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to read-only attestation SQL and a string contract test; no runtime app or migration behavior changes.
> 
> **Overview**
> **Fixes Production expand-phase attestation** by only checking PostgreSQL default table ACLs for the role that actually creates migrated objects (`current_user`), not every `defaclrole` in `pg_default_acl`.
> 
> The effective-privileges gate’s `table_default_acls` check now adds `default_acl.defaclrole = current_user::regrole`, so platform-owned `supabase_admin` defaults (which hosted `postgres` cannot revoke) no longer fail the deployment gate. A security spec assertion locks in that filter in `attest-effective-privileges.sql`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa3bb55de1e773a229ecc060a905a88cede65579. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->