### PR TITLE
fix(proxy): allow authenticated regeneration drains during maintenance

### DIFF
--- a/docs/architecture/internal-worker-routes.md
+++ b/docs/architecture/internal-worker-routes.md
@@ -47,7 +47,7 @@ The Vercel Cron email route accepts only `Authorization: Bearer $CRON_SECRET`; i
 
 ## Middleware
 
-`isProtectedRoute()` in `src/lib/proxy/middleware-policy.ts` skips Clerk for all `/api/internal/` paths and for the exact email Vercel Cron path. Token validation happens inside each route handler. The cron path is also exempt from maintenance redirects so Vercel can invoke it; its handler still checks `CRON_SECRET` before evaluating flags or reserving a run.
+`isProtectedRoute()` in `src/lib/proxy/middleware-policy.ts` skips Clerk for all `/api/internal/` paths and for the exact email Vercel Cron path. Token validation happens inside each route handler. The cron path is also exempt from maintenance redirects so Vercel can invoke it; its handler still checks `CRON_SECRET` before evaluating flags or reserving a run. The exact regeneration drain path is allowed through the maintenance redirect layer so the Production scheduler can invoke it, while route-level `REGENERATION_WORKER_TOKEN` authentication, queue enablement, and bounded drain controls still apply. Other internal maintenance routes remain covered by maintenance redirects unless separately and explicitly documented.
 
 ## Email delivery recovery
 

--- a/src/lib/proxy/middleware-policy.ts
+++ b/src/lib/proxy/middleware-policy.ts
@@ -18,6 +18,7 @@ const MAINTENANCE_MODE_BYPASS_PREFIXES = [
 const MAINTENANCE_MODE_BYPASS_PATHS = [
   '/api/health/worker',
   '/api/cron/notifications/email',
+  '/api/internal/jobs/regeneration/process',
   '/api/v1/notifications/email/unsubscribe',
 ] as const;
 

--- a/tests/unit/lib/proxy-middleware-policy.spec.ts
+++ b/tests/unit/lib/proxy-middleware-policy.spec.ts
@@ -69,6 +69,27 @@ describe('middleware policy', () => {
     expect(resolveMaintenanceRedirectPath(false, '/')).toBe(null);
   });
 
+  it('allows the exact regeneration drain through maintenance redirects', () => {
+    expect(
+      resolveMaintenanceRedirectPath(
+        true,
+        '/api/internal/jobs/regeneration/process',
+      ),
+    ).toBe(null);
+  });
+
+  it.each([
+    '/api/internal/maintenance/retention/cleanup',
+    '/api/internal/maintenance/plans/cleanup',
+    '/api/internal/maintenance/billing/reconcile-clerk',
+    '/api/internal/maintenance/notifications/email',
+    '/api/internal/jobs/regeneration/process/',
+    '/api/internal/jobs/regeneration/process/extra',
+    '/api/internal/jobs/regeneration/process-other',
+  ])('redirects maintenance-mode non-bypass path %s', (pathname) => {
+    expect(resolveMaintenanceRedirectPath(true, pathname)).toBe('/maintenance');
+  });
+
   it('shouldBypassClerkMiddleware', () => {
     expect(
       shouldBypassClerkMiddleware({


### PR DESCRIPTION
## Summary
- Forward-port #507's exact-path maintenance exemption to `develop`.
- Preserves route-level worker-token authentication, queue gate, rate limiting, and bounded drain behavior.

## Verification
- `SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit tests/unit/lib/proxy-middleware-policy.spec.ts tests/unit/api/internal-worker-access.spec.ts tests/unit/api/regeneration-worker-process-route.spec.ts` (28 passed)

This prevents the next `develop` → `main` release from regressing the Production route policy fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global maintenance routing for a production worker path; scope is narrow (exact match) and auth remains on the route handler.
> 
> **Overview**
> **Maintenance mode** no longer blocks the Production scheduler from hitting `POST /api/internal/jobs/regeneration/process`. The proxy now treats that **exact** path like the email cron and worker health probes: no redirect to `/maintenance`, while every other internal maintenance route still redirects unless separately exempted.
> 
> `resolveMaintenanceRedirectPath` gains the regeneration drain URL in `MAINTENANCE_MODE_BYPASS_PATHS`. Trailing slashes, subpaths, and similarly named paths stay redirected. Docs in `internal-worker-routes.md` spell out that only route-level `REGENERATION_WORKER_TOKEN` auth, queue gates, and drain limits protect the endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 074e02667ff0408c3fa3b9cc07b1d4b24743a5c9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->