### PR TITLE
fix(regeneration): return retryable-failure on drain workflow start failure

### DIFF
--- a/src/features/plans/regeneration-orchestration/process.ts
+++ b/src/features/plans/regeneration-orchestration/process.ts
@@ -79,15 +79,17 @@ export async function processPlanRegenerationJob(
     }
 
     if (attachResult.kind === 'start-failed') {
-      await d.queue.failJob(
+      // Match enqueue-time start-failed: keep the job pending for retry.
+      const failedJob = await d.queue.failJob(
         job.id,
         PLAN_REGENERATION_WORKFLOW_FAILURE_MESSAGE,
         { retryable: true },
       );
       return {
-        kind: 'permanent-failure',
+        kind: 'retryable-failure',
         jobId: job.id,
         planId: payload.planId,
+        willRetry: failedJob?.status === 'pending',
       };
     }
 

--- a/tests/unit/features/plans/regeneration-orchestration/process.spec.ts
+++ b/tests/unit/features/plans/regeneration-orchestration/process.spec.ts
@@ -207,14 +207,20 @@ describe('processPlanRegenerationJob', () => {
 
   it('keeps drain workflow startup failures retryable', async () => {
     workflowStartMock.mockRejectedValue(new Error('sdk-start-fail'));
-    const failJob = vi.fn(async () => null);
+    const failedQueueRow = makeJob({
+      status: 'pending',
+      attempts: 1,
+      maxAttempts: 3,
+    });
+    const failJob = vi.fn(async () => failedQueueRow);
     const deps = buildProcessDeps({ queue: { failJob } });
     const job = makeJob();
 
     await expect(processPlanRegenerationJob(job, deps)).resolves.toEqual({
-      kind: 'permanent-failure',
+      kind: 'retryable-failure',
       jobId: job.id,
       planId: planRow.id,
+      willRetry: true,
     });
     expect(failJob).toHaveBeenCalledWith(
       job.id,


### PR DESCRIPTION
## Summary
- Align drain-path `start-failed` with enqueue: keep `failJob({ retryable: true })` and return `retryable-failure` (with `willRetry`) instead of `permanent-failure`.
- Unblocks CodeRabbit CHANGES_REQUESTED on #494.

## Test plan
- [x] `pnpm vitest run --project unit tests/unit/features/plans/regeneration-orchestration/process.spec.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small result-kind alignment in plan regeneration job processing; queue retryability was already set correctly.
> 
> **Overview**
> Aligns drain-path workflow **start failures** with enqueue-time behavior: when attach returns `start-failed`, processing now returns **`retryable-failure`** (with `willRetry`) instead of incorrectly reporting `permanent-failure`.
> 
> The queue call was already `failJob(..., { retryable: true })`; this only corrects the result kind so callers see the job as retryable when it stays `pending`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1f96c3b7dbab907adbbcf5872e8b7ecf5e67ebd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->