### PR TITLE
fix(db): bind Production privilege attestation to table OID

### DIFF
--- a/scripts/db/attest-effective-privileges.sql
+++ b/scripts/db/attest-effective-privileges.sql
@@ -334,17 +334,21 @@ BEGIN
 
   SELECT format(
       'authenticated has INSERT column privilege on public.users.%I',
-      column_info.column_name
+      attribute.attname
     )
     INTO violation
-  FROM information_schema.columns AS column_info
-  WHERE column_info.table_schema = 'public'
-    AND column_info.table_name = 'users'
-    AND NOT has_table_privilege('authenticated', 'public.users', 'INSERT')
+  FROM pg_class AS class
+  JOIN pg_attribute AS attribute
+    ON attribute.attrelid = class.oid
+   AND attribute.attnum > 0
+   AND NOT attribute.attisdropped
+  WHERE class.relname = 'users'
+    AND class.relnamespace = 'public'::regnamespace
+    AND NOT has_table_privilege('authenticated', class.oid, 'INSERT')
     AND has_column_privilege(
       'authenticated',
-      'public.users',
-      column_info.column_name,
+      class.oid,
+      attribute.attnum,
       'INSERT'
     )
   LIMIT 1;

--- a/tests/security/effective-privileges-attestation.spec.ts
+++ b/tests/security/effective-privileges-attestation.spec.ts
@@ -71,6 +71,9 @@ describe('effective database privilege attestation', () => {
     );
     expect(ATTESTATION_SQL).toContain('authenticated has INSERT on public.%I');
     expect(ATTESTATION_SQL).toContain(
+      "has_column_privilege(\n      'authenticated',\n      class.oid,\n      attribute.attnum,\n      'INSERT'",
+    );
+    expect(ATTESTATION_SQL).toContain(
       "namespace.nspname IN ('public', 'private')",
     );
     expect(ATTESTATION_SQL).toContain(
@@ -323,7 +326,7 @@ describe('effective database privilege attestation', () => {
         ).rejects.toMatchObject({
           cause: expect.objectContaining({
             message: expect.stringMatching(
-              /authenticated has INSERT column privilege on public\.users\./,
+              /authenticated has INSERT column privilege on public\.users\.auth_user_id/,
             ),
           }),
         });


### PR DESCRIPTION
## Summary

- bind the users INSERT column privilege scan to one pg_class/pg_attribute identity
- avoid the mixed information_schema column plus text relation lookup that raised 42703 in Production
- tighten the existing security contract around the OID and attribute-number form

## Production evidence

- EXPAND run 31431703064 reported the remote schema up to date
- only the read-only effective-privilege attestation failed on public.users.instance_id
- no migration ledger repair, CONTRACT phase, environment variable, or rollout switch is changed

## Verification

- full lint passed
- TypeScript passed
- hosted Security RLS CI is required because Docker is unavailable locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only deployment gate SQL and test expectations only; no runtime grants, migrations, or client privilege behavior change.
> 
> **Overview**
> Fixes the **effective-privilege attestation** check that flags forbidden column-level `INSERT` grants on `public.users` when table-level `INSERT` is revoked.
> 
> The scan now walks **`pg_class` + `pg_attribute`** and calls `has_column_privilege` with **`class.oid` and `attribute.attnum`**, instead of mixing `information_schema.columns` with a text relation name. That alignment fixes Production **42703** failures (e.g. on `public.users.instance_id`) without changing migration phase behavior or privilege policy.
> 
> Tests assert the OID/attnum form in the attestation SQL and expect a concrete violation message for column-only `INSERT` on `auth_user_id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a19f0e2ff6403439888dc13f494aa48b3e2c528a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->