### PR TITLE
fix(release): close final promotion findings

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,4 +1,4 @@
-# Vercel Production environment variable names (values intentionally blank).
+# Vercel Production environment variable names (secret values intentionally blank).
 
 # Application
 APP_URL=
@@ -42,6 +42,7 @@ RESEND_FROM=
 MAINTENANCE_MODE=
 MAINTENANCE_WORKER_TOKEN=
 PLAN_CLEANUP_ENABLED=
+REGENERATION_QUEUE_ENABLED=false
 REGENERATION_WORKER_TOKEN=
 RETENTION_CLEANUP_ENABLED=
 WORKER_HEALTH_TOKEN=

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -470,6 +470,7 @@ jobs:
           case "${MODE}" in
             related)
               pnpm vitest related --project integration --run --coverage \
+                --passWithNoTests \
                 --reporter=default \
                 --reporter=json \
                 --outputFile=test-results.json \

--- a/docs/architecture/regeneration-worker-runbook.md
+++ b/docs/architecture/regeneration-worker-runbook.md
@@ -21,6 +21,8 @@ This endpoint drains up to `REGENERATION_MAX_JOBS_PER_DRAIN` jobs by calling `dr
 | `REGENERATION_INLINE_PROCESSING`     | Inline processing fallback from enqueue route                          | `false` in production       |
 | `PLAN_REGENERATION_WORKFLOW_ENABLED` | Routes drain/enqueue through Workflow SDK (`planRegenerationWorkflow`) | `false` (default)           |
 
+The queue and inline fallback default on in development, test, and Vercel Preview. Both default off in Production until a worker trigger is configured and verified.
+
 ## Workflow-backed regeneration
 
 When `PLAN_REGENERATION_WORKFLOW_ENABLED=true`:

--- a/docs/architecture/regeneration-worker-runbook.md
+++ b/docs/architecture/regeneration-worker-runbook.md
@@ -15,7 +15,7 @@ This endpoint drains up to `REGENERATION_MAX_JOBS_PER_DRAIN` jobs by calling `dr
 
 | Variable                             | Purpose                                                                | Production expectation      |
 | ------------------------------------ | ---------------------------------------------------------------------- | --------------------------- |
-| `REGENERATION_QUEUE_ENABLED`         | Master switch for enqueue/drain behavior                               | `true`                      |
+| `REGENERATION_QUEUE_ENABLED`         | Master switch for enqueue/drain behavior                               | Explicitly `true` after the worker trigger is configured; otherwise defaults `false` |
 | `REGENERATION_MAX_JOBS_PER_DRAIN`    | Max jobs processed per drain call                                      | Set to a safe bounded value |
 | `REGENERATION_WORKER_TOKEN`          | Shared bearer token for internal drain auth                            | Required                    |
 | `REGENERATION_INLINE_PROCESSING`     | Inline processing fallback from enqueue route                          | `false` in production       |
@@ -33,6 +33,8 @@ When `PLAN_REGENERATION_WORKFLOW_ENABLED=true`:
 Correlate failures using `job_queue.data.workflow.runId` and logs tagged with `workflowRunId`. See [Workflow SDK](./workflow-sdk.md) (correlation metadata and Preview testing). Env flags: [environment variables](../development/environment.md#workflow-sdk). Preview workflow testing: [development commands](../development/commands.md) (`pnpm deploy:preview`).
 
 ## Triggering the Worker
+
+Configure and verify a recurring worker trigger before setting `REGENERATION_QUEUE_ENABLED=true` in production.
 
 Use a scheduler (Cron, GitHub Actions, Vercel cron, etc.) to call:
 

--- a/docs/testing/test-standards.md
+++ b/docs/testing/test-standards.md
@@ -329,6 +329,10 @@ expect(screen.getByRole('link', { name: /privacy/i })).toHaveAttribute(
 - Use `findBy*` for async rendering.
 - Use `waitFor` only when you cannot wait on a specific element state.
 
+### Hydration
+
+For SSR/hydration-sensitive client components, render server markup with `renderToString` while `window` is absent, then `hydrateRoot` the markup and assert no `onRecoverableError`; unmount the root and remove its container in `finally`. Use normal RTL `render` otherwise.
+
 ### Assertions
 
 - Assert the smallest meaningful thing.

--- a/scripts/db/attest-effective-privileges.sql
+++ b/scripts/db/attest-effective-privileges.sql
@@ -4,6 +4,7 @@ DECLARE
   violation text;
   migration_phase text := current_setting('app.atlaris_migration_phase', true);
   users_update_columns text[] := ARRAY['name', 'updated_at'];
+  task_progress_update_columns text[] := ARRAY['status', 'completed_at', 'updated_at'];
 BEGIN
   IF migration_phase IS NULL OR migration_phase NOT IN ('expand', 'contract') THEN
     RAISE EXCEPTION 'attestation phase must be expand or contract';
@@ -352,7 +353,7 @@ BEGIN
   END IF;
 
   WITH required_privileges AS (
-    SELECT unnest(ARRAY['SELECT', 'INSERT', 'UPDATE']) AS privilege_type
+    SELECT unnest(ARRAY['SELECT', 'INSERT']) AS privilege_type
   )
   SELECT format('authenticated lacks %s on public.task_progress', privilege_type)
     INTO violation
@@ -390,6 +391,7 @@ BEGIN
     SELECT *
     FROM (VALUES
       ('users', 'UPDATE', users_update_columns),
+      ('task_progress', 'UPDATE', task_progress_update_columns),
       ('user_preferences', 'INSERT', ARRAY['user_id', 'preferred_ai_model', 'analytics_timezone', 'updated_at']),
       ('user_preferences', 'UPDATE', ARRAY['preferred_ai_model', 'analytics_timezone', 'updated_at']),
       ('user_email_notification_settings', 'INSERT', ARRAY['user_id', 'unsubscribe_all_optional_emails', 'updated_at']),
@@ -421,6 +423,7 @@ BEGIN
     SELECT *
     FROM (VALUES
       ('users', 'UPDATE', users_update_columns),
+      ('task_progress', 'UPDATE', task_progress_update_columns),
       ('user_preferences', 'INSERT', ARRAY['user_id', 'preferred_ai_model', 'analytics_timezone', 'updated_at']),
       ('user_preferences', 'UPDATE', ARRAY['preferred_ai_model', 'analytics_timezone', 'updated_at']),
       ('user_email_notification_settings', 'INSERT', ARRAY['user_id', 'unsubscribe_all_optional_emails', 'updated_at']),

--- a/scripts/db/run-phased-migrations.sh
+++ b/scripts/db/run-phased-migrations.sh
@@ -20,6 +20,7 @@ readonly -a EXPAND_MIGRATIONS=(
   supabase/migrations/20260811100200_enforce_resolved_email_delivery_payload_minimization.sql
   supabase/migrations/20260811100700_revoke_anon_unsafe_table_privileges.sql
   supabase/migrations/20260811100800_revoke_security_definer_execute.sql
+  supabase/migrations/20260811100900_restrict_task_progress_update_columns.sql
 )
 
 # Keep the users INSERT revoke contract-only until service-role provisioning is live.

--- a/src/app/(marketing)/pricing/components/ClerkPricingTable.tsx
+++ b/src/app/(marketing)/pricing/components/ClerkPricingTable.tsx
@@ -66,14 +66,6 @@ const PLAN_RANK: Record<string, number> = {
   [CLERK_BILLING_PLAN_SLUGS.pro]: 2,
 };
 
-function readCheckoutPeriodFromUrl(): BillingPeriod {
-  if (typeof window === 'undefined') return 'month';
-  const requestedPeriod = new URL(window.location.href).searchParams.get(
-    CHECKOUT_PERIOD_PARAM,
-  );
-  return requestedPeriod === 'annual' ? 'annual' : 'month';
-}
-
 function buildCheckoutSignInRedirect(
   planId: string,
   planSlug: string,
@@ -152,7 +144,7 @@ export function ClerkPricingTable({
   const { billing, loaded } = useClerk();
   const { isLoaded, userId } = useAuth();
   const [plans, setPlans] = useState<PricingPlan[]>([]);
-  const [period, setPeriod] = useState<BillingPeriod>(readCheckoutPeriodFromUrl);
+  const [period, setPeriod] = useState<BillingPeriod>('month');
   const [activePaidPlanSlug, setActivePaidPlanSlug] = useState<string | null>(
     null,
   );

--- a/src/features/lesson-content/run-module-lesson-generation-work.ts
+++ b/src/features/lesson-content/run-module-lesson-generation-work.ts
@@ -44,12 +44,14 @@ export async function runModuleLessonGenerationWork(
   deps: GenerateModuleLessonsDeps = {},
 ): Promise<ModuleLessonGenerationWorkResult> {
   const serverDbClient = deps.serverDbClient ?? serviceRoleDb;
+  const workflowRunId = params.generationMetadata?.workflow?.runId;
 
   if (!lessonContentEnv.generationEnabled) {
     await revertModuleLessonGeneratingToNotGenerated(serverDbClient, {
       userId: params.userId,
       planId: params.planId,
       moduleId: params.moduleId,
+      workflowRunId,
     });
     return { kind: 'disabled' };
   }
@@ -217,6 +219,7 @@ export async function runModuleLessonGenerationWork(
         userId: params.userId,
         planId: params.planId,
         moduleId: params.moduleId,
+        workflowRunId,
       });
     } catch (revertErr) {
       logger.error(
@@ -245,6 +248,7 @@ export async function runModuleLessonGenerationWork(
         userId: params.userId,
         planId: params.planId,
         moduleId: params.moduleId,
+        workflowRunId,
       });
     } catch (revertErr) {
       logger.error(

--- a/src/features/lesson-content/run-module-lesson-generation-work.ts
+++ b/src/features/lesson-content/run-module-lesson-generation-work.ts
@@ -43,7 +43,14 @@ export async function runModuleLessonGenerationWork(
   params: RunModuleLessonGenerationAfterClaimParams,
   deps: GenerateModuleLessonsDeps = {},
 ): Promise<ModuleLessonGenerationWorkResult> {
+  const serverDbClient = deps.serverDbClient ?? serviceRoleDb;
+
   if (!lessonContentEnv.generationEnabled) {
+    await revertModuleLessonGeneratingToNotGenerated(serverDbClient, {
+      userId: params.userId,
+      planId: params.planId,
+      moduleId: params.moduleId,
+    });
     return { kind: 'disabled' };
   }
 
@@ -52,7 +59,6 @@ export async function runModuleLessonGenerationWork(
   const timeoutConfig = resolveTimeoutConfig(params.timeoutConfig, clock);
   const runReserved =
     deps.runLessonQuotaReserved ?? runLessonGenerationQuotaReserved;
-  const serverDbClient = deps.serverDbClient ?? serviceRoleDb;
 
   const expectedTaskIds = params.load.tasks.map((t) => t.id);
   const promptInput: ModuleLessonBatchPromptInput = {

--- a/src/lib/config/env/queue.ts
+++ b/src/lib/config/env/queue.ts
@@ -29,7 +29,7 @@ export const regenerationQueueEnv: RegenerationQueueEnv = {
   get enabled(): boolean {
     return toBoolean(
       defaultQueueAccess.getServerOptional('REGENERATION_QUEUE_ENABLED'),
-      true,
+      !isQueueProductionRuntime(),
     );
   },
   /**

--- a/src/lib/config/env/queue.ts
+++ b/src/lib/config/env/queue.ts
@@ -19,7 +19,8 @@ interface RegenerationQueueEnv {
 const defaultQueueAccess = createServerEnvAccess(getProcessEnvSource);
 
 function isQueueProductionRuntime(): boolean {
-  return isProdRuntimeEnv(getProcessEnvSource());
+  const env = getProcessEnvSource();
+  return isProdRuntimeEnv(env) && env.VERCEL_ENV !== 'preview';
 }
 
 export const regenerationQueueEnv: RegenerationQueueEnv = {

--- a/src/lib/db/queries/module-lesson-generation.ts
+++ b/src/lib/db/queries/module-lesson-generation.ts
@@ -202,8 +202,13 @@ export async function revertModuleLessonGeneratingToNotGenerated(
     readonly userId: string;
     readonly planId: string;
     readonly moduleId: string;
+    readonly workflowRunId?: string;
   },
 ): Promise<void> {
+  const matchingWorkflowRun = args.workflowRunId
+    ? sql`${modules.lessonGenerationMetadata}->'workflow'->>'runId' = ${args.workflowRunId}`
+    : undefined;
+
   await dbClient
     .update(modules)
     .set({
@@ -212,6 +217,7 @@ export async function revertModuleLessonGeneratingToNotGenerated(
       lessonGenerationCompletedAt: null,
       lessonGenerationFailedAt: null,
       lessonGenerationError: null,
+      lessonGenerationMetadata: null,
     })
     .where(
       and(
@@ -219,6 +225,7 @@ export async function revertModuleLessonGeneratingToNotGenerated(
         eq(modules.planId, args.planId),
         eq(modules.lessonGenerationStatus, 'generating'),
         moduleOwnedByUser(args.userId),
+        matchingWorkflowRun,
       ),
     );
 }

--- a/supabase/migrations/20260811100900_restrict_task_progress_update_columns.sql
+++ b/supabase/migrations/20260811100900_restrict_task_progress_update_columns.sql
@@ -1,0 +1,2 @@
+REVOKE UPDATE ON TABLE "task_progress" FROM authenticated;
+GRANT UPDATE ("status", "completed_at", "updated_at") ON TABLE "task_progress" TO authenticated;

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -393,6 +393,13 @@
       "when": 1786442880000,
       "tag": "20260811100800_revoke_security_definer_execute",
       "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "7",
+      "when": 1786442940000,
+      "tag": "20260811100900_restrict_task_progress_update_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/supabase/privileges/task-progress-authenticated-update-columns.ts
+++ b/supabase/privileges/task-progress-authenticated-update-columns.ts
@@ -1,0 +1,9 @@
+/** PostgreSQL columns browser clients may update on public.task_progress. */
+export const TASK_PROGRESS_AUTHENTICATED_UPDATE_COLUMNS = [
+  'status',
+  'completed_at',
+  'updated_at',
+] as const;
+
+export const TASK_PROGRESS_AUTHENTICATED_UPDATE_COLUMNS_SQL =
+  TASK_PROGRESS_AUTHENTICATED_UPDATE_COLUMNS.join(', ');

--- a/tests/helpers/db/bootstrap.ts
+++ b/tests/helpers/db/bootstrap.ts
@@ -1,4 +1,5 @@
 import { AUTHENTICATED_SERVER_OWNED_WRITE_TABLES } from '../../../supabase/privileges/authenticated-table-privileges';
+import { TASK_PROGRESS_AUTHENTICATED_UPDATE_COLUMNS } from '../../../supabase/privileges/task-progress-authenticated-update-columns';
 import {
   USER_EMAIL_NOTIFICATION_PREFERENCES_AUTHENTICATED_INSERT_COLUMNS,
   USER_EMAIL_NOTIFICATION_PREFERENCES_AUTHENTICATED_UPDATE_COLUMNS,
@@ -78,7 +79,9 @@ export async function grantRlsPermissions(
       REVOKE INSERT, UPDATE, DELETE ON "job_queue" FROM authenticated;
       REVOKE INSERT, UPDATE, DELETE ON "job_queue" FROM anon;
       REVOKE INSERT, UPDATE, DELETE ON ${serverOwnedTablesSql} FROM authenticated;
-      GRANT INSERT, UPDATE ON "task_progress" TO authenticated;
+      GRANT INSERT ON "task_progress" TO authenticated;
+      REVOKE UPDATE ON "task_progress" FROM authenticated;
+      GRANT UPDATE (${TASK_PROGRESS_AUTHENTICATED_UPDATE_COLUMNS.join(', ')}) ON "task_progress" TO authenticated;
       REVOKE DELETE ON "task_progress" FROM authenticated;
     `);
 

--- a/tests/helpers/db/rls-bootstrap.ts
+++ b/tests/helpers/db/rls-bootstrap.ts
@@ -1,4 +1,5 @@
 import { AUTHENTICATED_SERVER_OWNED_WRITE_TABLES_SQL } from '../../../supabase/privileges/authenticated-table-privileges';
+import { TASK_PROGRESS_AUTHENTICATED_UPDATE_COLUMNS_SQL } from '../../../supabase/privileges/task-progress-authenticated-update-columns';
 import {
   USER_EMAIL_NOTIFICATION_PREFERENCES_AUTHENTICATED_INSERT_COLUMNS_SQL,
   USER_EMAIL_NOTIFICATION_PREFERENCES_AUTHENTICATED_UPDATE_COLUMNS_SQL,
@@ -87,7 +88,9 @@ export async function ensureRlsRolesAndPermissions() {
     REVOKE INSERT, UPDATE, DELETE ON ${sql.raw(
       AUTHENTICATED_SERVER_OWNED_WRITE_TABLES_SQL,
     )} FROM authenticated;
-    GRANT INSERT, UPDATE ON "task_progress" TO authenticated;
+    GRANT INSERT ON "task_progress" TO authenticated;
+    REVOKE UPDATE ON "task_progress" FROM authenticated;
+    GRANT UPDATE (${sql.raw(TASK_PROGRESS_AUTHENTICATED_UPDATE_COLUMNS_SQL)}) ON "task_progress" TO authenticated;
     REVOKE DELETE ON "task_progress" FROM authenticated;
   `);
 

--- a/tests/integration/db/module-lesson-workflow-metadata.spec.ts
+++ b/tests/integration/db/module-lesson-workflow-metadata.spec.ts
@@ -1,4 +1,7 @@
-import { claimModuleLessonGenerationOrDescribe } from '@/lib/db/queries/module-lesson-generation';
+import {
+  claimModuleLessonGenerationOrDescribe,
+  revertModuleLessonGeneratingToNotGenerated,
+} from '@/lib/db/queries/module-lesson-generation';
 import { modules } from '@supabase/schema';
 import { db } from '@supabase/service-role';
 import { createTestModule } from '@tests/fixtures/modules';
@@ -101,5 +104,63 @@ describe('module lesson workflow metadata (integration)', () => {
       .from(modules)
       .where(eq(modules.id, mod.id));
     expect(unchanged?.metadata?.workflow?.runId).toBe(runId);
+  });
+
+  it('does not release a newer workflow claim from a stale cleanup', async () => {
+    const authUserId = buildTestAuthUserId('mod-lesson-stale-cleanup');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+      subscriptionTier: 'free',
+    });
+    const plan = await createTestPlan({ userId, topic: 'Stale cleanup' });
+    const mod = await createTestModule({ planId: plan.id });
+    const runA = `wrun_${authUserId}_a`;
+    const runB = `wrun_${authUserId}_b`;
+
+    const claimA = await claimModuleLessonGenerationOrDescribe(
+      db,
+      plan.id,
+      mod.id,
+      userId,
+      { workflow: { runId: runA, startedAt: new Date().toISOString() } },
+    );
+    expect(claimA.kind).toBe('claimed');
+
+    await revertModuleLessonGeneratingToNotGenerated(db, {
+      userId,
+      planId: plan.id,
+      moduleId: mod.id,
+      workflowRunId: runA,
+    });
+
+    const claimB = await claimModuleLessonGenerationOrDescribe(
+      db,
+      plan.id,
+      mod.id,
+      userId,
+      { workflow: { runId: runB, startedAt: new Date().toISOString() } },
+    );
+    expect(claimB.kind).toBe('claimed');
+
+    await revertModuleLessonGeneratingToNotGenerated(db, {
+      userId,
+      planId: plan.id,
+      moduleId: mod.id,
+      workflowRunId: runA,
+    });
+
+    const [row] = await db
+      .select({
+        status: modules.lessonGenerationStatus,
+        metadata: modules.lessonGenerationMetadata,
+      })
+      .from(modules)
+      .where(eq(modules.id, mod.id));
+
+    expect(row).toMatchObject({
+      status: 'generating',
+      metadata: { workflow: { runId: runB } },
+    });
   });
 });

--- a/tests/security/effective-privileges-attestation.spec.ts
+++ b/tests/security/effective-privileges-attestation.spec.ts
@@ -1,4 +1,5 @@
 import { AUTHENTICATED_SERVER_OWNED_WRITE_TABLES } from '@supabase/privileges/authenticated-table-privileges';
+import { TASK_PROGRESS_AUTHENTICATED_UPDATE_COLUMNS } from '@supabase/privileges/task-progress-authenticated-update-columns';
 import {
   USER_EMAIL_NOTIFICATION_PREFERENCES_AUTHENTICATED_INSERT_COLUMNS,
   USER_EMAIL_NOTIFICATION_PREFERENCES_AUTHENTICATED_UPDATE_COLUMNS,
@@ -64,6 +65,9 @@ describe('effective database privilege attestation', () => {
     );
     expect(ATTESTATION_SQL).toContain(
       sqlArray(USERS_AUTHENTICATED_UPDATE_COLUMNS),
+    );
+    expect(ATTESTATION_SQL).toContain(
+      sqlArray(TASK_PROGRESS_AUTHENTICATED_UPDATE_COLUMNS),
     );
     expect(ATTESTATION_SQL).toContain('authenticated has INSERT on public.%I');
     expect(ATTESTATION_SQL).toContain(

--- a/tests/security/rls.policies.spec.ts
+++ b/tests/security/rls.policies.spec.ts
@@ -1523,6 +1523,21 @@ describe('RLS Policy Verification', () => {
 
       expect(updated).toHaveLength(1);
       expect(updated[0]?.status).toBe('in_progress');
+
+      await expectRlsBlocked(() =>
+        authDb
+          .update(taskProgress)
+          .set({ taskId: task.id })
+          .where(eq(taskProgress.taskId, task.id))
+          .returning(),
+      );
+      await expectRlsBlocked(() =>
+        authDb
+          .update(taskProgress)
+          .set({ userId: user.id })
+          .where(eq(taskProgress.taskId, task.id))
+          .returning(),
+      );
     });
   });
 

--- a/tests/unit/app/pricing/ClerkPricingTable.spec.tsx
+++ b/tests/unit/app/pricing/ClerkPricingTable.spec.tsx
@@ -6,7 +6,9 @@ import {
   within,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { cloneElement, isValidElement, type ReactElement } from 'react';
+import { act, cloneElement, isValidElement, type ReactElement } from 'react';
+import { hydrateRoot } from 'react-dom/client';
+import { renderToString } from 'react-dom/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
@@ -216,6 +218,65 @@ describe('ClerkPricingTable', () => {
       'annual',
     );
     expect(screen.getByText('$8')).toBeVisible();
+  });
+
+  it('hydrates monthly server markup before applying a validated annual checkout URL', async () => {
+    const { ClerkPricingTable } =
+      await import('@/app/(marketing)/pricing/components/ClerkPricingTable');
+    mocks.useAuth.mockReturnValue({ isLoaded: true, userId: null });
+    mocks.getPlans.mockResolvedValue({ data: [STARTER_PLAN] });
+
+    vi.stubGlobal('window', undefined);
+    let markup: string;
+    try {
+      markup = renderToString(
+        <ClerkPricingTable
+          appearance={{}}
+          newSubscriptionRedirectUrl='/settings#billing'
+        />,
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
+
+    window.history.replaceState(
+      {},
+      '',
+      '/pricing?checkoutPlan=plan_starter&checkoutPeriod=annual',
+    );
+    const container = document.createElement('div');
+    container.innerHTML = markup;
+    document.body.append(container);
+
+    expect(
+      within(container).getByRole('button', { name: 'Monthly' }),
+    ).toHaveAttribute('aria-pressed', 'true');
+
+    const onRecoverableError = vi.fn();
+    let root: ReturnType<typeof hydrateRoot> | undefined;
+    try {
+      await act(async () => {
+        root = hydrateRoot(
+          container,
+          <ClerkPricingTable
+            appearance={{}}
+            newSubscriptionRedirectUrl='/settings#billing'
+          />,
+          { onRecoverableError },
+        );
+      });
+
+      await waitFor(() =>
+        expect(
+          within(container).getByRole('button', { name: 'Yearly' }),
+        ).toHaveAttribute('aria-pressed', 'true'),
+      );
+      expect(within(container).getByText('$8')).toBeVisible();
+      expect(onRecoverableError).not.toHaveBeenCalled();
+    } finally {
+      await act(async () => root?.unmount());
+      container.remove();
+    }
   });
 
   it("preserves a signed-out visitor's selected plan and period through sign-in", async () => {

--- a/tests/unit/architecture/ci-pr-candidate-count.spec.ts
+++ b/tests/unit/architecture/ci-pr-candidate-count.spec.ts
@@ -22,4 +22,10 @@ describe('PR CI candidate file counting', () => {
     expect(CI_PR_WORKFLOW.split(CANDIDATE_COUNT)).toHaveLength(3);
     expect(CI_PR_WORKFLOW).not.toContain('echo "${FILES}" | wc -l');
   });
+
+  it('allows related mode to pass when no integration tests match', () => {
+    const relatedMode = CI_PR_WORKFLOW.match(/related\)([\s\S]*?)\n\s*;;/)?.[1];
+
+    expect(relatedMode).toContain('--passWithNoTests');
+  });
 });

--- a/tests/unit/architecture/db-migration-workflows.spec.ts
+++ b/tests/unit/architecture/db-migration-workflows.spec.ts
@@ -117,6 +117,9 @@ describe('Supabase migration workflows', () => {
     expect(script).toContain(
       '20260811100800_revoke_security_definer_execute.sql',
     );
+    expect(script).toContain(
+      '20260811100900_restrict_task_progress_update_columns.sql',
+    );
     expect(script).not.toContain(
       '20260811100000_clear_module_lesson_generation_errors.sql',
     );
@@ -244,6 +247,22 @@ describe('Supabase migration workflows', () => {
     expect(script).toContain(dropPolicyMigration);
   });
 
+  it('restricts authenticated task-progress updates to mutable progress fields', () => {
+    const migrationName =
+      '20260811100900_restrict_task_progress_update_columns.sql';
+    const migration = readFileSync(join(MIGRATIONS_DIR, migrationName), 'utf8');
+
+    expect(migration).toContain(
+      'REVOKE UPDATE ON TABLE "task_progress" FROM authenticated;',
+    );
+    expect(migration).toContain(
+      'GRANT UPDATE ("status", "completed_at", "updated_at") ON TABLE "task_progress" TO authenticated;',
+    );
+    expect(readFileSync(PHASED_MIGRATION_SCRIPT, 'utf8')).toContain(
+      migrationName,
+    );
+  });
+
   it('keeps published migration versions unique and maps the retained ledger identities', () => {
     const migrationFiles = readdirSync(MIGRATIONS_DIR).filter((fileName) =>
       fileName.endsWith('.sql'),
@@ -292,7 +311,7 @@ describe('Supabase migration workflows', () => {
     const targetEntries = journal.entries.filter((entry) =>
       entry.tag.startsWith('20260811100'),
     );
-    expect(targetEntries.slice(-5)).toEqual([
+    expect(targetEntries.slice(-6)).toEqual([
       {
         idx: 51,
         version: '7',
@@ -328,8 +347,15 @@ describe('Supabase migration workflows', () => {
         tag: '20260811100800_revoke_security_definer_execute',
         breakpoints: true,
       },
+      {
+        idx: 56,
+        version: '7',
+        when: 1786442940000,
+        tag: '20260811100900_restrict_task_progress_update_columns',
+        breakpoints: true,
+      },
     ]);
-    for (const entry of targetEntries.slice(-5)) {
+    for (const entry of targetEntries.slice(-6)) {
       expect(migrationFiles).toContain(`${entry.tag}.sql`);
     }
 

--- a/tests/unit/config/env.spec.ts
+++ b/tests/unit/config/env.spec.ts
@@ -733,6 +733,18 @@ describe('Environment Configuration', () => {
   });
 
   describe('regenerationQueueEnv', () => {
+    it.each([
+      ['development', true],
+      ['test', true],
+      ['production', false],
+    ] as const)('defaults queue enabled in %s to %s', (nodeEnv, expected) => {
+      vi.stubGlobal('window', undefined);
+      vi.stubEnv('NODE_ENV', nodeEnv);
+      vi.stubEnv('REGENERATION_QUEUE_ENABLED', '');
+
+      expect(regenerationQueueEnv.enabled).toBe(expected);
+    });
+
     it('keeps a minimum of 1 for positive fractional drain counts', () => {
       vi.stubEnv('REGENERATION_MAX_JOBS_PER_DRAIN', '0.5');
 

--- a/tests/unit/config/env.spec.ts
+++ b/tests/unit/config/env.spec.ts
@@ -734,16 +734,24 @@ describe('Environment Configuration', () => {
 
   describe('regenerationQueueEnv', () => {
     it.each([
-      ['development', true],
-      ['test', true],
-      ['production', false],
-    ] as const)('defaults queue enabled in %s to %s', (nodeEnv, expected) => {
-      vi.stubGlobal('window', undefined);
-      vi.stubEnv('NODE_ENV', nodeEnv);
-      vi.stubEnv('REGENERATION_QUEUE_ENABLED', '');
+      ['development', undefined, true],
+      ['test', undefined, true],
+      ['production', undefined, false],
+      ['production', 'production', false],
+      ['production', 'preview', true],
+    ] as const)(
+      'defaults queue enabled with NODE_ENV=%s and VERCEL_ENV=%s to %s',
+      (nodeEnv, vercelEnv, expected) => {
+        vi.stubGlobal('window', undefined);
+        vi.stubEnv('NODE_ENV', nodeEnv);
+        if (vercelEnv) {
+          vi.stubEnv('VERCEL_ENV', vercelEnv);
+        }
+        vi.stubEnv('REGENERATION_QUEUE_ENABLED', '');
 
-      expect(regenerationQueueEnv.enabled).toBe(expected);
-    });
+        expect(regenerationQueueEnv.enabled).toBe(expected);
+      },
+    );
 
     it('keeps a minimum of 1 for positive fractional drain counts', () => {
       vi.stubEnv('REGENERATION_MAX_JOBS_PER_DRAIN', '0.5');

--- a/tests/unit/features/lesson-content/run-module-lesson-generation-work.spec.ts
+++ b/tests/unit/features/lesson-content/run-module-lesson-generation-work.spec.ts
@@ -1,0 +1,60 @@
+import type { ModuleLessonGenerationContext } from '@/lib/db/queries/module-lesson-generation';
+import type { DbClient } from '@/lib/db/types';
+
+import { runModuleLessonGenerationWork } from '@/features/lesson-content/run-module-lesson-generation-work';
+import { createId } from '@tests/fixtures/ids';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  commitFailure: vi.fn(),
+  commitSuccess: vi.fn(),
+  revertClaim: vi.fn(),
+}));
+
+vi.mock('@/lib/config/env/lesson-content', () => ({
+  lessonContentEnv: {
+    get generationEnabled() {
+      return false;
+    },
+  },
+}));
+
+vi.mock('@/lib/db/queries/module-lesson-generation', () => ({
+  commitModuleLessonBatchSuccess: mocks.commitSuccess,
+  commitModuleLessonGenerationFailure: mocks.commitFailure,
+  revertModuleLessonGeneratingToNotGenerated: mocks.revertClaim,
+}));
+
+describe('runModuleLessonGenerationWork', () => {
+  beforeEach(() => {
+    mocks.revertClaim.mockReset();
+    mocks.revertClaim.mockResolvedValue(undefined);
+  });
+
+  it('releases an already-claimed module when generation is disabled', async () => {
+    const userId = createId('user');
+    const planId = createId('plan');
+    const moduleId = createId('module');
+    const serverDbClient = {} as DbClient;
+
+    await expect(
+      runModuleLessonGenerationWork(
+        {
+          load: {} as ModuleLessonGenerationContext,
+          userId,
+          planId,
+          moduleId,
+          userTier: 'free',
+        },
+        { serverDbClient },
+      ),
+    ).resolves.toEqual({ kind: 'disabled' });
+
+    expect(mocks.revertClaim).toHaveBeenCalledOnce();
+    expect(mocks.revertClaim).toHaveBeenCalledWith(serverDbClient, {
+      userId,
+      planId,
+      moduleId,
+    });
+  });
+});

--- a/tests/unit/features/lesson-content/run-module-lesson-generation-work.spec.ts
+++ b/tests/unit/features/lesson-content/run-module-lesson-generation-work.spec.ts
@@ -36,6 +36,7 @@ describe('runModuleLessonGenerationWork', () => {
     const planId = createId('plan');
     const moduleId = createId('module');
     const serverDbClient = {} as DbClient;
+    const workflowRunId = 'wrun_disabled';
 
     await expect(
       runModuleLessonGenerationWork(
@@ -45,6 +46,13 @@ describe('runModuleLessonGenerationWork', () => {
           planId,
           moduleId,
           userTier: 'free',
+          generationMetadata: {
+            version: 1,
+            workflow: {
+              provider: 'workflow-sdk',
+              runId: workflowRunId,
+            },
+          },
         },
         { serverDbClient },
       ),
@@ -55,6 +63,7 @@ describe('runModuleLessonGenerationWork', () => {
       userId,
       planId,
       moduleId,
+      workflowRunId,
     });
   });
 });


### PR DESCRIPTION
## Summary\n\n- fail closed for regeneration queueing in Production until a worker is explicitly enabled\n- allow related CI selection to pass when no integration tests match\n- restrict authenticated task-progress updates to mutable progress fields\n- keep pricing hydration deterministic while preserving validated annual checkout return\n- release claimed lesson generation work when generation is disabled\n\n## Verification\n\n- focused unit tests: 5 files, 158 tests passed\n- full pre-push lint and TypeScript checks passed\n- security migration coverage is included for hosted RLS CI\n\n## Release note\n\nAdds one EXPAND migration. No Production environment value or workflow switch is changed by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production-default regeneration queue behavior and tightens authenticated `task_progress` column privileges; pricing hydration behavior affects checkout UX but is covered by new tests.
> 
> **Overview**
> Closes several release-readiness gaps around **production defaults**, **CI**, **RLS**, **pricing hydration**, and **lesson generation cleanup**.
> 
> **Regeneration queue** now **fails closed in production**: when `REGENERATION_QUEUE_ENABLED` is unset, it defaults to **off** in production (still on in dev/test). `.env.production.example`, the regeneration worker runbook, and env unit tests document that operators should configure a worker trigger before explicitly enabling the flag.
> 
> **PR integration CI** adds `--passWithNoTests` for related-mode `vitest` runs so PRs with no matching integration tests do not fail the workflow.
> 
> A new **EXPAND migration** (`20260811100900_restrict_task_progress_update_columns`) revokes broad `UPDATE` on `task_progress` for `authenticated` and re-grants only **`status`**, **`completed_at`**, and **`updated_at`**. It is wired into phased migrations, the journal, architecture tests, and RLS security tests that block updates to **`taskId`** / **`userId`**.
> 
> **Pricing** (`ClerkPricingTable`) initializes billing period to **monthly** instead of reading the URL during initial state (avoiding SSR/hydration skew). Checkout URL params are still applied in an effect after plans load; a hydration test covers annual checkout return URLs.
> 
> **Module lesson generation** calls `revertModuleLessonGeneratingToNotGenerated` when generation is disabled but a module was already claimed, so modules do not stay stuck in `generating`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89307356abfbf2ec8269b6a360ceb4d07deb320c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->