### PR TITLE
chore(dev): ignore SWC cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ screenshots/
 
 # clerk configuration (can include secrets)
 /.clerk/
+/.swc


### PR DESCRIPTION
## Summary
- ignore the root SWC compiler cache

## Dependency
- stacked on #517, which restores the current TypeScript gate; this PR's own diff is one `.gitignore` line

## Verification
- `git check-ignore -v .swc/.probe`
- pre-push: `pnpm check:lint` and `pnpm check:type`