### PR TITLE
fix(ops): harden PR 494 local workflows and drain alerts

### DIFF
--- a/.github/workflows/regeneration-worker-scheduler.yml
+++ b/.github/workflows/regeneration-worker-scheduler.yml
@@ -77,3 +77,9 @@ jobs:
           esac
 
           jq -c '{ok, processedCount, completedCount, failedCount}' "${response_file}"
+
+          failed_count="$(jq -r '.failedCount // 0' "${response_file}")"
+          if [[ "${failed_count}" -gt 0 ]]; then
+            echo "::error title=Regeneration drain reported failures::failedCount=${failed_count} (runbook: alert on failedCount > 0)."
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ Quickstart:
 
 ```bash
 pnpm install
-pnpm dev              # Turbopack app only
-pnpm dev:full        # local DB + app
-pnpm check:full      # lint + type-check (runs check:lint + check:type)
-pnpm test            # lightweight changed unit + integration-class bundle
+pnpm dev              # Webpack + Workflow SDK (plan/lesson/regen capable)
+pnpm dev:turbopack    # Turbopack UI-only (no local workflow callbacks)
+pnpm dev:full         # local DB + pnpm dev
+pnpm check:full       # lint + type-check (runs check:lint + check:type)
+pnpm test             # lightweight changed unit + integration-class bundle
 ```
 
 Full script reference — flags, scoped test runners, database helpers: [`docs/development/commands.md`](docs/development/commands.md).

--- a/docs/architecture/regeneration-worker-runbook.md
+++ b/docs/architecture/regeneration-worker-runbook.md
@@ -77,7 +77,9 @@ The endpoint now uses the canonical API error contract (see `docs/api/error-cont
 ## Operational Checks
 
 - Monitor job backlog in `job_queue` for growing `pending` rows.
-- Alert on repeated `failedCount > 0` drains.
+- Alert on repeated `failedCount > 0` drains. The GitHub Action
+  `regeneration-worker-scheduler.yml` fails the run when `failedCount > 0`
+  after a successful `ok: true` drain response.
 - Alert on `401` responses from the internal drain endpoint (token mismatch/absence).
 - Alert on `503` responses (`REGENERATION_QUEUE_ENABLED=false` or missing worker token in production).
 

--- a/docs/architecture/workflow-sdk.md
+++ b/docs/architecture/workflow-sdk.md
@@ -16,7 +16,7 @@ Workflow queue callbacks hit `/.well-known/workflow/v1/*` from the Workflow SDK 
 | Deployment | Protection |
 | ---------- | ---------- |
 | **Vercel (production/preview)** | Workflow SDK registers handlers with `experimentalTriggers` so only [Vercel Queue](https://vercel.com/docs/queues) can invoke them. Proxy allows these routes through without an app token. |
-| **Local dev** | Local product work may start workflows, but does not expose workflow callback routes. |
+| **Local dev (`pnpm dev` / `dev:full` / `dev:local:*`)** | Webpack + `withWorkflow()` so create/retry and related paths can run. Prefer Preview (`pnpm deploy:preview`) when you need Vercel Queue callback semantics. Use `pnpm dev:turbopack` only for UI-only work (no workflow runtime). |
 | **Self-hosted / non-Vercel production** | Proxy requires `WORKFLOW_CALLBACK_TOKEN` via `Authorization: Bearer` or `x-workflow-callback-token`. Missing token configuration returns `503`. |
 
 Webhook resume routes (`/.well-known/workflow/v1/webhook/:token`) keep the SDK's URL-token auth and bypass the callback token gate.

--- a/docs/development/commands.md
+++ b/docs/development/commands.md
@@ -14,8 +14,10 @@ See [deploy.md](./deploy.md) for rollout notes that need ordered app-vs-migratio
 > **Note**: Do not auto-run these commands; listed for reference only.
 
 ```bash
-pnpm dev              # Next.js dev server (Turbopack enabled)
-pnpm dev:full         # Start Supabase local stack, then run the Next.js dev server
+pnpm dev              # Next.js + Workflow SDK (webpack; required for plan/lesson/regen locally)
+pnpm dev:turbopack    # Turbopack UI-only (does not run Workflow SDK callbacks)
+pnpm dev:workflow     # Alias of pnpm dev (webpack + Workflow SDK)
+pnpm dev:full         # Start Supabase local stack, then run pnpm dev
 pnpm deploy:preview   # Deploy the current worktree to Vercel's Preview environment
 ```
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "build": "next build --turbopack",
-    "dev": "next dev --turbopack",
+    "dev": "next dev --webpack",
+    "dev:turbopack": "next dev --turbopack",
     "dev:workflow": "next dev --webpack",
     "deploy:preview": "vercel deploy --yes",
     "dev:full": "pnpm db:dev:start && pnpm dev",

--- a/src/lib/db/queries/module-lesson-generation.ts
+++ b/src/lib/db/queries/module-lesson-generation.ts
@@ -194,7 +194,8 @@ function assertParsedTasksMatchCurrentTaskRows(
 
 /**
  * After `generating` claim, returns row to `not_generated` when work never ran
- * (e.g. monthly quota denial). Clears in-flight timestamps and error fields.
+ * (e.g. flag/quota kill switch). Clears in-flight timestamps and error fields.
+ * Keeps lessonGenerationMetadata so status polls can match workflowRunId and stop.
  */
 export async function revertModuleLessonGeneratingToNotGenerated(
   dbClient: GenerationDb,
@@ -217,7 +218,7 @@ export async function revertModuleLessonGeneratingToNotGenerated(
       lessonGenerationCompletedAt: null,
       lessonGenerationFailedAt: null,
       lessonGenerationError: null,
-      lessonGenerationMetadata: null,
+      // Keep lessonGenerationMetadata (workflow.runId) so status polls can terminate.
     })
     .where(
       and(

--- a/tests/integration/db/module-lesson-workflow-metadata.spec.ts
+++ b/tests/integration/db/module-lesson-workflow-metadata.spec.ts
@@ -125,6 +125,18 @@ describe('module lesson workflow metadata (integration)', () => {
       workflowRunId: runA,
     });
 
+    const [reverted] = await db
+      .select({
+        status: modules.lessonGenerationStatus,
+        metadata: modules.lessonGenerationMetadata,
+      })
+      .from(modules)
+      .where(eq(modules.id, mod.id));
+    expect(reverted).toMatchObject({
+      status: 'not_generated',
+      metadata: { workflow: { runId: runA } },
+    });
+
     const claimB = await claimModuleLessonGenerationOrDescribe(
       db,
       plan.id,


### PR DESCRIPTION
Retain lesson-generation workflow metadata on kill-switch revert so status polls can terminate, default local pnpm dev to webpack/Workflow SDK (dev:turbopack for UI-only), and fail regeneration-worker-scheduler when failedCount > 0.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches lesson-generation claim/revert metadata semantics (client poll termination) and production regeneration scheduler failure signaling. Dev script default change is low risk but affects local workflow behavior.
> 
> **Overview**
> Hardens three follow-ups from the workflow/regeneration rollout.
> 
> **Lesson generation:** `revertModuleLessonGeneratingToNotGenerated` no longer clears `lessonGenerationMetadata`, so kill-switch/quota reverts still leave the `workflow.runId` for status polls to terminate. Integration coverage asserts metadata retention.
> 
> **Local dev:** `pnpm dev` (and `dev:full` / `dev:local:*`) now runs **webpack + Workflow SDK**; Turbopack moves to `pnpm dev:turbopack` for UI-only work. Docs updated accordingly.
> 
> **Ops:** `regeneration-worker-scheduler.yml` fails the run when a successful drain reports `failedCount > 0`, matching the runbook alert guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f234398e9848fddc75261d2cca4f361032aebc3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->