### PR TITLE
feat(marketing): After Hours cinematic atlas hero

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.2",
     "flags": "^4.2.4",
+    "framer-motion": "12.43.0",
     "lru-cache": "^11.5.2",
     "lucide-react": "^0.577.0",
     "next": "16.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       flags:
         specifier: ^4.2.4
         version: 4.2.4(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      framer-motion:
+        specifier: 12.43.0
+        version: 12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       lru-cache:
         specifier: ^11.5.2
         version: 11.5.2
@@ -142,7 +145,7 @@ importers:
         version: 3.6.0
       workflow:
         specifier: ^4.8.0
-        version: 4.8.0(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.2)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@6.0.3)
+        version: 4.8.0(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.2)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@6.0.3)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -4287,6 +4290,20 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
+  framer-motion@12.43.0:
+    resolution: {integrity: sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
@@ -5037,6 +5054,12 @@ packages:
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
+  motion-dom@12.43.0:
+    resolution: {integrity: sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==}
+
+  motion-utils@12.39.0:
+    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -8976,7 +8999,7 @@ snapshots:
       - '@swc/helpers'
       - supports-color
 
-  '@workflow/cli@4.3.4(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)':
+  '@workflow/cli@4.3.4(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)':
     dependencies:
       '@oclif/core': 4.11.4
       '@oclif/plugin-help': 6.2.37
@@ -8987,7 +9010,7 @@ snapshots:
       '@workflow/errors': 4.2.1
       '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.21))
       '@workflow/utils': 4.1.4
-      '@workflow/web': 4.1.16
+      '@workflow/web': 4.1.16(supports-color@8.1.1)
       '@workflow/world': 4.3.1
       '@workflow/world-local': 4.2.4(@opentelemetry/api@1.9.1)
       '@workflow/world-vercel': 4.6.1(@opentelemetry/api@1.9.1)
@@ -9081,7 +9104,7 @@ snapshots:
       '@workflow/rollup': 4.0.15(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
       '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.21))
       '@workflow/vite': 4.0.15(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
-      '@workflow/web': 4.1.16
+      '@workflow/web': 4.1.16(supports-color@8.1.1)
       exsolve: 1.0.8
       pathe: 2.0.3
     transitivePeerDependencies:
@@ -9162,9 +9185,9 @@ snapshots:
       - '@swc/helpers'
       - supports-color
 
-  '@workflow/web@4.1.16':
+  '@workflow/web@4.1.16(supports-color@8.1.1)':
     dependencies:
-      express: 5.2.1
+      express: 5.2.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -9498,7 +9521,7 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  body-parser@2.3.0:
+  body-parser@2.3.0(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       content-type: 2.0.0
@@ -10156,10 +10179,10 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express@5.2.1:
+  express@5.2.1(supports-color@8.1.1):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.3.0
+      body-parser: 2.3.0(supports-color@8.1.1)
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -10169,7 +10192,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@8.1.1)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -10180,8 +10203,8 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.2
       range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.1
+      router: 2.2.0(supports-color@8.1.1)
+      send: 1.2.1(supports-color@8.1.1)
       serve-static: 2.2.1
       statuses: 2.0.2
       type-is: 2.1.0
@@ -10247,7 +10270,7 @@ snapshots:
     dependencies:
       filename-reserved-regex: 4.0.0
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
@@ -10294,6 +10317,15 @@ snapshots:
   format@0.2.2: {}
 
   forwarded@0.2.0: {}
+
+  framer-motion@12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      motion-dom: 12.43.0
+      motion-utils: 12.39.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   fresh@2.0.0: {}
 
@@ -11159,6 +11191,12 @@ snapshots:
 
   module-details-from-path@1.0.4: {}
 
+  motion-dom@12.43.0:
+    dependencies:
+      motion-utils: 12.39.0
+
+  motion-utils@12.39.0: {}
+
   ms@2.1.3: {}
 
   nan@2.26.2:
@@ -11799,7 +11837,7 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
-  router@2.2.0:
+  router@2.2.0(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
@@ -11858,7 +11896,7 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@1.2.1:
+  send@1.2.1(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
@@ -11879,7 +11917,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -12631,10 +12669,10 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
-  workflow@4.8.0(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.2)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@6.0.3):
+  workflow@4.8.0(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.2)(next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@6.0.3):
     dependencies:
       '@workflow/astro': 4.0.15(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
-      '@workflow/cli': 4.3.4(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
+      '@workflow/cli': 4.3.4(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)
       '@workflow/core': 4.8.0(@opentelemetry/api@1.9.1)
       '@workflow/errors': 4.2.1
       '@workflow/nest': 4.0.16(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)

--- a/src/app/(marketing)/landing/cinematic/page.tsx
+++ b/src/app/(marketing)/landing/cinematic/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next';
+
+import { CinematicAtlasHero } from '@/app/(marketing)/landing/components/CinematicAtlasHero';
+
+export const metadata: Metadata = {
+  title: 'Atlaris — A map for the quiet hours',
+  description:
+    'Name a goal and the hours you actually have. Atlaris charts a week-by-week plan for the quiet hours.',
+};
+
+export default function CinematicLandingPage() {
+  return <CinematicAtlasHero />;
+}

--- a/src/app/(marketing)/landing/components/CinematicAtlasHero.tsx
+++ b/src/app/(marketing)/landing/components/CinematicAtlasHero.tsx
@@ -1,0 +1,490 @@
+'use client';
+
+import { StarField } from '@/app/(marketing)/_shared/StarField';
+import BrandLogo from '@/components/shared/BrandLogo';
+import { ROUTES } from '@/features/navigation';
+import { cn } from '@/lib/utils';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+import {
+  ArrowRight,
+  CalendarDays,
+  Check,
+  Compass,
+  Map,
+  Menu,
+  X,
+} from 'lucide-react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useId, useState, type FormEvent, type ReactNode } from 'react';
+
+import styles from './cinematic-atlas-hero.module.css';
+
+const EASE_ENTRANCE = [0.16, 1, 0.3, 1] as const;
+const EASE_WAVE = [0.25, 1, 0.5, 1] as const;
+
+const NAV_ITEMS = [
+  { label: 'Home', href: ROUTES.LANDING },
+  { label: 'Route', href: ROUTES.LANDING + '#landing-route-heading' },
+  {
+    label: 'Instruments',
+    href: ROUTES.LANDING + '#landing-instruments-heading',
+  },
+  { label: 'Questions', href: ROUTES.LANDING + '#landing-questions-heading' },
+  { label: 'Pricing', href: ROUTES.PRICING },
+] as const;
+
+const HEADING_WORDS = [
+  { text: 'A', emphasis: false, breakAfter: false },
+  { text: 'map', emphasis: false, breakAfter: false },
+  { text: 'for', emphasis: false, breakAfter: true },
+  { text: 'the', emphasis: false, breakAfter: false },
+  { text: 'quiet', emphasis: true, breakAfter: false },
+  { text: 'hours', emphasis: false, breakAfter: false },
+] as const;
+
+const FEATURES = [
+  { label: 'Chart a route', icon: Map },
+  { label: 'Keep the week', icon: CalendarDays },
+  { label: 'Read your bearings', icon: Compass },
+] as const;
+
+const heroContainer = {
+  hidden: {},
+  show: {
+    transition: { staggerChildren: 0.12, delayChildren: 0.1 },
+  },
+};
+
+const heroItem = {
+  hidden: { y: 40, opacity: 0 },
+  show: {
+    y: 0,
+    opacity: 1,
+    transition: { duration: 1.2, ease: EASE_ENTRANCE },
+  },
+};
+
+type CaptureState =
+  | { kind: 'editing'; submitting: boolean }
+  | { kind: 'success' };
+
+type CinematicAtlasHeroProps = {
+  /** Simulated pause before the success swap. */
+  submitDelayMs?: number;
+};
+
+export function CinematicAtlasHero({
+  submitDelayMs = 1000,
+}: CinematicAtlasHeroProps) {
+  const pathname = usePathname();
+  const reduceMotion = useReducedMotion() === true;
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  return (
+    <section
+      id='cinematic-atlas-hero'
+      aria-labelledby='cinematic-atlas-heading'
+      className='relative flex h-full min-h-screen w-full flex-col justify-between overflow-hidden bg-background px-6 pt-5 pb-8 text-foreground min-[1440px]:px-16 md:px-12'
+    >
+      <CinematicSkyLayer />
+
+      <motion.nav
+        aria-label='Cinematic atlas'
+        className='relative z-20 flex w-full items-center justify-between gap-4 md:gap-12'
+        initial={reduceMotion ? false : { y: -30, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        transition={{ duration: 1.1, ease: EASE_ENTRANCE }}
+      >
+        <BrandLogo size='sm' onClick={() => setMenuOpen(false)} />
+
+        <div className='hidden items-center gap-7 rounded-full border border-border/60 bg-card/40 px-4 py-1 backdrop-blur-md lg:flex'>
+          {NAV_ITEMS.map((item) => (
+            <NavLink
+              key={item.label}
+              href={item.href}
+              label={item.label}
+              active={isNavActive(pathname, item.href)}
+            />
+          ))}
+        </div>
+
+        <div className='hidden w-[225px] items-center justify-end gap-4 lg:flex'>
+          <Link
+            href='/auth/sign-in'
+            className='font-sans text-[18px] tracking-[-0.2px] text-foreground/80 hover:text-foreground'
+          >
+            <WaveLabel text='Sign in' />
+          </Link>
+          <Link
+            href={ROUTES.PLANS.NEW}
+            className='rounded-lg border border-border/70 bg-primary px-4 py-[9px] font-sans text-[18px] tracking-[-0.2px] text-primary-foreground shadow-md shadow-primary/20'
+          >
+            <WaveLabel text='Begin tonight' />
+          </Link>
+        </div>
+
+        <button
+          type='button'
+          className='flex rounded-lg border border-border/70 bg-card/40 p-2 backdrop-blur-md md:p-2.5 lg:hidden'
+          aria-expanded={menuOpen}
+          aria-controls='cinematic-atlas-mobile-menu'
+          aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+          onClick={() => setMenuOpen((open) => !open)}
+        >
+          {menuOpen ? <X className='size-5' /> : <Menu className='size-5' />}
+        </button>
+      </motion.nav>
+
+      <AnimatePresence>
+        {menuOpen ? (
+          <motion.div
+            key='cinematic-atlas-mobile-menu'
+            id='cinematic-atlas-mobile-menu'
+            className={cn(
+              styles.capsule,
+              'absolute top-[72px] right-4 left-4 z-50 rounded-2xl bg-card/95 p-5 shadow-2xl backdrop-blur-xl md:top-[84px] md:right-6 md:left-6 md:rounded-[20px] md:p-8',
+            )}
+            initial={reduceMotion ? false : { opacity: 0, y: -20, scale: 0.98 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: -20, scale: 0.98 }}
+            transition={{ duration: 0.4, ease: EASE_ENTRANCE }}
+          >
+            <div className='flex flex-col gap-4'>
+              {NAV_ITEMS.map((item) => (
+                <NavLink
+                  key={item.label}
+                  href={item.href}
+                  label={item.label}
+                  active={isNavActive(pathname, item.href)}
+                  onNavigate={() => setMenuOpen(false)}
+                />
+              ))}
+              <Link
+                href='/auth/sign-in'
+                className='font-sans text-[18px] tracking-[-0.2px] text-foreground/80'
+                onClick={() => setMenuOpen(false)}
+              >
+                <WaveLabel text='Sign in' />
+              </Link>
+              <Link
+                href={ROUTES.PLANS.NEW}
+                className='rounded-lg border border-border/70 bg-primary px-4 py-[9px] text-center font-sans text-[18px] tracking-[-0.2px] text-primary-foreground'
+                onClick={() => setMenuOpen(false)}
+              >
+                <WaveLabel text='Begin tonight' />
+              </Link>
+            </div>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
+
+      <motion.div
+        className='relative z-10 flex flex-1 flex-col items-center pt-[8vh] pb-16 text-center md:pt-24 md:pb-28 lg:pt-24 lg:pb-32'
+        variants={heroContainer}
+        initial={reduceMotion ? false : 'hidden'}
+        animate='show'
+      >
+        <div className='flex w-full max-w-[670px] flex-col items-center'>
+          <motion.p
+            variants={heroItem}
+            className='flex items-center gap-2.5 font-sans text-[15px] tracking-[-0.72px] text-muted-foreground sm:text-[18px]'
+          >
+            <span className='flex -space-x-1.5' aria-hidden='true'>
+              <span className='size-6 rounded-full border border-primary/70 bg-primary/80' />
+              <span className='size-6 rounded-full border border-primary/70 bg-primary' />
+              <span className='size-6 rounded-full border border-primary/70 bg-primary/60' />
+            </span>
+            <span>For the hour after the day lets go</span>
+          </motion.p>
+
+          <motion.h1
+            id='cinematic-atlas-heading'
+            variants={heroItem}
+            className='mt-2.5 font-serif text-[2.75rem] leading-[1.08] font-semibold tracking-[-0.03em] text-balance sm:text-5xl md:text-[3.25rem]'
+          >
+            <span className='sr-only'>A map for the quiet hours</span>
+            <span aria-hidden='true'>
+              {HEADING_WORDS.map((word) => (
+                <span key={word.text}>
+                  <WaveLabel
+                    text={word.text}
+                    className={
+                      word.emphasis
+                        ? 'font-medium text-primary italic'
+                        : 'text-foreground'
+                    }
+                  />
+                  {word.breakAfter ? <br className='block lg:hidden' /> : null}
+                  {word.text === 'hours' ? null : ' '}
+                </span>
+              ))}
+            </span>
+          </motion.h1>
+
+          <motion.p
+            variants={heroItem}
+            className='mt-4 max-w-[630px] font-sans text-xl leading-[140%] tracking-[-0.4px] text-foreground/90'
+          >
+            Name a goal and the hours you actually have. Atlaris charts a
+            week-by-week plan — modules, tasks, and resources — so tonight is
+            already laid out.
+          </motion.p>
+
+          <motion.div
+            variants={heroItem}
+            className='mt-10 w-full max-w-[530px]'
+          >
+            <EmailCapture
+              submitDelayMs={submitDelayMs}
+              reduceMotion={reduceMotion}
+            />
+          </motion.div>
+
+          <motion.ul
+            variants={heroItem}
+            className='mt-5 flex flex-col gap-4 sm:flex-row sm:gap-12'
+          >
+            {FEATURES.map((feature) => (
+              <li
+                key={feature.label}
+                className='flex items-center justify-center gap-2 font-sans text-base tracking-[-0.2px] text-foreground'
+              >
+                <feature.icon
+                  className='size-5 text-primary'
+                  aria-hidden='true'
+                />
+                <WaveLabel text={feature.label} />
+              </li>
+            ))}
+          </motion.ul>
+        </div>
+      </motion.div>
+    </section>
+  );
+}
+
+function CinematicSkyLayer() {
+  return (
+    <div className='absolute inset-0 z-0 overflow-hidden' aria-hidden='true'>
+      <div className={styles.skyFilm}>
+        <div className='absolute -top-[20%] left-[8%] size-[78%] rounded-full bg-primary/25 blur-3xl' />
+        <div className='absolute top-[28%] -right-[12%] size-[68%] rounded-full bg-panel-muted/80 blur-3xl' />
+        <div className='absolute -bottom-[18%] left-[18%] size-[58%] rounded-full bg-card/90 blur-3xl' />
+      </div>
+      <StarField className='text-foreground' />
+      <div className={styles.grain} />
+      <div className='absolute inset-0 bg-background/15' />
+      <div className='absolute inset-0 bg-linear-to-b from-background/20 via-transparent to-background/40' />
+    </div>
+  );
+}
+
+function NavLink({
+  href,
+  label,
+  active,
+  onNavigate,
+}: {
+  href: string;
+  label: string;
+  active: boolean;
+  onNavigate?: () => void;
+}) {
+  return (
+    <Link
+      href={href}
+      aria-current={active ? 'page' : undefined}
+      onClick={onNavigate}
+      className={cn(
+        'font-sans text-[18px] tracking-[-0.2px]',
+        active
+          ? 'font-semibold text-foreground'
+          : 'font-normal text-foreground/80',
+      )}
+    >
+      <WaveLabel text={label} />
+    </Link>
+  );
+}
+
+function isNavActive(pathname: string, href: string): boolean {
+  if (href === ROUTES.PRICING) {
+    return pathname === ROUTES.PRICING;
+  }
+  if (href === ROUTES.LANDING) {
+    return (
+      pathname === ROUTES.HOME ||
+      pathname === ROUTES.LANDING ||
+      pathname.startsWith(ROUTES.LANDING + '/')
+    );
+  }
+  return false;
+}
+
+function WaveLabel({ text, className }: { text: string; className?: string }) {
+  const [isHovered, setIsHovered] = useState(false);
+  const reduceMotion = useReducedMotion() === true;
+  const characters = Array.from(text);
+
+  return (
+    <span
+      className={cn('inline-flex', className)}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <span className='sr-only'>{text}</span>
+      {characters.map((char, index) => {
+        const display = char === ' ' ? '\u00A0' : char;
+        return (
+          <motion.span
+            key={text + String(index)}
+            className={styles.waveChar}
+            aria-hidden='true'
+            initial={reduceMotion ? false : { y: 100, x: -100, opacity: 0 }}
+            whileInView={{ y: 0, x: 0, opacity: 1 }}
+            viewport={{ once: true }}
+            transition={{ duration: 1.8, ease: EASE_ENTRANCE }}
+          >
+            <motion.span
+              className='inline-block'
+              animate={
+                isHovered && !reduceMotion
+                  ? { y: '-100%', x: '100%', opacity: 0 }
+                  : { y: '0%', x: '0%', opacity: 1 }
+              }
+              transition={{
+                duration: 0.35,
+                delay: index * 0.015,
+                ease: EASE_WAVE,
+              }}
+            >
+              {display}
+            </motion.span>
+            <motion.span
+              className='absolute inset-0 inline-block'
+              initial={{ y: '100%', x: '-100%', opacity: 0 }}
+              animate={
+                isHovered && !reduceMotion
+                  ? { y: '0%', x: '0%', opacity: 1 }
+                  : { y: '100%', x: '-100%', opacity: 0 }
+              }
+              transition={{
+                duration: 0.45,
+                delay: index * 0.015,
+                ease: EASE_WAVE,
+              }}
+              aria-hidden='true'
+            >
+              {display}
+            </motion.span>
+          </motion.span>
+        );
+      })}
+    </span>
+  );
+}
+
+function EmailCapture({
+  submitDelayMs,
+  reduceMotion,
+}: {
+  submitDelayMs: number;
+  reduceMotion: boolean;
+}) {
+  const emailId = useId();
+  const [email, setEmail] = useState('');
+  const [capture, setCapture] = useState<CaptureState>({
+    kind: 'editing',
+    submitting: false,
+  });
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (capture.kind !== 'editing' || capture.submitting) {
+      return;
+    }
+    setCapture({ kind: 'editing', submitting: true });
+    await wait(submitDelayMs);
+    setCapture({ kind: 'success' });
+  }
+
+  const signUpHref =
+    '/auth/sign-up?email_address=' + encodeURIComponent(email.trim());
+
+  let captureView: ReactNode;
+  switch (capture.kind) {
+    case 'editing':
+      captureView = (
+        <motion.form
+          key='cinematic-atlas-email-form'
+          onSubmit={onSubmit}
+          className='flex items-center gap-2 rounded-xl border border-border/80 bg-card/30 p-1 pl-2 sm:pl-4'
+          initial={false}
+          exit={{ opacity: 0, y: -8 }}
+        >
+          <label htmlFor={emailId} className='sr-only'>
+            Email
+          </label>
+          <input
+            id={emailId}
+            name='email'
+            type='email'
+            required
+            autoComplete='email'
+            placeholder='Enter your email...'
+            value={email}
+            disabled={capture.submitting}
+            onChange={(event) => setEmail(event.target.value)}
+            className='min-w-0 flex-1 bg-transparent py-3 font-sans text-base text-foreground outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring/50'
+          />
+          <button
+            type='submit'
+            disabled={capture.submitting}
+            className='inline-flex shrink-0 items-center gap-1.5 rounded-[10px] border border-border/70 bg-primary px-3 py-3 font-sans text-sm font-medium text-primary-foreground sm:px-4'
+          >
+            <WaveLabel
+              text={capture.submitting ? 'Charting...' : 'Begin tonight'}
+            />
+            <ArrowRight className='size-4' aria-hidden='true' />
+          </button>
+        </motion.form>
+      );
+      break;
+    case 'success':
+      captureView = (
+        <motion.output
+          key='cinematic-atlas-email-success'
+          className='flex flex-wrap items-center justify-center gap-2 rounded-xl border border-success/30 bg-success/10 px-4 py-4 font-sans text-sm text-success'
+          initial={reduceMotion ? false : { opacity: 0, scale: 0.96 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ type: 'spring', stiffness: 300, damping: 25 }}
+        >
+          <Check className='size-4' aria-hidden='true' />
+          <span>Continue to Atlaris — we&apos;ll hold the route.</span>
+          <Link
+            href={signUpHref}
+            className='font-medium underline-offset-4 hover:underline'
+          >
+            Create your account
+          </Link>
+        </motion.output>
+      );
+      break;
+    default: {
+      const _exhaustive: never = capture;
+      throw new Error('Unhandled capture state: ' + String(_exhaustive));
+    }
+  }
+
+  return <AnimatePresence mode='wait'>{captureView}</AnimatePresence>;
+}
+
+function wait(ms: number): Promise<void> {
+  if (ms <= 0) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+}

--- a/src/app/(marketing)/landing/components/Landing.tsx
+++ b/src/app/(marketing)/landing/components/Landing.tsx
@@ -1,3 +1,4 @@
+import { CinematicAtlasHero } from './CinematicAtlasHero';
 import { DriftSection } from './DriftSection';
 import { HeroSection } from './HeroSection';
 import { InstrumentsSection } from './InstrumentsSection';
@@ -21,6 +22,8 @@ export function Landing() {
         <InstrumentsSection />
         <QuestionsSection />
         <PolarisSection />
+        <Hairline />
+        <CinematicAtlasHero />
       </div>
     </MarketingPageShell>
   );

--- a/src/app/(marketing)/landing/components/cinematic-atlas-hero.module.css
+++ b/src/app/(marketing)/landing/components/cinematic-atlas-hero.module.css
@@ -1,0 +1,54 @@
+/* Scoped to CinematicAtlasHero — no global html/body/font resets. */
+
+.capsule {
+  border: 1px solid color-mix(in oklab, var(--border) 80%, transparent);
+  outline: 1px solid color-mix(in oklab, var(--border) 40%, transparent);
+  outline-offset: 3px;
+}
+
+.skyFilm {
+  position: absolute;
+  inset: -10%;
+  animation: cinematicPan 50s cubic-bezier(0.16, 1, 0.3, 1) infinite;
+  will-change: transform;
+}
+
+.grain {
+  position: absolute;
+  inset: 0;
+  opacity: 0.1;
+  mix-blend-mode: overlay;
+  background-image: radial-gradient(
+    circle at 1px 1px,
+    color-mix(in oklab, var(--foreground) 50%, transparent) 1px,
+    transparent 0
+  );
+  background-size: 3px 3px;
+}
+
+.waveChar {
+  position: relative;
+  display: inline-block;
+  overflow: hidden;
+  vertical-align: bottom;
+}
+
+@keyframes cinematicPan {
+  0% {
+    transform: scale(1.01) translate3d(0, 0, 0);
+  }
+
+  40% {
+    transform: scale(1.045) translate3d(-1.2%, 0.8%, 0);
+  }
+
+  100% {
+    transform: scale(1.01) translate3d(0, 0, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skyFilm {
+    animation: none;
+  }
+}

--- a/src/components/shared/nav/SiteHeaderChrome.tsx
+++ b/src/components/shared/nav/SiteHeaderChrome.tsx
@@ -43,6 +43,7 @@ export default function SiteHeaderChrome({
   const isMarketing =
     pathname === ROUTES.HOME ||
     pathname === ROUTES.LANDING ||
+    pathname.startsWith(ROUTES.LANDING + '/') ||
     pathname === ROUTES.PRICING;
   const resolvedNavItems = isMarketing ? unauthenticatedNavItems : navItems;
   return (

--- a/tests/unit/app/landing/cinematic-atlas-hero.spec.tsx
+++ b/tests/unit/app/landing/cinematic-atlas-hero.spec.tsx
@@ -1,0 +1,70 @@
+import { CinematicAtlasHero } from '@/app/(marketing)/landing/components/CinematicAtlasHero';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/landing',
+}));
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'IntersectionObserver',
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+vi.mock('@/app/(marketing)/_shared/StarField', () => ({
+  StarField: () => null,
+}));
+
+describe('CinematicAtlasHero', () => {
+  it('renders the After Hours headline without waitlist claims', () => {
+    render(<CinematicAtlasHero submitDelayMs={0} />);
+
+    expect(
+      screen.getByRole('heading', { name: /a map for the quiet hours/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/for the hour after the day lets go/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/waitlist/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/7,943/)).not.toBeInTheDocument();
+  });
+
+  it('swaps the email capture to a sign-up handoff after a valid submit', async () => {
+    const user = userEvent.setup();
+    render(<CinematicAtlasHero submitDelayMs={0} />);
+
+    await user.type(screen.getByLabelText('Email'), 'ada@atlaris.app');
+    await user.click(screen.getByRole('button', { name: /begin tonight/i }));
+
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      /we'll hold the route/i,
+    );
+    expect(
+      screen.getByRole('link', { name: /create your account/i }),
+    ).toHaveAttribute(
+      'href',
+      '/auth/sign-up?email_address=' + encodeURIComponent('ada@atlaris.app'),
+    );
+  });
+
+  it('keeps the email form when the address is empty', async () => {
+    const user = userEvent.setup();
+    render(<CinematicAtlasHero submitDelayMs={0} />);
+
+    await user.click(screen.getByRole('button', { name: /begin tonight/i }));
+
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Experimental full-screen cinematic hero, adapted from an external landing-page prompt and rewritten for Atlaris.

Existing landing sections are unchanged. The new block is appended after Polaris, and `/landing/cinematic` is a full-viewport preview.

## What was substituted (on purpose)

The original prompt was a Flowmind productivity waitlist with third-party fonts, CDN video/logo/avatars, and fabricated social proof. None of that shipped.

| Prompt | Atlaris |
| --- | --- |
| Gantari / Instrument Sans / Instrument Serif | Sora + Work Sans (already in the app) |
| Black / `#13181F` / emerald waitlist chrome | After Hours semantic tokens |
| jiro CDN video, logo, icons, Unsplash faces | Token orbs + `StarField` + lucide icons + wordmark |
| “Focus in a Distracted World” / join waitlist / fake 7,943 count | Quiet-hours atlas copy; Sign in / Begin tonight |
| Contacts / Docs / waitlist | Home, Route, Instruments, Questions, Pricing |

Email capture is not a waitlist. Valid submit swaps to a success state, then “Create your account” goes to `/auth/sign-up`.

## How to try it

- Full-viewport: `/landing/cinematic`
- On the current landing, after Polaris: `/landing#cinematic-atlas-hero`

## Notes

- Installed `framer-motion@12.43.0` (13.x is newer than the 7-day release-age policy).
- `lucide-react` was already a dependency.
- Motion honors `prefers-reduced-motion`.
- Per-letter wave keeps a screen-reader label on the headline so it does not read as `Amapforthequiethours`.

## Test plan

- [ ] Open `/landing/cinematic` in light and dark; check type, tokens, and sky layer (no third-party video/logo).
- [ ] Hover nav labels and the headline for the letter wave; confirm reduced-motion skips it.
- [ ] Mobile: hamburger opens/closes the overlay.
- [ ] Submit an empty email — form stays. Submit a valid email — success + sign-up link.
- [ ] Confirm `/landing` still has Hero → Drift → Route → Instruments → Questions → Polaris, then this section.
- [ ] `pnpm vitest run --config vitest.config.ts --project unit tests/unit/app/landing/cinematic-atlas-hero.spec.tsx` (already passing).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff970-8c66-7fd8-beb9-3d95321e04ba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff970-8c66-7fd8-beb9-3d95321e04ba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

