### PR TITLE
fix(proxy): allow authenticated regeneration drains during maintenance

### DIFF
--- a/docs/architecture/internal-worker-routes.md
+++ b/docs/architecture/internal-worker-routes.md
@@ -47,7 +47,7 @@ The Vercel Cron email route accepts only `Authorization: Bearer $CRON_SECRET`; i
 
 ## Middleware
 
-`isProtectedRoute()` in `src/lib/proxy/middleware-policy.ts` skips Clerk for all `/api/internal/` paths and for the exact email Vercel Cron path. Token validation happens inside each route handler. The cron path is also exempt from maintenance redirects so Vercel can invoke it; its handler still checks `CRON_SECRET` before evaluating flags or reserving a run.
+`isProtectedRoute()` in `src/lib/proxy/middleware-policy.ts` skips Clerk for all `/api/internal/` paths and for the exact email Vercel Cron path. Token validation happens inside each route handler. The cron path is also exempt from maintenance redirects so Vercel can invoke it; its handler still checks `CRON_SECRET` before evaluating flags or reserving a run. The exact regeneration drain path is allowed through the maintenance redirect layer so the Production scheduler can invoke it, while route-level `REGENERATION_WORKER_TOKEN` authentication, queue enablement, and bounded drain controls still apply. Other internal maintenance routes remain covered by maintenance redirects unless separately and explicitly documented.
 
 ## Email delivery recovery
 

--- a/src/lib/proxy/middleware-policy.ts
+++ b/src/lib/proxy/middleware-policy.ts
@@ -18,6 +18,7 @@ const MAINTENANCE_MODE_BYPASS_PREFIXES = [
 const MAINTENANCE_MODE_BYPASS_PATHS = [
   '/api/health/worker',
   '/api/cron/notifications/email',
+  '/api/internal/jobs/regeneration/process',
   '/api/v1/notifications/email/unsubscribe',
 ] as const;
 

--- a/tests/unit/lib/proxy-middleware-policy.spec.ts
+++ b/tests/unit/lib/proxy-middleware-policy.spec.ts
@@ -69,6 +69,27 @@ describe('middleware policy', () => {
     expect(resolveMaintenanceRedirectPath(false, '/')).toBe(null);
   });
 
+  it('allows the exact regeneration drain through maintenance redirects', () => {
+    expect(
+      resolveMaintenanceRedirectPath(
+        true,
+        '/api/internal/jobs/regeneration/process',
+      ),
+    ).toBe(null);
+  });
+
+  it.each([
+    '/api/internal/maintenance/retention/cleanup',
+    '/api/internal/maintenance/plans/cleanup',
+    '/api/internal/maintenance/billing/reconcile-clerk',
+    '/api/internal/maintenance/notifications/email',
+    '/api/internal/jobs/regeneration/process/',
+    '/api/internal/jobs/regeneration/process/extra',
+    '/api/internal/jobs/regeneration/process-other',
+  ])('redirects maintenance-mode non-bypass path %s', (pathname) => {
+    expect(resolveMaintenanceRedirectPath(true, pathname)).toBe('/maintenance');
+  });
+
   it('shouldBypassClerkMiddleware', () => {
     expect(
       shouldBypassClerkMiddleware({


### PR DESCRIPTION
## Summary
- Root cause: the proxy's maintenance redirect returned HTTP 307 before the regeneration route could perform worker authentication.
- Scope: allow only the exact pathname `/api/internal/jobs/regeneration/process` through the maintenance redirect layer.
- The route's existing authentication and bounded-drain controls remain unchanged.

## Security invariants retained
- `REGENERATION_WORKER_TOKEN` authentication, `REGENERATION_QUEUE_ENABLED`, IP rate limiting, and `REGENERATION_MAX_JOBS_PER_DRAIN` remain enforced at the route boundary.
- The scheduler still does not follow redirects and logs counters only.
- Other internal maintenance routes and regeneration near-miss paths remain covered by maintenance redirects.

## Local verification
- Expected pre-fix TDD failure: `SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit tests/unit/lib/proxy-middleware-policy.spec.ts` — exact path returned `/maintenance`; 19 other assertions passed.
- `SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit tests/unit/lib/proxy-middleware-policy.spec.ts tests/unit/api/internal-worker-access.spec.ts tests/unit/api/regeneration-worker-process-route.spec.ts` — passed, 3 files / 28 tests.
- `pnpm check:full` — passed.
- `pnpm build` — passed.
- Focused security review found no medium, high, or critical findings.

## Production verification plan
1. Merge normally to `main`, then confirm the Ready Production alias deployment is built from the merge SHA.
2. Dispatch one bounded scheduler run on `main`; require direct HTTP 200, `ok: true`, and `failedCount: 0` with no redirect.
3. Enable the recurring GitHub scheduler gate only after that manual proof, then verify the first normal scheduled run.

## Rollback plan
- Disable the exact GitHub repository scheduler gate to stop future scheduled drains.
- Open a normal revert PR against `main`, deploy through the standard Production path, then forward-port the revert to `develop`.
- If the application queue gate is involved, set only exact Production `REGENERATION_QUEUE_ENABLED=false`, deploy a fresh artifact, and keep the GitHub gate disabled while diagnosing.

## JCS-45
- [JCS-45: Roll out and retire Workflow SDK environment switches](https://linear.app/jcs-personal-projects/issue/JCS-45/roll-out-and-retire-workflow-sdk-environment-switches)

## Scope boundaries
- No database or secret changes.
- No `MAINTENANCE_MODE` access or modification.
- No browser/product smoke was run by explicit user direction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single exact-path maintenance bypass with unchanged worker-token and drain controls at the route; no broadening of unauthenticated access.
> 
> **Overview**
> Fixes regeneration scheduler calls failing during **maintenance mode** because the proxy returned a **307** to `/maintenance` before `POST /api/internal/jobs/regeneration/process` could run.
> 
> The exact path `/api/internal/jobs/regeneration/process` is added to `MAINTENANCE_MODE_BYPASS_PATHS` in `middleware-policy.ts`, matching the existing email cron bypass pattern. **Route-level** `REGENERATION_WORKER_TOKEN` checks, queue gating, and drain limits are unchanged; other internal maintenance URLs and near-miss paths (trailing slash, extra segments) still redirect.
> 
> Docs in `internal-worker-routes.md` describe the behavior; unit tests cover the bypass and non-bypass cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9df47816ac7b50e72269c5a11fd108698c1d9366. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->