### PR TITLE
fix(db): backport privilege attestation to develop

### DIFF
--- a/scripts/db/attest-effective-privileges.sql
+++ b/scripts/db/attest-effective-privileges.sql
@@ -351,6 +351,7 @@ BEGIN
       attribute.attnum,
       'INSERT'
     )
+  ORDER BY attribute.attnum
   LIMIT 1;
   IF violation IS NOT NULL THEN
     RAISE EXCEPTION '%', violation;

--- a/scripts/db/attest-effective-privileges.sql
+++ b/scripts/db/attest-effective-privileges.sql
@@ -334,17 +334,21 @@ BEGIN
 
   SELECT format(
       'authenticated has INSERT column privilege on public.users.%I',
-      column_info.column_name
+      attribute.attname
     )
     INTO violation
-  FROM information_schema.columns AS column_info
-  WHERE column_info.table_schema = 'public'
-    AND column_info.table_name = 'users'
-    AND NOT has_table_privilege('authenticated', 'public.users', 'INSERT')
+  FROM pg_class AS class
+  JOIN pg_attribute AS attribute
+    ON attribute.attrelid = class.oid
+   AND attribute.attnum > 0
+   AND NOT attribute.attisdropped
+  WHERE class.relname = 'users'
+    AND class.relnamespace = 'public'::regnamespace
+    AND NOT has_table_privilege('authenticated', class.oid, 'INSERT')
     AND has_column_privilege(
       'authenticated',
-      'public.users',
-      column_info.column_name,
+      class.oid,
+      attribute.attnum,
       'INSERT'
     )
   LIMIT 1;

--- a/tests/security/effective-privileges-attestation.spec.ts
+++ b/tests/security/effective-privileges-attestation.spec.ts
@@ -71,6 +71,9 @@ describe('effective database privilege attestation', () => {
     );
     expect(ATTESTATION_SQL).toContain('authenticated has INSERT on public.%I');
     expect(ATTESTATION_SQL).toContain(
+      "has_column_privilege(\n      'authenticated',\n      class.oid,\n      attribute.attnum,\n      'INSERT'",
+    );
+    expect(ATTESTATION_SQL).toContain(
       "namespace.nspname IN ('public', 'private')",
     );
     expect(ATTESTATION_SQL).toContain(
@@ -323,7 +326,7 @@ describe('effective database privilege attestation', () => {
         ).rejects.toMatchObject({
           cause: expect.objectContaining({
             message: expect.stringMatching(
-              /authenticated has INSERT column privilege on public\.users\./,
+              /authenticated has INSERT column privilege on public\.users\.auth_user_id/,
             ),
           }),
         });

--- a/tests/security/effective-privileges-attestation.spec.ts
+++ b/tests/security/effective-privileges-attestation.spec.ts
@@ -73,6 +73,7 @@ describe('effective database privilege attestation', () => {
     expect(ATTESTATION_SQL).toContain(
       "has_column_privilege(\n      'authenticated',\n      class.oid,\n      attribute.attnum,\n      'INSERT'",
     );
+    expect(ATTESTATION_SQL).toContain('ORDER BY attribute.attnum\n  LIMIT 1;');
     expect(ATTESTATION_SQL).toContain(
       "namespace.nspname IN ('public', 'private')",
     );


### PR DESCRIPTION
Backports the already-merged Production privilege-attestation hotfix from #486 to `develop`.

Verification:
- `NODE_ENV=test pnpm vitest run --config vitest.config.ts --project security tests/security/effective-privileges-attestation.spec.ts` — passed (1 file, 9 tests).
- `git diff --check origin/develop...HEAD` — passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to a deployment security gate and its tests; tightens detection of column-only INSERT on `users` without altering application runtime behavior.
> 
> **Overview**
> Backports the production hotfix for **`public.users` INSERT column attestation** in `attest-effective-privileges.sql`.
> 
> The check that rejects **column-only** `INSERT` grants on `users` when table-level `INSERT` is revoked now walks **`pg_class` / `pg_attribute`** and calls **`has_column_privilege`** with **`class.oid`** and **`attribute.attnum`** instead of **`information_schema.columns`** and a **`public.users`** text target. Violation messages still name the column via **`attribute.attname`**.
> 
> Security tests now assert that SQL shape is present in the attestation script and expect the failure message to cite **`public.users.auth_user_id`** when only that column has `INSERT`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b09f806dfa41001baa010d41b9f258fc520ce07. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->