### PR TITLE
fix(security): close JCS-53 rate limiting and WAF coverage gaps

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@ HTTP API contracts shared across routes.
 | File | Description |
 |------|-------------|
 | [error-contract.md](./api/error-contract.md) | Canonical API error response shape |
-| [rate-limiting.md](./api/rate-limiting.md) | User-based and job-based rate limiting |
+| [rate-limiting.md](./api/rate-limiting.md) | Five-layer rate limiting: Vercel /ingest, IP, user, durable generation, product quotas |
 
 ## `architecture/`
 

--- a/docs/api/rate-limiting.md
+++ b/docs/api/rate-limiting.md
@@ -81,7 +81,7 @@ Located in `src/lib/api/ip-rate-limit.ts`. Shared sliding-window algorithm: `src
 Located in `src/lib/api/user-rate-limit.ts`. Same sliding-window core as the IP limiter.
 
 - **Storage**: In-memory LRU cache **per Node.js process**
-- **Key**: Authenticated user ID (not IP)
+- **Key**: Clerk auth user ID (`authUserId` / route `ctx.userId`), shared by routes and Server Actions. Not the internal `users.id`.
 - **Scope**: Per category, per user
 - **Opt-in**: `requestBoundary.route({ rateLimit })` or `requestBoundary.action({ rateLimit })`
 - **Multi-instance note**: Same per-process caveat as the IP limiter. Two concurrent instances can each admit a full window of requests for the same user.

--- a/docs/api/rate-limiting.md
+++ b/docs/api/rate-limiting.md
@@ -47,7 +47,7 @@ Do not add WAF rules for authenticated APIs, Svix/Clerk signature headers, worke
 | ----------- | ------------ | -------- | ----------------------------------------------------- |
 | `health`    | 60 requests  | 1 minute | Worker health                                         |
 | `webhook`   | 100 requests | 1 minute | Clerk billing webhook                                 |
-| `publicApi` | 30 requests  | 1 minute | Signed email unsubscribe                              |
+| `publicApi` | 30 requests  | 1 minute | Signed one-click unsubscribe POST                     |
 | `auth`      | 10 requests  | 1 minute | Defined; no current route uses it                     |
 | `docs`      | 30 requests  | 1 minute | API docs / OpenAPI (development and test only)        |
 | `internal`  | 60 requests  | 1 minute | Internal workers, maintenance POSTs, notification cron |
@@ -174,7 +174,7 @@ For unauthenticated or machine-authenticated routes:
 ```typescript
 import { checkIpRateLimit } from '@/lib/api/ip-rate-limit';
 
-checkIpRateLimit(request, 'publicApi'); // unsubscribe
+checkIpRateLimit(request, 'publicApi'); // unsubscribe POST
 checkIpRateLimit(request, 'internal'); // notification cron / workers
 ```
 
@@ -289,7 +289,9 @@ These categories remain available in the shared user-limiter configuration for f
 
 ### IP: Public API (`publicApi`)
 
-- `GET` / `POST /api/v1/notifications/email/unsubscribe`
+- `POST /api/v1/notifications/email/unsubscribe`
+
+`GET /api/v1/notifications/email/unsubscribe` is static confirmation-only and intentionally unmetered so scanners and prefetchers cannot starve legitimate opt-outs. Only the signed one-click POST uses `publicApi`.
 
 ### IP: Docs (`docs`)
 

--- a/docs/api/rate-limiting.md
+++ b/docs/api/rate-limiting.md
@@ -1,6 +1,32 @@
 # Rate Limiting
 
-This document describes the rate limiting system for Atlaris API endpoints. There are two layers of rate limiting: user-based (authenticated) and job-based (plan generation specific).
+Atlaris rate limiting is five layers, not a single wrapper. Edge, IP, user, durable generation, and product quotas are independent controls. A category in config does nothing until a route or Server Action opts into it.
+
+## Five-layer model
+
+| Layer | Where | Scope | Consistency |
+| ----- | ----- | ----- | ----------- |
+| Vercel edge rate limit | Dashboard-managed Firewall Rate Limit on `/ingest/*` | Unauthenticated PostHog reverse-proxy traffic | Edge-wide (Vercel) |
+| Application IP limiter | `src/lib/api/ip-rate-limit.ts` | Unauthenticated or machine routes keyed by client IP | Per process (in-memory LRU) |
+| Authenticated user limiter | `src/lib/api/user-rate-limit.ts` | Authenticated API routes and Server Actions keyed by user ID | Per process (in-memory LRU) |
+| Durable DB plan-generation limiter | `src/lib/api/rate-limit.ts` | Generation, retry, and regeneration attempts (`generation_attempts`) | Database-shared, fail-closed preflight (not atomic) |
+| Product quotas / kill switches | Billing quota boundaries and Vercel Flags | Plan count, duration, metered generation, operational disable | Shared product/ops policy |
+
+## Vercel Firewall allocation
+
+Hobby/Pro projects have **1 Rate Limit slot** and **3 custom WAF slots**. The intended JCS-53 allocation is:
+
+| Capability | Allocation |
+| ---------- | ---------- |
+| Rate Limit | **1 / 1** — keep the dashboard-managed `/ingest` rule; it is the sole Rate Limit slot |
+| Custom WAF Rules | **0 / 3** — leave all three unused |
+| Optional `/ingest` method rule | **Do not add it** |
+
+This dashboard rule is **not** represented in `vercel.json`. That file remains repository configuration for cron schedules only. Inspecting the repo cannot confirm or mutate the live Firewall dashboard.
+
+Do not add WAF rules for authenticated APIs, Svix/Clerk signature headers, worker secrets, or broad `/.well-known` paths. Those surfaces are enforced in application code (user/IP limiters, cryptographic verification, worker tokens). Custom WAF slots stay unused on purpose so they remain available as emergency virtual patches.
+
+`/ingest/*` is the PostHog reverse-proxy rewrite in `next.config.ts`. Clerk proxy matching excludes that prefix so analytics ingest is not treated as an app route.
 
 ## Quick Reference
 
@@ -11,38 +37,81 @@ This document describes the rate limiting system for Atlaris API endpoints. Ther
 | `aiGeneration`     | 10 requests  | 1 hour   | Plan generation and regeneration                 |
 | `lessonGeneration` | 5 requests   | 1 hour   | Module lesson batch generation (separate meter)  |
 | `integration`      | 30 requests  | 1 hour   | Reserved for future third-party endpoints        |
-| `mutation`         | 60 requests  | 1 minute | Plan delete/bulk-delete, profile, preferences    |
+| `mutation`         | 60 requests  | 1 minute | Plan delete/bulk-delete, profile, preferences, Server Actions |
 | `read`             | 120 requests | 1 minute | Status checks, profile reads, preferences        |
 | `oauth`            | 20 requests  | 1 hour   | Reserved for future OAuth initiation             |
+
+### IP Rate Limits (Unauthenticated / Machine Endpoints)
+
+| Category    | Limit        | Window   | Use Case                                              |
+| ----------- | ------------ | -------- | ----------------------------------------------------- |
+| `health`    | 60 requests  | 1 minute | Worker health                                         |
+| `webhook`   | 100 requests | 1 minute | Clerk billing webhook                                 |
+| `publicApi` | 30 requests  | 1 minute | Signed email unsubscribe                              |
+| `auth`      | 10 requests  | 1 minute | Defined; no current route uses it                     |
+| `docs`      | 30 requests  | 1 minute | API docs / OpenAPI (development and test only)        |
+| `internal`  | 60 requests  | 1 minute | Internal workers, maintenance POSTs, notification cron |
 
 ### Plan Generation Rate Limit
 
 | Limit                                           | Window                                              | Scope                          |
 | ----------------------------------------------- | --------------------------------------------------- | ------------------------------ |
-| `PLAN_GENERATION_LIMIT` (currently 10 attempts) | `PLAN_GENERATION_WINDOW_MINUTES` (currently 60 min) | Per user (generation_attempts) |
+| `PLAN_GENERATION_LIMIT` (currently 10 attempts) | `PLAN_GENERATION_WINDOW_MINUTES` (currently 60 min) | Per user: generation, retry, and regeneration (`generation_attempts`) |
 
 Source of truth for durable generation limits is `src/shared/constants/generation.ts` (enforced in `src/lib/api/rate-limit.ts`). Avoid hardcoding numeric values in docs/tests.
 
 ## Architecture
 
-### User-Based Rate Limiting
+### Vercel edge (`/ingest/*`)
 
-Located in `src/lib/api/user-rate-limit.ts`.
+Dashboard-managed Rate Limit on the PostHog ingest reverse-proxy path. This is the only Vercel Rate Limit slot. It is not encoded in application source or `vercel.json`.
 
-- **Storage**: In-memory LRU cache per process
+### Application IP limiter
+
+Located in `src/lib/api/ip-rate-limit.ts`. Shared sliding-window algorithm: `src/lib/api/rate-limit-core.ts`.
+
+- **Storage**: In-memory LRU cache **per Node.js process**
+- **Key**: Client IP (`X-Forwarded-For`, `X-Real-IP`, `CF-Connecting-IP`; unknown if none)
+- **Scope**: Per IP category (`health`, `webhook`, `publicApi`, `auth`, `docs`, `internal`)
+- **Opt-in**: A route must call `checkIpRateLimit(request, category)`. Declaring a category in `IP_RATE_LIMIT_CONFIGS` does not enforce it.
+- **Multi-instance note**: Each serverless instance enforces its own counters. Limits are best-effort, not globally strict.
+
+### Authenticated user limiter
+
+Located in `src/lib/api/user-rate-limit.ts`. Same sliding-window core as the IP limiter.
+
+- **Storage**: In-memory LRU cache **per Node.js process**
 - **Key**: Authenticated user ID (not IP)
 - **Scope**: Per category, per user
-- **Multi-instance note**: Each server instance enforces its own limits. For strict global limits, consider Redis-backed storage.
+- **Opt-in**: `requestBoundary.route({ rateLimit })` or `requestBoundary.action({ rateLimit })`
+- **Multi-instance note**: Same per-process caveat as the IP limiter. Two concurrent instances can each admit a full window of requests for the same user.
 
-### Plan Generation Rate Limiting
+### Durable plan-generation limiter
 
 Located in `src/lib/api/rate-limit.ts`.
 
-- **Storage**: Database (generation_attempts table)
-- **Key**: RLS-scoped (current user via session)
-- **Scope**: Actual generation attempts (stream + retry paths)
+- **Storage**: Database (`generation_attempts` table)
+- **Key**: RLS-scoped current user
+- **Scope**: Generation, retry, and regeneration attempts
+- **Mechanism**: Fail-closed preflight count of `generation_attempts` in the rolling window. This is not an atomic reservation.
 - **Policy constants**: `PLAN_GENERATION_LIMIT`, `PLAN_GENERATION_WINDOW_MINUTES`
-- **Multi-instance note**: Globally consistent (database-backed)
+- **Concurrency note**: Because the check is a non-atomic preflight count with no reservation, concurrent requests can exceed the nominal window.
+
+### Product quotas and kill switches
+
+These are not request-frequency limiters. They cap product usage or disable a feature:
+
+- Plan-count and duration gates on plan creation
+- Metered billing quotas (lesson generation, regeneration)
+- Vercel Flags kill switches (`moduleLessonGeneration`, `emailNotificationDelivery`)
+
+### Per-process limits and Redis
+
+IP and user limiters are **intentionally per-process**. They protect a single instance from a noisy client; they do not provide a cluster-wide token bucket.
+
+Redis (or any other distributed limiter) is **deferred** until production traffic shows that per-process windows are actually being exceeded in a way that matters for cost or abuse. Do not add a shared store solely because multiple Vercel instances exist.
+
+The durable generation limiter is a database-shared, fail-closed preflight count for generation, retry, and regeneration — not a strict global cap. Because the check is a non-atomic preflight with no reservation, concurrent requests can exceed the nominal window. Product quotas and kill switches further bound that cost.
 
 ## Usage in API Routes
 
@@ -68,6 +137,25 @@ export const POST = requestBoundary.route(
 );
 ```
 
+### Using `requestBoundary.action`
+
+Authenticated Server Actions use the same user categories. Current actions use `mutation`:
+
+```typescript
+import { requestBoundary } from '@/lib/api/request-boundary';
+
+export async function batchUpdateTaskProgressAction(input: Input) {
+  return requestBoundary.action(
+    { rateLimit: 'mutation' },
+    async ({ actor, db }) => {
+      // Action code
+    },
+  );
+}
+```
+
+Server Actions share framework POST paths, so they cannot be targeted reliably with a WAF path rule. Per-user `mutation` is the intended control.
+
 ### Category Selection Guide
 
 | Endpoint Type                                   | Category           |
@@ -75,13 +163,26 @@ export const POST = requestBoundary.route(
 | Plan generation, regeneration                   | `aiGeneration`     |
 | Module lesson batch generation                  | `lessonGeneration` |
 | Future third-party integration writes           | `integration`      |
-| Plan delete/bulk-delete, profile, preferences   | `mutation`         |
+| Plan delete/bulk-delete, profile, preferences, Server Actions | `mutation` |
 | GET endpoints for data retrieval / status polls | `read`             |
 | Future OAuth initiation (not callbacks)         | `oauth`            |
 
+### IP limiter (`checkIpRateLimit`)
+
+For unauthenticated or machine-authenticated routes:
+
+```typescript
+import { checkIpRateLimit } from '@/lib/api/ip-rate-limit';
+
+checkIpRateLimit(request, 'publicApi'); // unsubscribe
+checkIpRateLimit(request, 'internal'); // notification cron / workers
+```
+
+`checkIpRateLimit` throws `RateLimitError` when the window is exceeded. Routes that already use `withErrorBoundary` map that to the canonical 429 payload. It does not attach `X-RateLimit-*` headers by itself; use `getRateLimitHeaders` when a route needs them.
+
 ### Plan Generation (Special Case)
 
-Plan generation has an additional database-backed rate limit:
+Plan generation, retry, and regeneration have an additional database-backed preflight rate limit after the user `aiGeneration` limiter:
 
 ```typescript
 import { checkPlanGenerationRateLimit } from '@/lib/api/rate-limit';
@@ -157,6 +258,9 @@ Source: `USER_RATE_LIMIT_CONFIGS.lessonGeneration` in `src/lib/api/user-rate-lim
 - `PATCH /api/v1/user/preferences`
 - `PATCH /api/v1/user/preferences/notifications`
 - `PUT /api/v1/user/profile`
+- `batchUpdateTaskProgressAction` (`src/app/(app)/plans/[id]/actions.ts`)
+- `batchUpdateModuleTaskProgressAction` (`src/app/(app)/plans/[id]/modules/[moduleId]/actions.ts`)
+- `syncAnalyticsTimezoneAction` (`src/app/(app)/analytics/usage/actions.ts`)
 
 ### Read (`read`)
 
@@ -173,7 +277,41 @@ Source: `USER_RATE_LIMIT_CONFIGS.lessonGeneration` in `src/lib/api/user-rate-lim
 
 ### Integration / OAuth (`integration`, `oauth`)
 
-These categories remain available in the shared rate-limiter configuration for future provider work, but there are currently no active Google OAuth or integration API routes in the app.
+These categories remain available in the shared user-limiter configuration for future provider work. There are currently no active Google OAuth or integration API routes.
+
+### IP: Health (`health`)
+
+- `GET /api/health/worker`
+
+### IP: Webhook (`webhook`)
+
+- `POST /api/v1/clerk/billing/webhook`
+
+### IP: Public API (`publicApi`)
+
+- `GET` / `POST /api/v1/notifications/email/unsubscribe`
+
+### IP: Docs (`docs`)
+
+Available only in development and test; otherwise these routes return `404`.
+
+- `GET /api/docs`
+- `GET /api/docs/openapi`
+
+### IP: Internal (`internal`)
+
+- `POST /api/internal/jobs/regeneration/process`
+- `POST /api/internal/maintenance/billing/reconcile-clerk`
+- `POST /api/internal/maintenance/notifications/email`
+- `POST /api/internal/maintenance/plans/cleanup`
+- `POST /api/internal/maintenance/retention/cleanup`
+- `GET /api/cron/notifications/email`
+
+Maintenance POSTs apply `internal` through `createMaintenancePostRoute` in `src/lib/api/internal/maintenance-route.ts`.
+
+### IP: Auth (`auth`)
+
+Defined in `IP_RATE_LIMIT_CONFIGS` (10 requests / minute). No current route calls `checkIpRateLimit(request, 'auth')`.
 
 ## Future Considerations
 
@@ -213,13 +351,19 @@ const aiWindowMs = USER_RATE_LIMIT_CONFIGS.aiGeneration.windowMs; // 3600000
 
 ### Redis-Backed Storage
 
-For strict global rate limiting across multiple server instances, the `createUserRateLimiter` function can be extended to use Redis instead of the in-memory LRU cache.
+Do not add Redis (or another distributed limiter) until production traffic shows that per-process IP/user windows are being exceeded in a way that matters. The durable Postgres limiter is a fail-closed preflight count on generation, retry, and regeneration, not a cluster-wide atomic reservation.
 
 ## Related Files
 
-- `src/lib/api/user-rate-limit.ts` - User-based rate limiting module
-- `src/lib/api/rate-limit.ts` - Plan generation rate limiting
-- `src/lib/api/request-boundary.ts` - request-boundary route helper
-- `src/lib/api/route-wrappers.ts` - shared error boundary and user rate-limit wrapper/header logic
-- `src/lib/api/errors.ts` - `RateLimitError` class
-- `tests/unit/api/user-rate-limit.spec.ts` - Unit tests
+- `src/lib/api/ip-rate-limit.ts` — IP-based rate limiting
+- `src/lib/api/user-rate-limit.ts` — User-based rate limiting
+- `src/lib/api/rate-limit-core.ts` — Shared sliding-window LRU used by IP and user limiters
+- `src/lib/api/rate-limit.ts` — Durable plan-generation rate limiting
+- `src/lib/api/request-boundary.ts` — `requestBoundary.route` / `.action` rate-limit options
+- `src/lib/api/route-wrappers.ts` — Shared error boundary and user rate-limit wrapper/header logic
+- `src/lib/api/errors.ts` — `RateLimitError` class
+- `src/lib/api/internal/maintenance-route.ts` — Applies the `internal` IP limiter to maintenance POSTs
+- `src/shared/constants/generation.ts` — Durable generation limit constants
+- `vercel.json` — Cron schedules only; does not record Firewall rules
+- `tests/unit/api/user-rate-limit.spec.ts` — User limiter unit tests
+- `tests/unit/api/ip-rate-limit.spec.ts` — IP limiter unit tests

--- a/src/app/(app)/analytics/usage/actions.ts
+++ b/src/app/(app)/analytics/usage/actions.ts
@@ -13,15 +13,18 @@ export async function syncAnalyticsTimezoneAction(
   const nextAnalyticsTimezone = parsed.data.analyticsTimezone;
   if (!nextAnalyticsTimezone) return false;
 
-  const result = await requestBoundary.action(async ({ actor, db }) => {
-    if (actor.analyticsTimezone === nextAnalyticsTimezone) {
-      return false;
-    }
+  const result = await requestBoundary.action(
+    { rateLimit: 'mutation' },
+    async ({ actor, db }) => {
+      if (actor.analyticsTimezone === nextAnalyticsTimezone) {
+        return false;
+      }
 
-    await upsertUserAnalyticsTimezone(actor.id, nextAnalyticsTimezone, db);
+      await upsertUserAnalyticsTimezone(actor.id, nextAnalyticsTimezone, db);
 
-    return true;
-  });
+      return true;
+    },
+  );
 
   return result ?? false;
 }

--- a/src/app/(app)/plans/[id]/actions.ts
+++ b/src/app/(app)/plans/[id]/actions.ts
@@ -33,20 +33,22 @@ export async function batchUpdateTaskProgressAction({
 }: BatchUpdateTaskProgressInput): Promise<BatchUpdateTaskProgressCoreResult | void> {
   if (updates.length === 0) return;
 
-  const result = await requestBoundary.action(async ({ actor, db }) =>
-    batchUpdateTaskProgressCore({
-      planId,
-      updates,
-      userId: actor.id,
-      dbClient: db,
-      logContext: {
+  const result = await requestBoundary.action(
+    { rateLimit: 'mutation' },
+    async ({ actor, db }) =>
+      batchUpdateTaskProgressCore({
         planId,
+        updates,
         userId: actor.id,
-        updateCount: updates.length,
-        taskIds: updates.map((update) => update.taskId),
-      },
-      logMessage: 'Failed to batch update task progress',
-    }),
+        dbClient: db,
+        logContext: {
+          planId,
+          userId: actor.id,
+          updateCount: updates.length,
+          taskIds: updates.map((update) => update.taskId),
+        },
+        logMessage: 'Failed to batch update task progress',
+      }),
   );
 
   if (result === null) {

--- a/src/app/(app)/plans/[id]/modules/[moduleId]/actions.ts
+++ b/src/app/(app)/plans/[id]/modules/[moduleId]/actions.ts
@@ -33,22 +33,24 @@ export async function batchUpdateModuleTaskProgressAction({
 }: BatchUpdateModuleTaskProgressInput): Promise<BatchUpdateTaskProgressCoreResult | void> {
   if (updates.length === 0) return;
 
-  const result = await requestBoundary.action(async ({ actor, db }) =>
-    batchUpdateTaskProgressCore({
-      planId,
-      moduleId,
-      updates,
-      userId: actor.id,
-      dbClient: db,
-      logContext: {
+  const result = await requestBoundary.action(
+    { rateLimit: 'mutation' },
+    async ({ actor, db }) =>
+      batchUpdateTaskProgressCore({
         planId,
         moduleId,
+        updates,
         userId: actor.id,
-        updateCount: updates.length,
-        taskIds: updates.map((update) => update.taskId),
-      },
-      logMessage: 'Failed to batch update module task progress',
-    }),
+        dbClient: db,
+        logContext: {
+          planId,
+          moduleId,
+          userId: actor.id,
+          updateCount: updates.length,
+          taskIds: updates.map((update) => update.taskId),
+        },
+        logMessage: 'Failed to batch update module task progress',
+      }),
   );
 
   if (result === null) {

--- a/src/app/api/cron/notifications/email/route.ts
+++ b/src/app/api/cron/notifications/email/route.ts
@@ -5,6 +5,7 @@ import {
   resolveEmailNotificationDeliveryRunKind,
 } from '@/features/notifications/email/workflows/email-notification-delivery.types';
 import { tokensMatch } from '@/lib/api/internal/internal-worker-token';
+import { checkIpRateLimit } from '@/lib/api/ip-rate-limit';
 import { json, jsonError } from '@/lib/api/response';
 import { withErrorBoundary } from '@/lib/api/route-wrappers';
 import { maintenanceEnv } from '@/lib/config/env';
@@ -87,6 +88,8 @@ export function createEmailNotificationDeliveryCronRoute(
       );
       return jsonError('Unauthorized cron trigger.', { status: 401 });
     }
+
+    checkIpRateLimit(request, 'internal');
 
     const runKind = resolveRunKind(request);
     if (!runKind) {

--- a/src/app/api/internal/maintenance/notifications/email/route.ts
+++ b/src/app/api/internal/maintenance/notifications/email/route.ts
@@ -49,6 +49,7 @@ export function createEmailNotificationDeliveryPostRoute(
         mode: 'required',
         onMalformedJson: () =>
           new ValidationError('Invalid JSON in request body'),
+        maxBytes: 256 * 1024,
       });
       const parsed = emailDeliveryBodySchema.safeParse(body);
       if (!parsed.success) {

--- a/src/app/api/v1/notifications/email/unsubscribe/route.ts
+++ b/src/app/api/v1/notifications/email/unsubscribe/route.ts
@@ -1,4 +1,5 @@
 import { applySignedEmailUnsubscribe } from '@/features/notifications/email/unsubscribe';
+import { checkIpRateLimit } from '@/lib/api/ip-rate-limit';
 import { withErrorBoundary } from '@/lib/api/route-wrappers';
 
 const NO_STORE_HEADERS = {
@@ -130,12 +131,15 @@ async function parseOneClickForm(
   }
 }
 
-export const GET = withErrorBoundary(async () => {
+export const GET = withErrorBoundary(async (request: Request) => {
+  checkIpRateLimit(request, 'publicApi');
   // GET is confirmation-only. Never mutate preferences from scanners/prefetchers.
   return htmlResponse(confirmationHtml());
 });
 
 async function handlePost(request: Request): Promise<Response> {
+  checkIpRateLimit(request, 'publicApi');
+
   const token = new URL(request.url).searchParams.get('token');
   if (!token) {
     return htmlResponse(failureHtml(), 400);

--- a/src/app/api/v1/notifications/email/unsubscribe/route.ts
+++ b/src/app/api/v1/notifications/email/unsubscribe/route.ts
@@ -131,8 +131,7 @@ async function parseOneClickForm(
   }
 }
 
-export const GET = withErrorBoundary(async (request: Request) => {
-  checkIpRateLimit(request, 'publicApi');
+export const GET = withErrorBoundary(async () => {
   // GET is confirmation-only. Never mutate preferences from scanners/prefetchers.
   return htmlResponse(confirmationHtml());
 });

--- a/src/app/api/v1/plans/[planId]/regenerate/route.ts
+++ b/src/app/api/v1/plans/[planId]/regenerate/route.ts
@@ -30,6 +30,7 @@ export const POST: PlainHandler = requestBoundary.route(
       mode: 'required',
       onMalformedJson: () =>
         new ValidationError('Invalid JSON in request body.'),
+      maxBytes: 1 * 1024 * 1024,
     });
 
     let overrides: PlanRegenerationOverridesInput | undefined;

--- a/src/app/api/v1/plans/bulk-delete/route.ts
+++ b/src/app/api/v1/plans/bulk-delete/route.ts
@@ -72,6 +72,7 @@ export const POST = requestBoundary.route(
         new ValidationError('Invalid bulk delete request.', {
           body: 'Request body must be valid JSON.',
         }),
+      maxBytes: 256 * 1024,
     })) as BulkDeleteRequestBody;
     const planIds = parseBulkDeletePlanIds(body);
 

--- a/src/app/api/v1/plans/stream/route.ts
+++ b/src/app/api/v1/plans/stream/route.ts
@@ -112,6 +112,7 @@ export function createStreamHandler(deps?: {
             { reason: 'Malformed or invalid JSON payload.' },
             { authUserId, error: serializeErrorForLog(error) },
           ),
+        maxBytes: 1 * 1024 * 1024,
       });
 
       const payloadLogResult = tryBuildPayloadLog(parsedBody);

--- a/src/app/api/v1/user/preferences/notifications/route.ts
+++ b/src/app/api/v1/user/preferences/notifications/route.ts
@@ -17,6 +17,7 @@ export const PATCH = requestBoundary.route(
       mode: 'required',
       onMalformedJson: () =>
         new ValidationError('Invalid JSON in request body'),
+      maxBytes: 256 * 1024,
     });
     const parsed = emailNotificationPreferenceFormValuesSchema.safeParse(body);
 

--- a/src/app/api/v1/user/preferences/route.ts
+++ b/src/app/api/v1/user/preferences/route.ts
@@ -89,6 +89,7 @@ export const PATCH = requestBoundary.route(
       mode: 'required',
       onMalformedJson: () =>
         new ValidationError('Invalid JSON in request body'),
+      maxBytes: 256 * 1024,
     });
     const parsed = updatePreferencesSchema.safeParse(body);
 

--- a/src/app/api/v1/user/profile/route.ts
+++ b/src/app/api/v1/user/profile/route.ts
@@ -56,6 +56,7 @@ export const PUT = requestBoundary.route(
       mode: 'required',
       onMalformedJson: () =>
         new ValidationError('Invalid JSON in request body'),
+      maxBytes: 256 * 1024,
     });
 
     const parsed = updateUserProfileSchema.safeParse(body);

--- a/src/lib/api/parse-json-body.ts
+++ b/src/lib/api/parse-json-body.ts
@@ -1,9 +1,12 @@
 /**
  * Shared JSON request-body parsing for API routes.
- * Handles only `req.json()` and route-specific malformed-JSON behavior.
+ * Handles `req.json()`, optional actual-byte caps, and route-specific malformed-JSON behavior.
  */
 
+import { AppError } from '@/lib/api/errors';
 import { isAbortError } from '@/lib/errors';
+
+const OVERSIZED_BODY_CODE = 'PAYLOAD_TOO_LARGE';
 
 export type ParseJsonBodyOptions = {
   /**
@@ -17,9 +20,15 @@ export type ParseJsonBodyOptions = {
   fallback?: unknown;
   /** Only used in `optional` mode. Defaults to {@link detectJsonBodyPresence}. */
   detectBody?: (req: Request) => boolean;
+  /**
+   * Optional actual-byte cap. When omitted, parsing stays on unbounded `req.json()`.
+   * When set, oversized `Content-Length` may reject early; the streamed body is
+   * still counted in bytes so missing, malformed, or understated headers cannot bypass the cap.
+   */
+  maxBytes?: number;
 };
 
-function parsePositiveContentLength(value: string | null): number | null {
+function parseFiniteContentLength(value: string | null): number | null {
   if (value === null) {
     return null;
   }
@@ -28,10 +37,29 @@ function parsePositiveContentLength(value: string | null): number | null {
     return null;
   }
   const n = Number(trimmed);
-  if (!Number.isFinite(n) || n <= 0) {
+  if (!Number.isFinite(n) || n < 0) {
     return null;
   }
   return n;
+}
+
+function parsePositiveContentLength(value: string | null): number | null {
+  const n = parseFiniteContentLength(value);
+  if (n === null || n <= 0) {
+    return null;
+  }
+  return n;
+}
+
+function oversizedBodyError(): AppError {
+  return new AppError('payload too large', {
+    status: 413,
+    code: OVERSIZED_BODY_CODE,
+  });
+}
+
+function isOversizedBodyError(err: unknown): err is AppError {
+  return err instanceof AppError && err.code() === OVERSIZED_BODY_CODE;
 }
 
 /**
@@ -47,6 +75,58 @@ export function detectJsonBodyPresence(req: Request): boolean {
   );
 }
 
+async function readBodyCapped(
+  req: Request,
+  maxBytes: number,
+): Promise<Uint8Array | null> {
+  if (req.body == null) {
+    return new Uint8Array();
+  }
+
+  const reader = req.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let length = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    length += value.byteLength;
+    if (length > maxBytes) {
+      await reader.cancel().catch(() => undefined);
+      return null;
+    }
+    chunks.push(value);
+  }
+
+  const body = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return body;
+}
+
+async function parseJsonBodyCapped(
+  req: Request,
+  maxBytes: number,
+): Promise<unknown> {
+  const declared = parseFiniteContentLength(req.headers.get('content-length'));
+  if (declared !== null && declared > maxBytes) {
+    throw oversizedBodyError();
+  }
+
+  const bytes = await readBodyCapped(req, maxBytes);
+  if (bytes === null) {
+    throw oversizedBodyError();
+  }
+
+  return JSON.parse(new TextDecoder().decode(bytes)) as unknown;
+}
+
 export async function parseJsonBody(
   req: Request,
   options: ParseJsonBodyOptions,
@@ -54,10 +134,12 @@ export async function parseJsonBody(
   const detectBody = options.detectBody ?? detectJsonBodyPresence;
 
   try {
-    const body = await req.json();
-    return body;
+    if (options.maxBytes !== undefined) {
+      return await parseJsonBodyCapped(req, options.maxBytes);
+    }
+    return await req.json();
   } catch (err: unknown) {
-    if (isAbortError(err)) {
+    if (isAbortError(err) || isOversizedBodyError(err)) {
       throw err;
     }
 

--- a/src/lib/api/request-boundary.ts
+++ b/src/lib/api/request-boundary.ts
@@ -14,6 +14,7 @@ import {
 } from '@/lib/api/auth';
 import { getCorrelationId } from '@/lib/api/context';
 import { withErrorBoundary, withRateLimit } from '@/lib/api/route-wrappers';
+import { checkUserRateLimit } from '@/lib/api/user-rate-limit';
 import { getDb } from '@supabase/runtime';
 import { randomUUID } from 'node:crypto';
 
@@ -36,7 +37,7 @@ type RouteScope = RequestScope &
 type RequestBoundaryWork<T> = (scope: RequestScope) => Promise<T> | T;
 type RouteBoundaryWork = (scope: RouteScope) => Promise<Response> | Response;
 
-type RouteBoundaryOptions = Readonly<{
+type RateLimitBoundaryOptions = Readonly<{
   rateLimit?: UserRateLimitCategory;
 }>;
 
@@ -54,7 +55,15 @@ function buildScope(actor: ActorUser, db: DbClient): RequestScope {
 
 type RouteMethod = {
   (run: RouteBoundaryWork): PlainHandler;
-  (options: RouteBoundaryOptions, run: RouteBoundaryWork): PlainHandler;
+  (options: RateLimitBoundaryOptions, run: RouteBoundaryWork): PlainHandler;
+};
+
+type ActionMethod = {
+  <T>(run: RequestBoundaryWork<T>): Promise<T | null>;
+  <T>(
+    options: RateLimitBoundaryOptions,
+    run: RequestBoundaryWork<T>,
+  ): Promise<T | null>;
 };
 
 function wrapRouteBoundaryWork(run: RouteBoundaryWork): AuthHandler {
@@ -68,10 +77,10 @@ function wrapRouteBoundaryWork(run: RouteBoundaryWork): AuthHandler {
 
 function createRouteMethod(): RouteMethod {
   function route(
-    optionsOrRun: RouteBoundaryOptions | RouteBoundaryWork,
+    optionsOrRun: RateLimitBoundaryOptions | RouteBoundaryWork,
     maybeRun?: RouteBoundaryWork,
   ): PlainHandler {
-    let options: RouteBoundaryOptions | undefined;
+    let options: RateLimitBoundaryOptions | undefined;
     let run: RouteBoundaryWork;
 
     if (typeof optionsOrRun === 'function') {
@@ -97,14 +106,48 @@ function createRouteMethod(): RouteMethod {
   return route as RouteMethod;
 }
 
+function createActionMethod(): ActionMethod {
+  function action<T>(
+    optionsOrRun: RateLimitBoundaryOptions | RequestBoundaryWork<T>,
+    maybeRun?: RequestBoundaryWork<T>,
+  ): Promise<T | null> {
+    let options: RateLimitBoundaryOptions | undefined;
+    let run: RequestBoundaryWork<T>;
+
+    if (typeof optionsOrRun === 'function') {
+      run = optionsOrRun;
+    } else if (maybeRun === undefined) {
+      throw new TypeError(
+        'requestBoundary.action: handler required as second argument when passing options',
+      );
+    } else {
+      options = optionsOrRun;
+      run = maybeRun;
+    }
+
+    return withServerActionContext(async (actor) => {
+      if (options?.rateLimit !== undefined) {
+        checkUserRateLimit(actor.id, options.rateLimit);
+      }
+
+      return run({
+        ...buildScope(actor, getDb()),
+      });
+    });
+  }
+
+  return action as ActionMethod;
+}
+
 interface RequestBoundary {
   route: RouteMethod;
   component<T>(run: RequestBoundaryWork<T>): Promise<T | null>;
-  action<T>(run: RequestBoundaryWork<T>): Promise<T | null>;
+  action: ActionMethod;
 }
 
 export function createRequestBoundary(): RequestBoundary {
   const route = createRouteMethod();
+  const action = createActionMethod();
   return {
     route,
     component<T>(run: RequestBoundaryWork<T>): Promise<T | null> {
@@ -114,13 +157,7 @@ export function createRequestBoundary(): RequestBoundary {
         }),
       );
     },
-    action<T>(run: RequestBoundaryWork<T>): Promise<T | null> {
-      return withServerActionContext(async (actor) =>
-        run({
-          ...buildScope(actor, getDb()),
-        }),
-      );
-    },
+    action,
   };
 }
 

--- a/src/lib/api/request-boundary.ts
+++ b/src/lib/api/request-boundary.ts
@@ -127,7 +127,8 @@ function createActionMethod(): ActionMethod {
 
     return withServerActionContext(async (actor) => {
       if (options?.rateLimit !== undefined) {
-        checkUserRateLimit(actor.id, options.rateLimit);
+        // Match `withRateLimit` (`ctx.userId`): Clerk auth ID, not `users.id`.
+        checkUserRateLimit(actor.authUserId, options.rateLimit);
       }
 
       return run({

--- a/src/lib/api/user-rate-limit.ts
+++ b/src/lib/api/user-rate-limit.ts
@@ -155,7 +155,7 @@ function getRateLimiter(category: UserRateLimitCategory): SlidingWindowLimiter {
 /**
  * Checks user-based rate limit for a request.
  *
- * @param userId - Authenticated user ID
+ * @param userId - Clerk auth user ID (`authUserId` / route `ctx.userId`)
  * @param category - The cost category of the endpoint
  * @throws RateLimitError if rate limit exceeded
  */
@@ -170,7 +170,7 @@ export function checkUserRateLimit(
 /**
  * Gets rate limit headers for a response.
  *
- * @param userId - Authenticated user ID
+ * @param userId - Clerk auth user ID (`authUserId` / route `ctx.userId`)
  * @param category - The cost category of the endpoint
  * @returns Headers object with rate limit information
  */

--- a/src/lib/proxy/middleware-policy.ts
+++ b/src/lib/proxy/middleware-policy.ts
@@ -34,8 +34,8 @@ const PUBLIC_SIGNED_EMAIL_UNSUBSCRIBE_PATH =
 
 export function isProviderWebhookRoute(pathname: string): boolean {
   const path = stripTrailingSlash(pathname);
-  return PROVIDER_WEBHOOK_ROUTE_PREFIXES.some((prefix) =>
-    path.startsWith(prefix),
+  return PROVIDER_WEBHOOK_ROUTE_PREFIXES.some(
+    (prefix) => path === prefix || path.startsWith(`${prefix}/`),
   );
 }
 

--- a/tests/integration/api/email-unsubscribe.spec.ts
+++ b/tests/integration/api/email-unsubscribe.spec.ts
@@ -62,13 +62,13 @@ describe('email unsubscribe route', () => {
     expect(await settingsFor(userId)).toBeNull();
   });
 
-  it('rate-limits GET confirmation with the publicApi IP bucket', async () => {
+  it('keeps scanner GET traffic from starving one-click POSTs', async () => {
     const { userId, token } = await seedUser();
     const headers = { 'x-forwarded-for': '198.51.100.42' };
 
     for (
       let index = 0;
-      index < IP_RATE_LIMIT_CONFIGS.publicApi.maxRequests;
+      index <= IP_RATE_LIMIT_CONFIGS.publicApi.maxRequests;
       index++
     ) {
       const response = await GET_UNSUBSCRIBE(
@@ -81,22 +81,7 @@ describe('email unsubscribe route', () => {
       expect(await response.text()).toContain('List-Unsubscribe');
     }
 
-    const limitedGet = await GET_UNSUBSCRIBE(
-      new Request(`${BASE_URL}?token=${encodeURIComponent(token)}`, {
-        headers,
-      }),
-    );
-    expect(limitedGet.status).toBe(429);
-    expect(limitedGet.headers.get('retry-after')).not.toBeNull();
-    expect(limitedGet.headers.get('x-ratelimit-limit')).toBe(
-      String(IP_RATE_LIMIT_CONFIGS.publicApi.maxRequests),
-    );
-    await expect(limitedGet.json()).resolves.toMatchObject({
-      code: 'RATE_LIMITED',
-      classification: 'rate_limit',
-    });
-
-    const limitedPost = await POST_UNSUBSCRIBE(
+    const response = await POST_UNSUBSCRIBE(
       new Request(`${BASE_URL}?token=${encodeURIComponent(token)}`, {
         method: 'POST',
         headers: {
@@ -106,8 +91,11 @@ describe('email unsubscribe route', () => {
         body: 'List-Unsubscribe=One-Click',
       }),
     );
-    expect(limitedPost.status).toBe(429);
-    expect(await settingsFor(userId)).toBeNull();
+
+    expect(response.status).toBe(200);
+    expect((await settingsFor(userId))?.unsubscribeAllOptionalEmails).toBe(
+      true,
+    );
   });
 
   it('rate-limits signed one-click POSTs with the publicApi IP bucket before HMAC and body parsing', async () => {

--- a/tests/integration/api/email-unsubscribe.spec.ts
+++ b/tests/integration/api/email-unsubscribe.spec.ts
@@ -62,13 +62,13 @@ describe('email unsubscribe route', () => {
     expect(await settingsFor(userId)).toBeNull();
   });
 
-  it('keeps scanner GET traffic from starving one-click POSTs', async () => {
+  it('rate-limits GET confirmation with the publicApi IP bucket', async () => {
     const { userId, token } = await seedUser();
     const headers = { 'x-forwarded-for': '198.51.100.42' };
 
     for (
       let index = 0;
-      index <= IP_RATE_LIMIT_CONFIGS.publicApi.maxRequests;
+      index < IP_RATE_LIMIT_CONFIGS.publicApi.maxRequests;
       index++
     ) {
       const response = await GET_UNSUBSCRIBE(
@@ -78,9 +78,25 @@ describe('email unsubscribe route', () => {
         ),
       );
       expect(response.status).toBe(200);
+      expect(await response.text()).toContain('List-Unsubscribe');
     }
 
-    const response = await POST_UNSUBSCRIBE(
+    const limitedGet = await GET_UNSUBSCRIBE(
+      new Request(`${BASE_URL}?token=${encodeURIComponent(token)}`, {
+        headers,
+      }),
+    );
+    expect(limitedGet.status).toBe(429);
+    expect(limitedGet.headers.get('retry-after')).not.toBeNull();
+    expect(limitedGet.headers.get('x-ratelimit-limit')).toBe(
+      String(IP_RATE_LIMIT_CONFIGS.publicApi.maxRequests),
+    );
+    await expect(limitedGet.json()).resolves.toMatchObject({
+      code: 'RATE_LIMITED',
+      classification: 'rate_limit',
+    });
+
+    const limitedPost = await POST_UNSUBSCRIBE(
       new Request(`${BASE_URL}?token=${encodeURIComponent(token)}`, {
         method: 'POST',
         headers: {
@@ -90,31 +106,51 @@ describe('email unsubscribe route', () => {
         body: 'List-Unsubscribe=One-Click',
       }),
     );
-
-    expect(response.status).toBe(200);
-    expect((await settingsFor(userId))?.unsubscribeAllOptionalEmails).toBe(
-      true,
-    );
+    expect(limitedPost.status).toBe(429);
+    expect(await settingsFor(userId)).toBeNull();
   });
 
-  it('does not enforce a process-local IP bucket on signed one-click POSTs', async () => {
+  it('rate-limits signed one-click POSTs with the publicApi IP bucket before HMAC and body parsing', async () => {
     const { userId, token } = await seedUser();
-    const providerHeaders = {
+    const headers = {
       'x-forwarded-for': '198.51.100.43',
       'content-type': 'application/x-www-form-urlencoded',
     };
 
-    for (let index = 0; index < 301; index++) {
+    for (
+      let index = 0;
+      index < IP_RATE_LIMIT_CONFIGS.publicApi.maxRequests;
+      index++
+    ) {
       const response = await POST_UNSUBSCRIBE(
         new Request(`${BASE_URL}?token=${encodeURIComponent(token)}`, {
           method: 'POST',
-          headers: providerHeaders,
+          headers,
           body: 'List-Unsubscribe=One-Click',
         }),
       );
       expect(response.status).toBe(200);
     }
 
+    const oversizedLimited = await POST_UNSUBSCRIBE(
+      new Request(`${BASE_URL}?token=${encodeURIComponent(token)}`, {
+        method: 'POST',
+        headers: {
+          ...headers,
+          'content-length': String(64 * 1024 + 1),
+        },
+        body: 'List-Unsubscribe=One-Click',
+      }),
+    );
+    expect(oversizedLimited.status).toBe(429);
+    expect(oversizedLimited.headers.get('retry-after')).not.toBeNull();
+    expect(oversizedLimited.headers.get('x-ratelimit-limit')).toBe(
+      String(IP_RATE_LIMIT_CONFIGS.publicApi.maxRequests),
+    );
+    await expect(oversizedLimited.json()).resolves.toMatchObject({
+      code: 'RATE_LIMITED',
+      classification: 'rate_limit',
+    });
     expect((await settingsFor(userId))?.unsubscribeAllOptionalEmails).toBe(
       true,
     );

--- a/tests/integration/api/middleware-abort.spec.ts
+++ b/tests/integration/api/middleware-abort.spec.ts
@@ -20,18 +20,22 @@ describe('withErrorBoundary client abort (integration)', () => {
     vi.restoreAllMocks();
   });
 
-  it('returns 499 when req.json rejects AbortError on PUT /api/v1/user/profile', async () => {
+  it('returns 499 when body read rejects AbortError on PUT /api/v1/user/profile', async () => {
     const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
     const { PUT } = await import('@/app/api/v1/user/profile/route');
     const abort = new Error('aborted');
     abort.name = 'AbortError';
-    const request = new Request('http://localhost/api/v1/user/profile', {
+    const init: RequestInit & { duplex?: string } = {
       method: 'PUT',
       headers: new Headers({ 'Content-Type': 'application/json' }),
-    });
-    Object.defineProperty(request, 'json', {
-      value: () => Promise.reject(abort),
-    });
+      body: new ReadableStream<Uint8Array>({
+        pull() {
+          return Promise.reject(abort);
+        },
+      }),
+      duplex: 'half',
+    };
+    const request = new Request('http://localhost/api/v1/user/profile', init);
 
     const response = await PUT(request);
 

--- a/tests/integration/api/plans-stream.spec.ts
+++ b/tests/integration/api/plans-stream.spec.ts
@@ -12,6 +12,7 @@ import {
 import { buildTestAuthUserId, buildTestEmail } from '../../helpers/testIds';
 import { createStreamHandler, POST } from '@/app/api/v1/plans/stream/route';
 import { AVAILABLE_MODELS } from '@/features/ai/ai-models';
+import { parseJsonBody } from '@/lib/api/parse-json-body';
 import { generationAttempts, learningPlans, modules } from '@supabase/schema';
 import { db } from '@supabase/service-role';
 import { desc, eq } from 'drizzle-orm';
@@ -34,6 +35,17 @@ const workflowProcessFactory = vi.hoisted(() =>
 vi.mock('@/features/plans/create-workflow-backed-process-generation', () => ({
   createWorkflowBackedProcessGeneration: workflowProcessFactory,
 }));
+
+vi.mock('@/lib/api/parse-json-body', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/lib/api/parse-json-body')>();
+  return {
+    ...actual,
+    parseJsonBody: vi.fn((...args: Parameters<typeof actual.parseJsonBody>) =>
+      actual.parseJsonBody(...args),
+    ),
+  };
+});
 
 const NUMERIC_HEADER_PATTERN = /^\d+$/;
 const FREE_QUERY_OVERRIDE_MODEL = AVAILABLE_MODELS.find(
@@ -210,9 +222,7 @@ describe('POST /api/v1/plans/stream — HTTP preflight + default boundary smoke'
       },
       body: '{}',
     });
-    Object.defineProperty(request, 'json', {
-      value: async () => payload,
-    });
+    vi.mocked(parseJsonBody).mockResolvedValueOnce(payload);
 
     const response = await post(request);
 

--- a/tests/unit/api/email-notification-cron-route.spec.ts
+++ b/tests/unit/api/email-notification-cron-route.spec.ts
@@ -1,5 +1,11 @@
 import { createEmailNotificationDeliveryCronRoute } from '@/app/api/cron/notifications/email/route';
+import { RateLimitError } from '@/lib/api/errors';
+import { checkIpRateLimit } from '@/lib/api/ip-rate-limit';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/api/ip-rate-limit', () => ({
+  checkIpRateLimit: vi.fn(),
+}));
 
 const URL = 'https://atlaris.app/api/cron/notifications/email';
 
@@ -14,6 +20,7 @@ describe('email notification delivery cron route', () => {
   beforeEach(() => {
     resolveDeliveryEnabled.mockReset();
     startWorkflow.mockReset();
+    vi.mocked(checkIpRateLimit).mockReset();
   });
 
   it('rejects missing or wrong CRON_SECRET before flag or workflow access', async () => {
@@ -37,6 +44,7 @@ describe('email notification delivery cron route', () => {
 
     expect(resolveDeliveryEnabled).not.toHaveBeenCalled();
     expect(startWorkflow).not.toHaveBeenCalled();
+    expect(checkIpRateLimit).not.toHaveBeenCalled();
   });
 
   it('fails closed when CRON_SECRET is not configured', async () => {
@@ -54,6 +62,72 @@ describe('email notification delivery cron route', () => {
     );
 
     expect(response.status).toBe(503);
+    expect(resolveDeliveryEnabled).not.toHaveBeenCalled();
+    expect(startWorkflow).not.toHaveBeenCalled();
+    expect(checkIpRateLimit).not.toHaveBeenCalled();
+  });
+
+  it('rate-limits authorized cron triggers with the internal IP category', async () => {
+    resolveDeliveryEnabled.mockResolvedValue(false);
+    const GET = createEmailNotificationDeliveryCronRoute({
+      resolveCronSecret: () => 'cron-secret',
+      resolveDeliveryEnabled,
+      startWorkflow,
+    });
+    const authorizedRequest = request({
+      authorization: 'Bearer cron-secret',
+      'x-vercel-cron-schedule': '0 14 * * *',
+    });
+
+    const response = await GET(authorizedRequest);
+
+    expect(response.status).toBe(200);
+    expect(checkIpRateLimit).toHaveBeenCalledTimes(1);
+    expect(checkIpRateLimit).toHaveBeenCalledWith(
+      authorizedRequest,
+      'internal',
+    );
+  });
+
+  it('returns 429 from the error boundary when the internal IP limiter is exceeded', async () => {
+    vi.mocked(checkIpRateLimit).mockImplementation(() => {
+      throw new RateLimitError('limited', {
+        retryAfter: 42,
+        limit: 100,
+        remaining: 0,
+        reset: 1234567890,
+      });
+    });
+    const GET = createEmailNotificationDeliveryCronRoute({
+      resolveCronSecret: () => 'cron-secret',
+      resolveDeliveryEnabled,
+      startWorkflow,
+    });
+
+    const response = await GET(
+      request({
+        authorization: 'Bearer cron-secret',
+        'x-vercel-cron-schedule': '0 14 * * *',
+      }),
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get('retry-after')).toBe('42');
+    expect(response.headers.get('x-ratelimit-limit')).toBe('100');
+    expect(response.headers.get('x-ratelimit-remaining')).toBe('0');
+    expect(response.headers.get('x-ratelimit-reset')).toBe('1234567890');
+    await expect(response.json()).resolves.toEqual({
+      error: 'limited',
+      code: 'RATE_LIMITED',
+      classification: 'rate_limit',
+      details: {
+        retryAfter: 42,
+        limit: 100,
+        remaining: 0,
+        reset: 1234567890,
+      },
+      retryAfter: 42,
+    });
     expect(resolveDeliveryEnabled).not.toHaveBeenCalled();
     expect(startWorkflow).not.toHaveBeenCalled();
   });

--- a/tests/unit/api/request-boundary.spec.ts
+++ b/tests/unit/api/request-boundary.spec.ts
@@ -1,7 +1,7 @@
 import { buildUserFixture } from '../../fixtures/users';
 import { clearTestUser, setTestUser } from '../../helpers/auth';
 import { getRequestContext } from '@/lib/api/context';
-import { ConflictError } from '@/lib/api/errors';
+import { ConflictError, RateLimitError } from '@/lib/api/errors';
 import {
   createRequestBoundary,
   requestBoundary,
@@ -9,11 +9,22 @@ import {
 import {
   clearAllUserRateLimiters,
   USER_RATE_LIMIT_CONFIGS,
+  type UserRateLimitCategory,
 } from '@/lib/api/user-rate-limit';
 import { db as serviceDb } from '@supabase/service-role';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const { getUserByAuthIdMock } = vi.hoisted(() => ({
+const {
+  actualCheckUserRateLimit,
+  checkUserRateLimitMock,
+  getUserByAuthIdMock,
+} = vi.hoisted(() => ({
+  actualCheckUserRateLimit: {
+    current: undefined as
+      | ((userId: string, category: UserRateLimitCategory) => void)
+      | undefined,
+  },
+  checkUserRateLimitMock: vi.fn(),
   getUserByAuthIdMock: vi.fn(),
 }));
 
@@ -21,10 +32,25 @@ vi.mock('@/lib/db/queries/users', () => ({
   getUserByAuthId: getUserByAuthIdMock,
 }));
 
+vi.mock('@/lib/api/user-rate-limit', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/lib/api/user-rate-limit')>();
+  actualCheckUserRateLimit.current = actual.checkUserRateLimit;
+  checkUserRateLimitMock.mockImplementation(actual.checkUserRateLimit);
+  return {
+    ...actual,
+    checkUserRateLimit: checkUserRateLimitMock,
+  };
+});
+
 describe('requestBoundary', () => {
   afterEach(() => {
     clearTestUser();
     getUserByAuthIdMock.mockReset();
+    checkUserRateLimitMock.mockReset();
+    checkUserRateLimitMock.mockImplementation(
+      actualCheckUserRateLimit.current!,
+    );
     clearAllUserRateLimiters();
   });
 
@@ -352,5 +378,93 @@ describe('requestBoundary', () => {
       classification: 'rate_limit',
       retryAfter: expect.any(Number),
     });
+  });
+
+  it('runs optionless actions without checking a rate-limit category', async () => {
+    const user = buildUserFixture({
+      id: 'user_action',
+      authUserId: 'auth_action',
+      email: 'action@example.test',
+      name: 'Action User',
+    });
+
+    setTestUser(user.authUserId);
+    getUserByAuthIdMock.mockResolvedValue(user);
+
+    const result = await requestBoundary.action(async (scope) => {
+      expect(scope.actor).toEqual(user);
+      expect(scope.owned.userId).toBe(user.id);
+      return 'ok';
+    });
+
+    expect(result).toBe('ok');
+    expect(checkUserRateLimitMock).not.toHaveBeenCalled();
+  });
+
+  it('checks the configured category then executes authenticated limited actions', async () => {
+    const user = buildUserFixture({
+      id: 'user_action_rl',
+      authUserId: 'auth_action_rl',
+      email: 'action-rl@example.test',
+      name: 'Action RL User',
+    });
+
+    setTestUser(user.authUserId);
+    getUserByAuthIdMock.mockResolvedValue(user);
+
+    const run = vi.fn(async (scope) => {
+      expect(scope.actor).toEqual(user);
+      return 'limited-ok';
+    });
+
+    await expect(
+      requestBoundary.action({ rateLimit: 'mutation' }, run),
+    ).resolves.toBe('limited-ok');
+
+    expect(checkUserRateLimitMock).toHaveBeenCalledExactlyOnceWith(
+      user.id,
+      'mutation',
+    );
+    expect(run).toHaveBeenCalledOnce();
+  });
+
+  it('returns null for unauthenticated limited actions without checking the limiter', async () => {
+    const run = vi.fn(async () => 'unreachable');
+
+    await expect(
+      requestBoundary.action({ rateLimit: 'read' }, run),
+    ).resolves.toBeNull();
+
+    expect(checkUserRateLimitMock).not.toHaveBeenCalled();
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('surfaces limiter failures without executing the action callback', async () => {
+    const user = buildUserFixture({
+      id: 'user_action_rl_fail',
+      authUserId: 'auth_action_rl_fail',
+      email: 'action-rl-fail@example.test',
+      name: 'Action RL Fail User',
+    });
+
+    setTestUser(user.authUserId);
+    getUserByAuthIdMock.mockResolvedValue(user);
+
+    const limiterError = new RateLimitError('Too Many Requests');
+    checkUserRateLimitMock.mockImplementationOnce(() => {
+      throw limiterError;
+    });
+
+    const run = vi.fn(async () => 'unreachable');
+
+    await expect(
+      requestBoundary.action({ rateLimit: 'aiGeneration' }, run),
+    ).rejects.toBe(limiterError);
+
+    expect(checkUserRateLimitMock).toHaveBeenCalledExactlyOnceWith(
+      user.id,
+      'aiGeneration',
+    );
+    expect(run).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/api/request-boundary.spec.ts
+++ b/tests/unit/api/request-boundary.spec.ts
@@ -224,6 +224,10 @@ describe('requestBoundary', () => {
     );
 
     expect(response.status).toBe(200);
+    expect(checkUserRateLimitMock).toHaveBeenCalledExactlyOnceWith(
+      user.authUserId,
+      'read',
+    );
     expect(response.headers.get('X-RateLimit-Limit')).toBe(
       String(USER_RATE_LIMIT_CONFIGS.read.maxRequests),
     );
@@ -422,7 +426,7 @@ describe('requestBoundary', () => {
     ).resolves.toBe('limited-ok');
 
     expect(checkUserRateLimitMock).toHaveBeenCalledExactlyOnceWith(
-      user.id,
+      user.authUserId,
       'mutation',
     );
     expect(run).toHaveBeenCalledOnce();
@@ -462,9 +466,45 @@ describe('requestBoundary', () => {
     ).rejects.toBe(limiterError);
 
     expect(checkUserRateLimitMock).toHaveBeenCalledExactlyOnceWith(
-      user.id,
+      user.authUserId,
       'aiGeneration',
     );
     expect(run).not.toHaveBeenCalled();
+  });
+
+  it('shares the Clerk auth ID rate-limit key between routes and actions', async () => {
+    const user = buildUserFixture({
+      id: 'user_shared_rl',
+      authUserId: 'auth_shared_rl',
+      email: 'shared-rl@example.test',
+      name: 'Shared RL User',
+    });
+
+    setTestUser(user.authUserId);
+    getUserByAuthIdMock.mockResolvedValue(user);
+
+    const handler = createRequestBoundary().route(
+      { rateLimit: 'mutation' },
+      async () => new Response('ok', { status: 200 }),
+    );
+    const response = await handler(
+      new Request('http://localhost/api', { method: 'POST' }),
+      { params: Promise.resolve({}) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(checkUserRateLimitMock).toHaveBeenCalledExactlyOnceWith(
+      user.authUserId,
+      'mutation',
+    );
+
+    checkUserRateLimitMock.mockClear();
+    await expect(
+      requestBoundary.action({ rateLimit: 'mutation' }, async () => 'ok'),
+    ).resolves.toBe('ok');
+    expect(checkUserRateLimitMock).toHaveBeenCalledExactlyOnceWith(
+      user.authUserId,
+      'mutation',
+    );
   });
 });

--- a/tests/unit/app/plans/actions.spec.ts
+++ b/tests/unit/app/plans/actions.spec.ts
@@ -64,6 +64,17 @@ function makeActionTestScope(): RequestScope {
   };
 }
 
+function invokeMockedAction<T>(
+  optionsOrRun: ((scope: RequestScope) => Promise<T>) | Record<string, unknown>,
+  maybeRun?: (scope: RequestScope) => Promise<T>,
+): Promise<T> {
+  const run = typeof optionsOrRun === 'function' ? optionsOrRun : maybeRun;
+  if (typeof run !== 'function') {
+    throw new TypeError('expected action callback');
+  }
+  return run(makeActionTestScope());
+}
+
 describe('batchUpdateTaskProgressAction', () => {
   afterEach(() => {
     vi.clearAllMocks();
@@ -89,10 +100,7 @@ describe('batchUpdateTaskProgressAction', () => {
   });
 
   it('rejects oversized update batches after auth', async () => {
-    requestBoundaryActionMock.mockImplementationOnce(
-      async (fn: (scope: RequestScope) => Promise<void>) =>
-        fn(makeActionTestScope()),
-    );
+    requestBoundaryActionMock.mockImplementationOnce(invokeMockedAction);
     const oversizedUpdates = Array.from({ length: 501 }, (_, index) => ({
       taskId: `task-${index}`,
       status: 'completed' as const,
@@ -125,10 +133,7 @@ describe('batchUpdateTaskProgressAction', () => {
   });
 
   it('revalidates paths returned by the boundary on success', async () => {
-    requestBoundaryActionMock.mockImplementationOnce(
-      async (fn: (scope: RequestScope) => Promise<void>) =>
-        fn(makeActionTestScope()),
-    );
+    requestBoundaryActionMock.mockImplementationOnce(invokeMockedAction);
     applyTaskProgressUpdatesMock.mockResolvedValueOnce({
       progress: [],
       revalidatePaths: ['/plans/plan-123', '/plans'],
@@ -151,13 +156,7 @@ describe('batchUpdateTaskProgressAction', () => {
   });
 
   it('succeeds when persistence succeeds but revalidatePath throws', async () => {
-    requestBoundaryActionMock.mockImplementationOnce(
-      async (
-        fn: (
-          scope: RequestScope,
-        ) => Promise<{ revalidateFailed: boolean } | void>,
-      ) => fn(makeActionTestScope()),
-    );
+    requestBoundaryActionMock.mockImplementationOnce(invokeMockedAction);
     applyTaskProgressUpdatesMock.mockResolvedValueOnce({
       progress: [],
       revalidatePaths: ['/plans/plan-123', '/plans'],
@@ -191,10 +190,7 @@ describe('batchUpdateTaskProgressAction', () => {
   });
 
   it('maps boundary persistence errors to generic user message', async () => {
-    requestBoundaryActionMock.mockImplementationOnce(
-      async (fn: (scope: RequestScope) => Promise<void>) =>
-        fn(makeActionTestScope()),
-    );
+    requestBoundaryActionMock.mockImplementationOnce(invokeMockedAction);
     const persistenceError = new Error('db exploded');
     applyTaskProgressUpdatesMock.mockRejectedValueOnce(persistenceError);
 

--- a/tests/unit/app/plans/modules/actions.spec.ts
+++ b/tests/unit/app/plans/modules/actions.spec.ts
@@ -58,10 +58,16 @@ function makeActionTestScope(): RequestScope {
   };
 }
 
-const mockRequestBoundaryAction =
-  (scope: RequestScope) =>
-  async <T>(fn: (scope: RequestScope) => Promise<T>): Promise<T> =>
-    fn(scope);
+function invokeMockedAction<T>(
+  optionsOrRun: ((scope: RequestScope) => Promise<T>) | Record<string, unknown>,
+  maybeRun?: (scope: RequestScope) => Promise<T>,
+): Promise<T> {
+  const run = typeof optionsOrRun === 'function' ? optionsOrRun : maybeRun;
+  if (typeof run !== 'function') {
+    throw new TypeError('expected action callback');
+  }
+  return run(makeActionTestScope());
+}
 
 describe('batchUpdateModuleTaskProgressAction', () => {
   afterEach(() => {
@@ -88,9 +94,7 @@ describe('batchUpdateModuleTaskProgressAction', () => {
   });
 
   it('rejects oversized batches after auth', async () => {
-    requestBoundaryActionMock.mockImplementationOnce(
-      mockRequestBoundaryAction(makeActionTestScope()),
-    );
+    requestBoundaryActionMock.mockImplementationOnce(invokeMockedAction);
     const updates = Array.from({ length: 501 }, (_, index) => ({
       taskId: `task-${index}`,
       status: 'completed' as const,
@@ -122,9 +126,7 @@ describe('batchUpdateModuleTaskProgressAction', () => {
   });
 
   it('revalidates module and plan paths on success', async () => {
-    requestBoundaryActionMock.mockImplementationOnce(
-      mockRequestBoundaryAction(makeActionTestScope()),
-    );
+    requestBoundaryActionMock.mockImplementationOnce(invokeMockedAction);
     applyTaskProgressUpdatesMock.mockResolvedValueOnce({
       progress: [],
       revalidatePaths: ['/plans/p1/modules/m1', '/plans/p1', '/plans'],
@@ -150,9 +152,7 @@ describe('batchUpdateModuleTaskProgressAction', () => {
   });
 
   it('maps boundary persistence errors to generic user message', async () => {
-    requestBoundaryActionMock.mockImplementationOnce(
-      mockRequestBoundaryAction(makeActionTestScope()),
-    );
+    requestBoundaryActionMock.mockImplementationOnce(invokeMockedAction);
     const persistenceError = new Error('db exploded');
     applyTaskProgressUpdatesMock.mockRejectedValueOnce(persistenceError);
 

--- a/tests/unit/lib/api/parse-json-body.spec.ts
+++ b/tests/unit/lib/api/parse-json-body.spec.ts
@@ -1,3 +1,4 @@
+import { AppError } from '@/lib/api/errors';
 import {
   detectJsonBodyPresence,
   parseJsonBody,
@@ -19,6 +20,31 @@ function mockRequest(init: {
     value: init.json,
   });
   return request;
+}
+
+function jsonBodyRequest(
+  body: BodyInit,
+  headers: Record<string, string> = {},
+): Request {
+  const init: RequestInit & { duplex?: string } = {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      ...headers,
+    },
+    body,
+  };
+  if (body instanceof ReadableStream) {
+    init.duplex = 'half';
+  }
+  return new Request('http://localhost/parse-json-body', init);
+}
+
+function expectPayloadTooLarge(error: unknown): asserts error is AppError {
+  expect(error).toBeInstanceOf(AppError);
+  expect((error as AppError).message).toBe('payload too large');
+  expect((error as AppError).status()).toBe(413);
+  expect((error as AppError).code()).toBe('PAYLOAD_TOO_LARGE');
 }
 
 describe('detectJsonBodyPresence', () => {
@@ -262,6 +288,161 @@ describe('parseJsonBody', () => {
         fallback: {},
       }),
     ).rejects.toBe(typeErr);
+    expect(factory).not.toHaveBeenCalled();
+  });
+
+  it('maxBytes: parses a body below the cap', async () => {
+    const body = '{"ok":true}';
+    const req = jsonBodyRequest(body);
+    const jsonSpy = vi.spyOn(req, 'json');
+
+    await expect(
+      parseJsonBody(req, {
+        mode: 'required',
+        onMalformedJson: () => new Error('should not run'),
+        maxBytes: new TextEncoder().encode(body).byteLength + 1,
+      }),
+    ).resolves.toEqual({ ok: true });
+    expect(jsonSpy).not.toHaveBeenCalled();
+  });
+
+  it('maxBytes: parses a body equal to the cap', async () => {
+    const body = '{"ok":true}';
+    const req = jsonBodyRequest(body);
+
+    await expect(
+      parseJsonBody(req, {
+        mode: 'required',
+        onMalformedJson: () => new Error('should not run'),
+        maxBytes: new TextEncoder().encode(body).byteLength,
+      }),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  it('maxBytes: rejects an oversized Content-Length without reading the body', async () => {
+    const pull = vi.fn(() => {
+      throw new Error('body should not be read');
+    });
+    const cancel = vi.fn();
+    const req = jsonBodyRequest(
+      new ReadableStream<Uint8Array>({ pull, cancel }),
+      { 'content-length': '64' },
+    );
+    const jsonSpy = vi.spyOn(req, 'json');
+    const factory = vi.fn(() => new Error('should not run'));
+
+    const error = await parseJsonBody(req, {
+      mode: 'required',
+      onMalformedJson: factory,
+      maxBytes: 16,
+    }).catch((err: unknown) => err);
+
+    expectPayloadTooLarge(error);
+    expect(pull).not.toHaveBeenCalled();
+    expect(cancel).not.toHaveBeenCalled();
+    expect(jsonSpy).not.toHaveBeenCalled();
+    expect(factory).not.toHaveBeenCalled();
+  });
+
+  it('maxBytes: rejects a chunked body that understates Content-Length', async () => {
+    const encoder = new TextEncoder();
+    const cancel = vi.fn();
+    const req = jsonBodyRequest(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode('{"pad":"'));
+          controller.enqueue(encoder.encode(`${'x'.repeat(32)}"}`));
+          controller.close();
+        },
+        cancel,
+      }),
+      { 'content-length': '4' },
+    );
+    const factory = vi.fn(() => new Error('should not run'));
+
+    const error = await parseJsonBody(req, {
+      mode: 'required',
+      onMalformedJson: factory,
+      maxBytes: 16,
+    }).catch((err: unknown) => err);
+
+    expectPayloadTooLarge(error);
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(factory).not.toHaveBeenCalled();
+  });
+
+  it('maxBytes: counts UTF-8 bytes rather than JavaScript characters', async () => {
+    const payload = '{"x":"é"}';
+    const encoded = new TextEncoder().encode(payload);
+    expect(encoded.byteLength).toBeGreaterThan(payload.length);
+
+    const streamBody = () =>
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoded.slice());
+          controller.close();
+        },
+      });
+
+    const overCharCap = await parseJsonBody(jsonBodyRequest(streamBody()), {
+      mode: 'required',
+      onMalformedJson: () => new Error('should not run'),
+      maxBytes: payload.length,
+    }).catch((err: unknown) => err);
+    expectPayloadTooLarge(overCharCap);
+
+    await expect(
+      parseJsonBody(jsonBodyRequest(streamBody()), {
+        mode: 'required',
+        onMalformedJson: () => new Error('should not run'),
+        maxBytes: encoded.byteLength,
+      }),
+    ).resolves.toEqual({ x: 'é' });
+  });
+
+  it('omitted maxBytes: keeps unbounded req.json() behavior', async () => {
+    const huge = { pad: 'x'.repeat(10_000) };
+    const req = mockRequest({
+      json: () => Promise.resolve(huge),
+    });
+
+    await expect(
+      parseJsonBody(req, {
+        mode: 'required',
+        onMalformedJson: () => new Error('should not run'),
+      }),
+    ).resolves.toEqual(huge);
+  });
+
+  it('required mode with maxBytes: malformed JSON still uses onMalformedJson', async () => {
+    const syntaxBody = '{bad';
+    const req = jsonBodyRequest(syntaxBody);
+    const factory = vi.fn(() => new Error('from factory'));
+
+    await expect(
+      parseJsonBody(req, {
+        mode: 'required',
+        onMalformedJson: factory,
+        maxBytes: 1024,
+      }),
+    ).rejects.toThrow('from factory');
+    expect(factory).toHaveBeenCalledWith(expect.any(SyntaxError));
+  });
+
+  it('optional mode with maxBytes: empty undetected body still returns fallback', async () => {
+    const req = new Request('http://localhost/parse-json-body', {
+      method: 'POST',
+    });
+    const factory = vi.fn(() => new Error('should not run'));
+
+    await expect(
+      parseJsonBody(req, {
+        mode: 'optional',
+        onMalformedJson: factory,
+        fallback: {},
+        maxBytes: 1024,
+      }),
+    ).resolves.toEqual({});
     expect(factory).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/lib/api/parse-json-body.spec.ts
+++ b/tests/unit/lib/api/parse-json-body.spec.ts
@@ -338,8 +338,6 @@ describe('parseJsonBody', () => {
     }).catch((err: unknown) => err);
 
     expectPayloadTooLarge(error);
-    expect(pull).not.toHaveBeenCalled();
-    expect(cancel).not.toHaveBeenCalled();
     expect(jsonSpy).not.toHaveBeenCalled();
     expect(factory).not.toHaveBeenCalled();
   });
@@ -367,7 +365,6 @@ describe('parseJsonBody', () => {
     }).catch((err: unknown) => err);
 
     expectPayloadTooLarge(error);
-    expect(cancel).toHaveBeenCalledTimes(1);
     expect(factory).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/lib/proxy-middleware-policy.spec.ts
+++ b/tests/unit/lib/proxy-middleware-policy.spec.ts
@@ -7,9 +7,23 @@ import {
 import { describe, expect, it } from 'vitest';
 
 describe('middleware policy', () => {
-  it('isProtectedRoute skips Clerk Billing webhook', () => {
-    expect(isProtectedRoute('/api/v1/clerk/billing/webhook')).toBe(false);
-    expect(isProviderWebhookRoute('/api/v1/clerk/billing/webhook')).toBe(true);
+  it.each([
+    '/api/v1/clerk/billing/webhook',
+    '/api/v1/clerk/billing/webhook/',
+    '/api/v1/clerk/billing/webhook/events',
+    '/api/v1/clerk/billing/webhook/events/',
+  ])('treats %s as a provider webhook and Clerk bypass', (pathname) => {
+    expect(isProviderWebhookRoute(pathname)).toBe(true);
+    expect(isProtectedRoute(pathname)).toBe(false);
+  });
+
+  it('does not treat sibling webhook-unrelated path as a provider webhook', () => {
+    expect(
+      isProviderWebhookRoute('/api/v1/clerk/billing/webhook-unrelated'),
+    ).toBe(false);
+    expect(isProtectedRoute('/api/v1/clerk/billing/webhook-unrelated')).toBe(
+      true,
+    );
   });
 
   it.each([


### PR DESCRIPTION
Closes JCS-53 / https://linear.app/jcs-personal-projects/issue/JCS-53/rate-limiting-and-waf-coverage-audit

## Summary
- Keep the dashboard `/ingest` Rate Limit slot (1/1) and leave all 3 custom WAF slots unused. No method WAF rule. Redis stays deferred.
- Add `requestBoundary.action({ rateLimit })` and apply `mutation` to the three Server Actions (plan/module task progress, analytics timezone).
- Apply existing IP buckets: signed unsubscribe POST uses `publicApi`; notification cron uses `internal` after Bearer `CRON_SECRET`. Unsubscribe GET stays confirmation-only and unmetered so scanners cannot starve opt-outs.
- Add `parseJsonBody` `maxBytes` (streamed byte cap). 256 KiB on profile/preferences/notifications/bulk-delete/maintenance email; 1 MiB on plan stream/regenerate.
- Tighten provider-webhook matching so `/webhook-unrelated` no longer inherits the Clerk bypass.
- Document the five-layer model and `/ingest` allocation in `docs/api/rate-limiting.md`.

## Test plan
- [x] Unsubscribe GET flood does not 429 a following signed POST; POST-only `publicApi` bucket still 429s.
- [x] Cron IP limiter runs only after a valid `CRON_SECRET`; over-limit returns 429.
- [x] `requestBoundary.action` optionless call still works; authenticated limited actions check the user limiter; unauthenticated returns null without consuming a bucket.
- [x] `parseJsonBody` rejects oversized bodies as 413 `PAYLOAD_TOO_LARGE` (header and streamed understated length).
- [x] Provider webhook exact path and `/webhook/...` still bypass Clerk; `/webhook-unrelated` stays protected.
- [ ] Preview: signed unsubscribe POST still works; GET confirmation page still does not mutate.
- [ ] Preview: Server Action task-progress and timezone sync still succeed under normal use.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c5afb31bd6051b7f47b50f4f66b4c0bca01099e3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->