### PR TITLE
fix(marketing): keep landing metadata in layout

### DIFF
--- a/src/app/(marketing)/landing/layout.tsx
+++ b/src/app/(marketing)/landing/layout.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from 'next';
 
 const LANDING_CANONICAL_URL = '/landing';
-export const LANDING_CANONICAL_TITLE =
+const LANDING_CANONICAL_TITLE =
   'Atlaris — Turn learning goals into a scheduled plan';
-export const LANDING_DESCRIPTION =
+const LANDING_DESCRIPTION =
   'Atlaris turns what you want to learn into a time-blocked, resource-linked study plan, with calendar sync coming soon.';
 
 export const metadata: Metadata = {

--- a/src/app/(marketing)/landing/page.tsx
+++ b/src/app/(marketing)/landing/page.tsx
@@ -1,12 +1,4 @@
-import type { Metadata } from 'next';
-
-import { LANDING_CANONICAL_TITLE, LANDING_DESCRIPTION } from './layout';
 import { Landing } from '@/app/(marketing)/landing/components/Landing';
-
-export const metadata: Metadata = {
-  title: LANDING_CANONICAL_TITLE,
-  description: LANDING_DESCRIPTION,
-};
 
 export default function LandingPage() {
   return <Landing />;


### PR DESCRIPTION
## Summary
- remove unsupported named exports from the landing App Router layout
- keep landing metadata owned by the nested layout and remove the duplicate page declaration

## Verification
- `pnpm check:type`
- pre-push: `pnpm check:lint` and `pnpm check:type`