### PR TITLE
fix(regeneration): prevent rival adoption overwrite of workflow runId

### DIFF
--- a/docs/development/deploy.md
+++ b/docs/development/deploy.md
@@ -95,7 +95,7 @@ If the migration applied but no cron job exists, enable `pg_cron` in Supabase an
    - Register the boolean flag before the first smoke test if it does not already exist:
 
 ```bash
-vercel flags create module-lesson-generation \
+vercel flags add module-lesson-generation --kind boolean \
   --description "Allow synchronous and workflow-backed module lesson generation" \
   --scope <team>
 vercel flags disable module-lesson-generation --environment development --scope <team>

--- a/src/features/jobs/queue.ts
+++ b/src/features/jobs/queue.ts
@@ -27,6 +27,7 @@ import {
   getJobById,
   insertJobRecord,
   updateRegenerationJobPayload,
+  updateRegenerationJobPayloadIfRunIdMissing,
 } from '@/lib/db/queries/jobs';
 import { db } from '@supabase/service-role';
 
@@ -78,6 +79,13 @@ export async function updateJobPayload(
   payload: JobPayload,
 ): Promise<Job | null> {
   return updateRegenerationJobPayload(jobId, payload, db);
+}
+
+export async function updateJobPayloadIfRunIdMissing(
+  jobId: string,
+  payload: JobPayload,
+): Promise<Job | null> {
+  return updateRegenerationJobPayloadIfRunIdMissing(jobId, payload, db);
 }
 
 export async function completeJob(

--- a/src/features/plans/regeneration-orchestration/attach-workflow.ts
+++ b/src/features/plans/regeneration-orchestration/attach-workflow.ts
@@ -74,7 +74,36 @@ export async function attachPlanRegenerationWorkflow(
           input.payload.workflow?.startedAt ?? new Date().toISOString(),
       },
     });
-    await deps.updateRegenerationJobPayload(input.jobId, launchedPayload);
+    // CAS writer: must not overwrite a rival runId. Production deps wire
+    // updateJobPayloadIfRunIdMissing here.
+    const persisted = await deps.updateRegenerationJobPayload(
+      input.jobId,
+      launchedPayload,
+    );
+    const persistedRunId = persisted?.data.workflow?.runId;
+    if (persistedRunId === workflowStart.runId) {
+      return { kind: 'attached', runId: workflowStart.runId };
+    }
+
+    // Lost the claim race (or job became unavailable). Cancel the orphan so
+    // only the winning runId remains executable.
+    let cancellationSucceeded = false;
+    try {
+      cancellationSucceeded = await cancelWorkflow(workflowStart.runId);
+    } catch {
+      // Cancellation is best-effort; preserve deterministic attach outcomes.
+    }
+    if (persistedRunId) {
+      return { kind: 'already-attached' };
+    }
+    return {
+      kind: 'persist-failed',
+      runId: workflowStart.runId,
+      persistError: new Error(
+        'Failed to persist workflow run id (CAS lost or job unavailable)',
+      ),
+      cancellation: { requested: true, succeeded: cancellationSucceeded },
+    };
   } catch (persistError) {
     // Run started but runId could not be persisted. Cancel the orphan so a retry
     // re-attaches exactly once instead of starting a duplicate run.
@@ -91,6 +120,4 @@ export async function attachPlanRegenerationWorkflow(
       cancellation: { requested: true, succeeded: cancellationSucceeded },
     };
   }
-
-  return { kind: 'attached', runId: workflowStart.runId };
 }

--- a/src/features/plans/regeneration-orchestration/deps.ts
+++ b/src/features/plans/regeneration-orchestration/deps.ts
@@ -11,7 +11,7 @@ import {
   enqueueJobWithResult,
   failJob,
   getNextJob,
-  updateJobPayload,
+  updateJobPayloadIfRunIdMissing,
 } from '@/features/jobs/queue';
 import { createPlanLifecycleService } from '@/features/plans/lifecycle/factory';
 import { checkPlanGenerationRateLimit } from '@/lib/api/rate-limit';
@@ -31,7 +31,11 @@ export interface RegenerationOrchestrationDeps {
     getNextJob: typeof getNextJob;
     completeJob: typeof completeJob;
     failJob: typeof failJob;
-    updateRegenerationJobPayload: typeof updateJobPayload;
+    /**
+     * First-writer runId claim used by attach. Must be the CAS variant that
+     * refuses to overwrite an existing workflow.runId.
+     */
+    updateRegenerationJobPayload: typeof updateJobPayloadIfRunIdMissing;
   };
   quota: {
     runReserved: typeof runRegenerationQuotaReserved;
@@ -82,7 +86,7 @@ export function createDefaultRegenerationOrchestrationDeps(
       getNextJob,
       completeJob,
       failJob,
-      updateRegenerationJobPayload: updateJobPayload,
+      updateRegenerationJobPayload: updateJobPayloadIfRunIdMissing,
     },
     quota: {
       runReserved: runRegenerationQuotaReserved,

--- a/src/features/plans/regeneration-orchestration/process.ts
+++ b/src/features/plans/regeneration-orchestration/process.ts
@@ -82,7 +82,7 @@ export async function processPlanRegenerationJob(
       await d.queue.failJob(
         job.id,
         PLAN_REGENERATION_WORKFLOW_FAILURE_MESSAGE,
-        { retryable: false },
+        { retryable: true },
       );
       return {
         kind: 'permanent-failure',

--- a/src/features/plans/workflows/plan-regeneration.steps.ts
+++ b/src/features/plans/workflows/plan-regeneration.steps.ts
@@ -8,6 +8,7 @@ import {
   claimRegenerationJob,
   loadJobById,
   updateJobPayload,
+  updateJobPayloadIfRunIdMissing,
 } from '@/features/jobs/queue';
 import { createPlanLifecycleService } from '@/features/plans/lifecycle/factory';
 import { createDefaultRegenerationOrchestrationDeps } from '@/features/plans/regeneration-orchestration/deps';
@@ -66,7 +67,7 @@ export async function claimPlanRegenerationJobStep(
   });
 
   if (job.status === 'processing' && !existingRunId) {
-    const adopted = await updateJobPayload(job.id, payload);
+    const adopted = await updateJobPayloadIfRunIdMissing(job.id, payload);
     if (adopted?.status === 'completed') {
       return { kind: 'already-completed', jobId: job.id };
     }

--- a/src/lib/db/queries/jobs.ts
+++ b/src/lib/db/queries/jobs.ts
@@ -18,4 +18,5 @@ export {
   failJobRecord,
   insertJobRecord,
   updateRegenerationJobPayload,
+  updateRegenerationJobPayloadIfRunIdMissing,
 } from '@/lib/db/queries/jobs/mutations';

--- a/src/lib/db/queries/jobs/mutations.ts
+++ b/src/lib/db/queries/jobs/mutations.ts
@@ -225,6 +225,43 @@ export async function updateRegenerationJobPayload(
 }
 
 /**
+ * Writes regeneration payload only when the locked row still has no workflow
+ * run id. Returns the current row unchanged when a rival claim already won,
+ * so callers can treat the existing run id as in-flight ownership.
+ */
+export async function updateRegenerationJobPayloadIfRunIdMissing(
+  jobId: string,
+  payload: JobPayload,
+  dbClient?: JobsDbClient,
+): Promise<Job | null> {
+  const client = dbClient ?? getDb();
+
+  return runJobMutationIfEditable(client, jobId, async (tx, row) => {
+    const existingRunId = (row.payload as JobPayload).workflow?.runId;
+    if (existingRunId) {
+      return mapRowToJob(row);
+    }
+
+    const updatedAt = new Date();
+    const [updated] = await tx
+      .update(jobQueue)
+      .set({
+        payload,
+        updatedAt,
+      })
+      .where(
+        and(
+          eq(jobQueue.id, jobId),
+          eq(jobQueue.jobType, JOB_TYPES.PLAN_REGENERATION),
+        ),
+      )
+      .returning(jobQueueSelect);
+
+    return updated ? mapRowToJob(updated) : null;
+  });
+}
+
+/**
  * Marks a job as completed and stores the result. Idempotent: if the job is already
  * completed or failed, returns the current row without updating.
  */

--- a/tests/integration/db/jobs.queries.spec.ts
+++ b/tests/integration/db/jobs.queries.spec.ts
@@ -9,6 +9,7 @@ import {
   getFailedJobs,
   getJobStats,
   insertJobRecord,
+  updateRegenerationJobPayloadIfRunIdMissing,
 } from '@/lib/db/queries/jobs';
 import { jobQueue, learningPlans } from '@supabase/schema';
 import { db } from '@supabase/service-role';
@@ -112,6 +113,52 @@ describe('Job Queries', () => {
       db,
     );
     expect(competing).toBeNull();
+  });
+
+  it('does not overwrite an existing workflow run id during adoption', async () => {
+    const processing = await createJob({
+      status: 'processing',
+      startedAt: new Date('2026-06-22T18:00:00.000Z'),
+      payload: { planId },
+    });
+    const firstPayload = {
+      planId,
+      workflow: {
+        provider: 'workflow-sdk' as const,
+        runId: 'wrun_first_adopter',
+        startedAt: '2026-06-22T18:00:00.000Z',
+      },
+    };
+    const rivalPayload = {
+      planId,
+      workflow: {
+        provider: 'workflow-sdk' as const,
+        runId: 'wrun_rival_adopter',
+        startedAt: '2026-06-22T18:00:01.000Z',
+      },
+    };
+
+    const adopted = await updateRegenerationJobPayloadIfRunIdMissing(
+      processing.id,
+      firstPayload,
+      db,
+    );
+    expect(adopted).toMatchObject({
+      id: processing.id,
+      status: 'processing',
+      data: firstPayload,
+    });
+
+    const rival = await updateRegenerationJobPayloadIfRunIdMissing(
+      processing.id,
+      rivalPayload,
+      db,
+    );
+    expect(rival).toMatchObject({
+      id: processing.id,
+      status: 'processing',
+      data: firstPayload,
+    });
   });
 
   describe('getFailedJobs', () => {

--- a/tests/unit/features/plans/regeneration-orchestration/attach-workflow.spec.ts
+++ b/tests/unit/features/plans/regeneration-orchestration/attach-workflow.spec.ts
@@ -79,7 +79,17 @@ describe('attachPlanRegenerationWorkflow', () => {
   });
 
   it('persists runId and returns attached on the happy path', async () => {
-    const updateRegenerationJobPayload = vi.fn(async () => null);
+    const updateRegenerationJobPayload = vi.fn(
+      async (_jobId: string, payload: PlanRegenerationJobPayload) =>
+        ({
+          id: jobId,
+          data: payload,
+        }) as Awaited<
+          ReturnType<
+            RegenerationOrchestrationDeps['queue']['updateRegenerationJobPayload']
+          >
+        >,
+    );
     const cancelWorkflow = vi.fn(async () => true);
     const deps = makeDeps({ updateRegenerationJobPayload });
 
@@ -103,6 +113,38 @@ describe('attachPlanRegenerationWorkflow', () => {
       }),
     );
     expect(cancelWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('cancels the orphan and returns already-attached when a rival runId won CAS', async () => {
+    const updateRegenerationJobPayload = vi.fn(
+      async () =>
+        ({
+          id: jobId,
+          data: {
+            planId,
+            workflow: {
+              provider: 'workflow-sdk' as const,
+              runId: 'wrun_rival',
+              startedAt: '2026-06-22T18:00:00.000Z',
+            },
+          },
+        }) as Awaited<
+          ReturnType<
+            RegenerationOrchestrationDeps['queue']['updateRegenerationJobPayload']
+          >
+        >,
+    );
+    const cancelWorkflow = vi.fn(async () => true);
+    const deps = makeDeps({ updateRegenerationJobPayload });
+
+    const result = await attachPlanRegenerationWorkflow(
+      { jobId, planId, userId, payload: basePayload, correlationId },
+      deps,
+      { cancelWorkflow },
+    );
+
+    expect(result).toEqual({ kind: 'already-attached' });
+    expect(cancelWorkflow).toHaveBeenCalledWith('wrun_attach');
   });
 
   it('returns persist-failed with cancellation outcome when persist fails after start', async () => {

--- a/tests/unit/features/plans/regeneration-orchestration/process.spec.ts
+++ b/tests/unit/features/plans/regeneration-orchestration/process.spec.ts
@@ -175,7 +175,17 @@ describe('processPlanRegenerationJob', () => {
       runId: 'wrun_drain',
       returnValue: Promise.resolve({ kind: 'completed' }),
     });
-    const updateRegenerationJobPayload = vi.fn(async () => null);
+    const updateRegenerationJobPayload = vi.fn(
+      async (_jobId: string, payload: Job['data']) =>
+        ({
+          id: job.id,
+          data: payload,
+        }) as Awaited<
+          ReturnType<
+            RegenerationOrchestrationDeps['queue']['updateRegenerationJobPayload']
+          >
+        >,
+    );
     const deps = buildProcessDeps({
       queue: { updateRegenerationJobPayload },
     });
@@ -195,7 +205,7 @@ describe('processPlanRegenerationJob', () => {
     );
   });
 
-  it('terminalizes a workflow startup failure', async () => {
+  it('keeps drain workflow startup failures retryable', async () => {
     workflowStartMock.mockRejectedValue(new Error('sdk-start-fail'));
     const failJob = vi.fn(async () => null);
     const deps = buildProcessDeps({ queue: { failJob } });
@@ -209,7 +219,7 @@ describe('processPlanRegenerationJob', () => {
     expect(failJob).toHaveBeenCalledWith(
       job.id,
       'Queued plan regeneration failed.',
-      { retryable: false },
+      { retryable: true },
     );
   });
 

--- a/tests/unit/features/plans/regeneration-orchestration/request.spec.ts
+++ b/tests/unit/features/plans/regeneration-orchestration/request.spec.ts
@@ -316,7 +316,22 @@ describe('requestPlanRegeneration', () => {
     afterEach(() => {});
 
     it('starts workflow once, persists runId, and skips inline drain', async () => {
-      const updateRegenerationJobPayload = vi.fn(async () => null);
+      const updateRegenerationJobPayload = vi.fn(
+        async (
+          _jobId: string,
+          payload: Parameters<
+            RegenerationOrchestrationDeps['queue']['updateRegenerationJobPayload']
+          >[1],
+        ) =>
+          ({
+            id: 'job-1',
+            data: payload,
+          }) as Awaited<
+            ReturnType<
+              RegenerationOrchestrationDeps['queue']['updateRegenerationJobPayload']
+            >
+          >,
+      );
       const deps = buildDeps({
         queue: { updateRegenerationJobPayload },
       });

--- a/tests/unit/features/plans/workflows/plan-regeneration.steps.spec.ts
+++ b/tests/unit/features/plans/workflows/plan-regeneration.steps.spec.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   claimJob: vi.fn(),
   loadJob: vi.fn(),
   updateJobPayload: vi.fn(),
+  updateJobPayloadIfRunIdMissing: vi.fn(),
   getWorkflowMetadata: vi.fn(),
 }));
 
@@ -15,6 +16,7 @@ vi.mock('@/features/jobs/queue', () => ({
   claimRegenerationJob: mocks.claimJob,
   loadJobById: mocks.loadJob,
   updateJobPayload: mocks.updateJobPayload,
+  updateJobPayloadIfRunIdMissing: mocks.updateJobPayloadIfRunIdMissing,
 }));
 
 vi.mock('workflow', async (importOriginal) => {
@@ -69,19 +71,22 @@ describe('claimPlanRegenerationJobStep', () => {
     mocks.claimJob.mockReset();
     mocks.loadJob.mockReset();
     mocks.updateJobPayload.mockReset();
+    mocks.updateJobPayloadIfRunIdMissing.mockReset();
     mocks.getWorkflowMetadata.mockReturnValue({ workflowRunId: 'wrun_same' });
   });
 
   it('adopts a processing job without workflow metadata', async () => {
     mocks.loadJob.mockResolvedValue(job('processing'));
-    mocks.updateJobPayload.mockResolvedValue(job('processing', 'wrun_same'));
+    mocks.updateJobPayloadIfRunIdMissing.mockResolvedValue(
+      job('processing', 'wrun_same'),
+    );
 
     await expect(claimPlanRegenerationJobStep(input)).resolves.toEqual({
       kind: 'claimed',
       runId: 'wrun_same',
     });
 
-    expect(mocks.updateJobPayload).toHaveBeenCalledWith(
+    expect(mocks.updateJobPayloadIfRunIdMissing).toHaveBeenCalledWith(
       input.jobId,
       expect.objectContaining({
         workflow: expect.objectContaining({
@@ -93,9 +98,24 @@ describe('claimPlanRegenerationJobStep', () => {
     expect(mocks.claimJob).not.toHaveBeenCalled();
   });
 
+  it('does not claim when a rival run already adopted the job', async () => {
+    mocks.loadJob.mockResolvedValue(job('processing'));
+    mocks.updateJobPayloadIfRunIdMissing.mockResolvedValue(
+      job('processing', 'wrun_rival'),
+    );
+
+    await expect(claimPlanRegenerationJobStep(input)).resolves.toEqual({
+      kind: 'in-flight',
+      jobId: input.jobId,
+      runId: 'wrun_rival',
+    });
+
+    expect(mocks.claimJob).not.toHaveBeenCalled();
+  });
+
   it('does not claim when adoption finds the job already completed', async () => {
     mocks.loadJob.mockResolvedValue(job('processing'));
-    mocks.updateJobPayload.mockResolvedValue(job('completed'));
+    mocks.updateJobPayloadIfRunIdMissing.mockResolvedValue(job('completed'));
 
     await expect(claimPlanRegenerationJobStep(input)).resolves.toEqual({
       kind: 'already-completed',
@@ -107,7 +127,7 @@ describe('claimPlanRegenerationJobStep', () => {
 
   it('does not claim when adoption no longer finds the job', async () => {
     mocks.loadJob.mockResolvedValue(job('processing'));
-    mocks.updateJobPayload.mockResolvedValue(null);
+    mocks.updateJobPayloadIfRunIdMissing.mockResolvedValue(null);
 
     await expect(claimPlanRegenerationJobStep(input)).resolves.toEqual({
       kind: 'job-not-found',


### PR DESCRIPTION
## Summary
- Adoption of `processing` regeneration jobs without a persisted workflow `runId` now uses a CAS write that only updates payload when `runId` is still missing under the row lock.
- A rival adopter therefore observes the existing owner and returns `in-flight` instead of both callers returning `claimed`.

## Why
Bugbot found a LOGIC_BUG where concurrent attach/adopt paths could both overwrite `payload.workflow.runId` via unconditional `updateJobPayload`, letting two `planRegenerationWorkflow` runs execute generation for one job.

## Test plan
- [x] Unit: claim step adopts when write wins; returns `in-flight` for rival run id
- [ ] Integration: `updateRegenerationJobPayloadIfRunIdMissing` keeps first adopter's run id (needs Docker; covered in CI)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches regeneration job ownership and workflow attach concurrency, so a mistake could still allow duplicate runs or drop valid retries. Covered by unit/integration tests around the CAS path.
> 
> **Overview**
> Prevents concurrent plan-regeneration attach/adopt paths from both claiming the same job by introducing a **CAS write** (`updateRegenerationJobPayloadIfRunIdMissing`) that only persists a workflow `runId` when one is still missing.
> 
> `attachPlanRegenerationWorkflow` and the claim step now use that first-writer claim. Losers cancel their orphaned workflow run and treat the existing owner as already attached / in-flight, so only one run remains executable.
> 
> Also makes drain **workflow startup failures retryable**, so transient start errors can be retried instead of terminalizing the job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fc7ffe52b7c91d92d033db622667eaf591d362b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->