### PR TITLE
fix(pricing): wait for annual checkout URL hydration in signed-out test

### DIFF
--- a/tests/unit/app/pricing/ClerkPricingTable.spec.tsx
+++ b/tests/unit/app/pricing/ClerkPricingTable.spec.tsx
@@ -312,9 +312,12 @@ describe('ClerkPricingTable', () => {
 
     await renderPricingTable();
 
-    expect(await screen.findByTestId('sign-in-checkout')).toHaveAttribute(
-      'data-redirect',
-      '/pricing?checkoutPlan=plan_starter&checkoutPlanSlug=starter_plan&checkoutPeriod=annual',
+    // Plans paint with default month first; URL hydration flips to annual after.
+    await waitFor(() =>
+      expect(screen.getByTestId('sign-in-checkout')).toHaveAttribute(
+        'data-redirect',
+        '/pricing?checkoutPlan=plan_starter&checkoutPlanSlug=starter_plan&checkoutPeriod=annual',
+      ),
     );
     expect(screen.getByRole('button', { name: 'Yearly' })).toHaveAttribute(
       'aria-pressed',


### PR DESCRIPTION
The assertion raced the default monthly paint before URL period hydration applied.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timing fix with no production code changes.
> 
> **Overview**
> Fixes a flaky signed-out pricing test that asserted the annual checkout redirect before URL period hydration finished.
> 
> Wraps the `sign-in-checkout` redirect assertion in `waitFor`, matching other hydration-aware tests, so it no longer races the default monthly paint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38d77bc116e087388c2cc5e0a46ae4dc0c8ba772. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->