### PR TITLE
fix(security): remediate Codex scan findings

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -89,6 +89,7 @@ Security audits and supply-chain policy.
 
 | File | Description |
 |------|-------------|
+| [codex-scan-verification-2026-08-20.md](./security/codex-scan-verification-2026-08-20.md) | Codex scan `1ebeff2f` verification (2026-08-20); hosted gates still open |
 | [security-audit-checklist.md](./security/security-audit-checklist.md) | Pre-launch security checklist (24 areas) |
 | [supply-chain-policy.md](./security/supply-chain-policy.md) | pnpm `minimumReleaseAge` policy |
 
@@ -163,6 +164,7 @@ docs/
 │   ├── local-database.md
 │   └── logging.md
 ├── security/
+│   ├── codex-scan-verification-2026-08-20.md
 │   ├── security-audit-checklist.md
 │   └── supply-chain-policy.md
 ├── styles/

--- a/docs/api/rate-limiting.md
+++ b/docs/api/rate-limiting.md
@@ -6,7 +6,7 @@ Atlaris rate limiting is five layers, not a single wrapper. Edge, IP, user, dura
 
 | Layer | Where | Scope | Consistency |
 | ----- | ----- | ----- | ----------- |
-| Vercel edge rate limit | Dashboard-managed Firewall Rate Limit on `/ingest/*` | Unauthenticated PostHog reverse-proxy traffic | Edge-wide (Vercel) |
+| Vercel edge rate limit | Dashboard-managed Firewall Rate Limit on `/ingest` | Unauthenticated PostHog ingest-proxy traffic | Edge-wide (Vercel) |
 | Application IP limiter | `src/lib/api/ip-rate-limit.ts` | Unauthenticated or machine routes keyed by client IP | Per process (in-memory LRU) |
 | Authenticated user limiter | `src/lib/api/user-rate-limit.ts` | Authenticated API routes and Server Actions keyed by user ID | Per process (in-memory LRU) |
 | Durable DB plan-generation limiter | `src/lib/api/rate-limit.ts` | Generation, retry, and regeneration attempts (`generation_attempts`) | Database-shared, fail-closed preflight (not atomic) |
@@ -19,14 +19,14 @@ Hobby/Pro projects have **1 Rate Limit slot** and **3 custom WAF slots**. The in
 | Capability | Allocation |
 | ---------- | ---------- |
 | Rate Limit | **1 / 1** — keep the dashboard-managed `/ingest` rule; it is the sole Rate Limit slot |
-| Custom WAF Rules | **0 / 3** — leave all three unused |
-| Optional `/ingest` method rule | **Do not add it** |
+| Custom WAF Rules | **1 / 3** — `/ingest` unsupported-method deny; leave the remaining two unused |
+| Optional `/ingest` method rule | Dashboard-managed method allowlist (GET, HEAD, POST, OPTIONS) as defense in depth |
 
 This dashboard rule is **not** represented in `vercel.json`. That file remains repository configuration for cron schedules only. Inspecting the repo cannot confirm or mutate the live Firewall dashboard.
 
-Do not add WAF rules for authenticated APIs, Svix/Clerk signature headers, worker secrets, or broad `/.well-known` paths. Those surfaces are enforced in application code (user/IP limiters, cryptographic verification, worker tokens). Custom WAF slots stay unused on purpose so they remain available as emergency virtual patches.
+Do not add WAF rules for authenticated APIs, Svix/Clerk signature headers, worker secrets, or broad `/.well-known` paths. Those surfaces are enforced in application code (user/IP limiters, cryptographic verification, worker tokens). Keep the remaining custom WAF slots unused so they remain available as emergency virtual patches.
 
-`/ingest/*` is the PostHog reverse-proxy rewrite in `next.config.ts`. Clerk proxy matching excludes that prefix so analytics ingest is not treated as an app route.
+`/ingest` is an application-owned constrained PostHog proxy (`src/app/ingest/[...path]/route.ts`), not a raw reverse-proxy rewrite. Clerk proxy matching excludes that prefix so analytics ingest stays public; the route itself enforces path, method, body, header, redirect, and timeout policy.
 
 ## Quick Reference
 
@@ -64,7 +64,7 @@ Source of truth for durable generation limits is `src/shared/constants/generatio
 
 ### Vercel edge (`/ingest/*`)
 
-Dashboard-managed Rate Limit on the PostHog ingest reverse-proxy path. This is the only Vercel Rate Limit slot. It is not encoded in application source or `vercel.json`.
+Dashboard-managed Rate Limit on the PostHog ingest proxy path (`^/ingest(?:/|$)`). This is the only Vercel Rate Limit slot. A separate dashboard method rule denies methods outside GET, HEAD, POST, and OPTIONS on the same path. Neither rule is encoded in application source or `vercel.json`.
 
 ### Application IP limiter
 

--- a/docs/api/rate-limiting.md
+++ b/docs/api/rate-limiting.md
@@ -24,6 +24,10 @@ Hobby/Pro projects have **1 Rate Limit slot** and **3 custom WAF slots**. The in
 
 This dashboard rule is **not** represented in `vercel.json`. That file remains repository configuration for cron schedules only. Inspecting the repo cannot confirm or mutate the live Firewall dashboard.
 
+Live verification on 2026-08-21 confirmed the published configuration is active: the rate rule is a fixed window of 100 requests per 60 seconds per IP on `^/ingest(?:/|$)`, and the method rule denies methods outside GET, HEAD, POST, and OPTIONS. A fresh-window direct test against the public production domain sent 105 harmless HEAD requests in five seconds and received 100 application responses followed by 5 HTTP 429 responses. A direct PUT returned 403.
+
+Do not use `vercel curl` to verify custom WAF enforcement. It automatically supplies a Vercel automation-bypass token, and Vercel documents that this token bypasses ordinary Firewall blocks. It is appropriate for protected Preview application checks, but the WAF threshold must be tested through a non-bypassed public domain or another path that does not carry the automation token.
+
 Do not add WAF rules for authenticated APIs, Svix/Clerk signature headers, worker secrets, or broad `/.well-known` paths. Those surfaces are enforced in application code (user/IP limiters, cryptographic verification, worker tokens). Keep the remaining custom WAF slots unused so they remain available as emergency virtual patches.
 
 `/ingest` is an application-owned constrained PostHog proxy (`src/app/ingest/[...path]/route.ts`), not a raw reverse-proxy rewrite. Clerk proxy matching excludes that prefix so analytics ingest stays public; the route itself enforces path, method, body, header, redirect, and timeout policy.

--- a/docs/architecture/plan-generation-architecture.md
+++ b/docs/architecture/plan-generation-architecture.md
@@ -132,7 +132,18 @@ Production path: `GenerationAdapter` calls `runGenerationExecution(...)` in `src
 
 **Failure:**
 
-- mark attempt failure and plan `failed` (not quota-eligible)
+- Attempt/job rows record the failure.
+- Last-good plans (`is_quota_eligible = true`, including populated ready plans
+  mid-regeneration) stay `ready` and quota-eligible. Modules are not cleared.
+- Plans that never owned a cap slot (`is_quota_eligible = false`, including
+  first-time generating plans with no usable content) become `failed` and stay
+  ineligible, which releases a generating reservation.
+- Admission/reservation rejection uses the same plan-row rule (`plan_only`
+  finalization does not hide last-good plans from quota accounting).
+- Retry of an ineligible plan must reserve a generating slot under the same
+  per-user advisory lock as new-plan admission before provider work. Success
+  may set `is_quota_eligible = true` only if the plan already owns that slot
+  (`is_quota_eligible` or `generation_status = generating`).
 - **retryable:** no usage writes (same domain rule as before)
 - **permanent with usage:** usage event + metric increment in the same transaction
 

--- a/docs/security/codex-scan-verification-2026-08-20.md
+++ b/docs/security/codex-scan-verification-2026-08-20.md
@@ -1,0 +1,316 @@
+# Codex Security Scan Verification
+
+## Baseline
+
+- Scan ID: `1ebeff2f-25a0-4eff-bdb5-efabddda8453`
+- Sealed scan SHA: `ce21da6d24560abcd36f6ad6bfdab6538badf951`
+- Current develop SHA: `0a2a6a3cc23ff6b7f582a171a57de1766984a23e` (`HEAD` and `origin/develop` were identical at report draft; `0/0` divergence)
+- Verification branch: `security/codex-security-scan-fixes`
+- Date: 2026-08-20 (America/Chicago)
+- Test environment: Local working tree on the verification branch, started from the develop SHA above. Focused Vitest unit and integration runs recorded in worker handoffs. No preview or production deployment was authorized. Canonical scan artifacts (`report.md`, `findings.json`, `scan-manifest.json`, `coverage.json`) were not modified.
+- External controls inspected: Read-only. Vercel CLI 53.2.0 listed a published rate-limit rule on `^/ingest(?:/|$)` (100 requests / 60 seconds / IP, action `rate_limit`) and a published method-deny rule on the same path that rejects methods other than GET, HEAD, POST, and OPTIONS. No draft rules; `pendingChanges = 0`. The Firewall overview was unavailable because the CLI required an IP bypass; that limitation is recorded, not inferred. PostHog project `551450` settings were inspected without recording secrets; session replay and masking were enabled. This report records no token, session material, or credential value.
+
+This report does **not** declare the scan fully remediated. Local source fixes and automated tests exist for all six findings, and `pnpm test` plus `pnpm check:full` later exited 0 (see Full Validation). Hosted sentinel capture, live Vercel rate-threshold exercise, preview smoke tests, and firewall overview remain deferred without deployment authorization. The scan is not fully remediated until those hosted gates are proven.
+
+## Summary
+
+| Finding ID | Original severity | Final disposition | Current severity | Fix PR/commit | Evidence |
+|---|---:|---|---:|---|---|
+| `csf_fd68543d3520e162ac2643c4` | High | Confirmed — Fixed | Residual until hosted sentinel proof | Pending — local working tree only | Application-owned `/ingest` proxy; unit header-strip tests (33 passed in `ingest-proxy.spec.ts` last worker run). Hosted session-header capture not run. |
+| `csf_d96410ccc4c1e9180d9b2348` | Medium | Confirmed — Fixed | None (local automated) | Pending — local working tree only | `providerStartedAt` settlement + stale-marker cleanup + ns3 lifecycle lock. Unit 33 + 55; lesson boundary 19/19 after stale-assert fix; lifecycle lock integration 9/9; abandoned-marker cleanup integration 6/6. |
+| `csf_5a4d4ce1935028ded77c7665` | Medium | Confirmed — Fixed | Residual until live rate-threshold proof | Pending — local working tree only | Same `/ingest` proxy path/method/body allowlists; Vercel rule inspected read-only. Live threshold not crossed. |
+| `csf_c5b56b8805301b01be4acfa6` | Medium | Confirmed — Fixed | None (local automated) | Pending — local working tree only | Per-user admission lock + atomic last-good failure UPDATE. Quota-cap / persistence / cleanup integration: 22 passed. |
+| `csf_57cb64ce0282ad978f485c72` | Medium | Confirmed — Fixed | None (local automated) | Pending — local working tree only | Namespace-2 payer lock + bounded Clerk refresh. Unit 16; webhook-claims integration 17, including reverse-completion and hung-fetch cases. |
+| `csf_b2d5b3cb56a146e0ea1edbd5` | Low | Already Remediated After Scan | None | Production `maxBytes` already on develop; test-only local additions pending commit | All seven production `parseJsonBody` callers pass a finite cap. Focused run: 38 tests passed across `tests/unit/lib/api/parse-json-body.spec.ts` and `tests/unit/api/plans.bulk-delete-route.spec.ts`, including malformed, negative, overflow, and unsafe `Content-Length` bodies. |
+
+## Finding 1: PostHog Credential Forwarding
+
+### Current Code
+
+The sealed scan described Next.js external rewrites of `/ingest/*` with Clerk middleware excluding that prefix and no application-owned outbound header allowlist.
+
+Current working-tree code replaces those rewrites with an application-owned proxy:
+
+- `src/app/ingest/[...path]/route.ts` — public catch-all that delegates GET/HEAD/POST/PUT/PATCH/DELETE/OPTIONS to `proxyIngestRequest`.
+- `src/lib/posthog/ingest-proxy.ts` — path, method, body, origin, redirect, timeout, and header policy. `buildOutboundHeaders` constructs a new `Headers` object and, for body-bearing paths, copies only `content-type` and `content-encoding` after allowlist checks. Session, identity, and forwarding inbound headers are never copied.
+- `next.config.ts` — external PostHog rewrites removed; `skipTrailingSlashRedirect` retained so exact `/e/`, `/s/`, and `/flags/` are not redirected before the proxy.
+- `src/proxy.ts` — Clerk matcher still excludes `/ingest`; the comment states the ingest route owns validation.
+
+Origins come from `resolvePostHogRewriteDestinations` only. HTTPS is required except http loopback in non-production.
+
+### Reproduction Method
+
+Local unit tests in `tests/unit/lib/posthog/ingest-proxy.spec.ts` send mocked requests that include session, identity, Clerk-prefixed, and forwarding headers, then assert those names are absent from the upstream `fetch` headers. Downstream tests assert Set-Cookie, WWW-Authenticate, Server, Location, and tracing headers are stripped from the client response.
+
+Controlled hosted reproduction (preview deployment, non-production sentinel session headers, disposable upstream receiver) was **not** executed. No deployment was authorized.
+
+### Sanitized Hosted Evidence
+
+Not collected. Hosted sentinel session-header capture against a controlled receiver is deferred without deployment authorization. No session material was generated or retained.
+
+### Result
+
+Confirmed in source: the rewrite vector is gone, and the application proxy does not forward session-bearing headers. Hosted Vercel behavior of this new function path is unproven.
+
+### Root Cause
+
+Same-origin `/ingest` plus a catch-all external rewrite could attach application session headers to an upstream PostHog origin. Middleware exclusion meant no application code inspected that hop.
+
+### Implemented Fix
+
+One constrained PostHog proxy (shared with Finding 3). Outbound headers are built from scratch. Response headers are copied only from `cache-control`, `content-encoding`, `content-type`, `etag`, and `last-modified`. Upstream fetch uses `redirect: 'manual'` and a 10s timeout.
+
+### Regression Tests
+
+Last worker run: `SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit tests/unit/lib/posthog/ingest-proxy.spec.ts` — 33 passed. Coverage includes inbound session/identity/Clerk/forwarding strip, outbound Set-Cookie strip, known capture/replay/flags/asset paths, unknown/backslash/dot-segment reject before fetch, 405 for unsupported methods, declared and streamed 1 MiB body caps, exact-at-cap success, redirect reject, and timeout 504.
+
+### Residual Risk
+
+Hosted proof that the deployed Vercel function actually runs this code, and that no platform hop re-attaches credentials, is missing. `loadSiteApp` arbitrary API URLs are not proxied. Nested `/s/*` and slashless `/ingest/s` are rejected; only exact `/ingest/s/` is allowed. Upstream PostHog sees the Vercel function IP/UA, not the browser (intentional).
+
+### Final Disposition
+
+**Confirmed — Fixed.** Local automated proof only. Hosted sentinel evidence remains an open acceptance gate.
+
+## Finding 2: Provider Work Refund
+
+### Current Code
+
+`runModuleLessonGenerationWork` writes `providerStartedAt` onto owned module JSON immediately before provider invocation (`markModuleLessonProviderStarted`). The existing `lessonGeneration` reservation is the durable attempt token. After that marker, failures return `disposition: 'consumed'` with `provider_started_failure` and do not compensate. Failures before the marker return `revert` and compensate. Existing plan-cleanup maintenance now settles stale generating modules that retain this marker by marking them failed without touching `usageMetrics`; a later retry must reserve a new slot.
+
+Parent-plan / child-lesson races use PostgreSQL transaction advisory lock namespace `3` keyed by `hashtext(planId)` with a 15s `lock_timeout` (`src/lib/db/queries/helpers/plan-lifecycle-lock.ts`). Child claim, `reserveAttemptSlot` (ns1 then ns3), successful module replacement, and deletion take the same lock. An active `lessonGenerationStatus = 'generating'` child blocks reservation (`active_child_generation` → retryable rate_limit), success persist, and delete.
+
+### Deterministic Race
+
+Lesson-settlement tests fail the provider/parser/persist path after the marker and assert the reservation stays consumed. Lifecycle-lock integration claims a child only when the parent is `ready`; non-ready parent returns `in_flight` with no mutation; regeneration reservation and success persist refuse an active child; delete refuses an active child; same-plan lock serialization is observed via `pg_locks` (granted + waiting), with different plan IDs taking independent locks. Three deterministic ordering cases additionally prove delete-before-claim, provider-start-before-delete, and provider-start-before-regeneration behavior. Cleanup integration proves stale provider-started state is classified without refund and a later retry consumes another slot.
+
+### Database State Before and After
+
+| Timing | Failure | Work disposition | Compensate | Module |
+| --- | --- | --- | --- | --- |
+| Before marker (provider resolve/init, lifecycle, marker persist) | error | `revert` | yes | failure persist, then quota compensate |
+| After marker (provider/parse/success persist) | error | `consumed` `provider_started_failure` | no | failure persist best-effort |
+| After marker + failure persist fails | error | `consumed` `provider_started_failure` | no | logged, not thrown |
+| Process crash after marker | n/a | process dies, then existing cleanup settles stale marker | no | marker remains durable; module is classified failed and the consumed reservation is not refunded |
+
+Parser failure after provider start retains the reservation. The stale boundary assertion that expected compensation back to count `2` was corrected to consumed count `3`; 19/19 tests in `tests/integration/db/module-lesson-generation.boundary.spec.ts` then passed.
+
+### Result
+
+Confirmed. Post-provider parse and persistence failures cannot restore the provider-attempt budget. Existing maintenance reconciliation classifies stale provider-started modules without refunding their reservation, and parent deletion/regeneration coordinate with active child jobs under the same durable lock.
+
+### Root Cause
+
+Quota compensation ran after provider work had started, and parent plan mutations were not serialized with child lesson jobs, so a refund or replacement could race an in-flight child.
+
+### Implemented Fix
+
+Durable `providerStartedAt` marker plus consumed-on-started settlement. Existing plan-cleanup maintenance settles stale provider-started modules as failed without compensation, so retries follow the normal reservation path. Namespace-3 advisory lock around child claim, reservation, success persist, and delete. Lifecycle finalization skips plan-only completion for `active_child_generation` so last-good ready plans stay intact.
+
+### Regression Tests
+
+- Lesson settlement unit (3 owned specs): 33 passed; flag spec: 3 passed.
+- Lesson boundary integration: 19 passed (19).
+- Lifecycle lock unit (`delete-plan`, `attempts-persistence`, `write-service`, `process-generation`): 4 files, 55 passed.
+- The original combined lifecycle integration run had 52 passed and 1 failed. It preceded the stale assertion correction and the three deterministic lock-order tests; the single failure was the old parser-refund expectation of count `2`. The assertion was corrected to consumed count `3`; targeted reruns passed: lesson boundary 19/19, lifecycle lock 9/9, and cleanup/reconciliation 6/6. The final full changed-test run then passed 52 integration files / 298 tests.
+- Slice `oxlint`, `pnpm exec tsc --noEmit`, and `git diff --check`: pass. Final orchestrator `pnpm test` and `pnpm check:full` both exited 0; see Full Validation.
+
+### Residual Risk
+
+An abandoned provider-started module is now settled by the existing plan-cleanup maintenance boundary after the shared 15-minute stale window; the usage reservation remains consumed and is never compensated. If maintenance is unavailable, the generating state remains until that boundary runs. Hosted/preview proof of ordinary lesson generation is deferred. No production provider charges were incurred.
+
+### Final Disposition
+
+**Confirmed — Fixed.**
+
+## Finding 3: Public PostHog Relay
+
+### Current Source Controls
+
+Same proxy as Finding 1. Allowlist matches installed `posthog-js` 1.415.1:
+
+- POST `/e/`, `/s/`, `/flags/` (query allowlist only)
+- GET/HEAD `/array/{token}/config` and `config.js`
+- GET/HEAD `/static/{version}/{kind}.js` and `/static/{kind}.js`
+
+Unknown paths return 404 before fetch. Unsupported methods return 405 with `Allow` before fetch. OPTIONS is not relayed. Body cap is 1 MiB (declared Content-Length and streamed). Origins are resolver-owned; request-selected hosts are ignored.
+
+### Current Vercel Controls
+
+Read-only CLI inspection (Vercel CLI 53.2.0), not a dashboard overview:
+
+- Rate-limit rule: path `^/ingest(?:/|$)`, 100 requests / 60 seconds / IP, action `rate_limit`.
+- Method-deny rule on the same path: methods other than GET, HEAD, POST, and OPTIONS rejected.
+- No draft rules; `pendingChanges = 0`.
+- Firewall overview unavailable (CLI required an IP bypass). Coverage of preview vs production, fail-open behavior, and regional durability were therefore not confirmed from the overview UI.
+- Neither rule is encoded in application source or `vercel.json`.
+
+### Path/Method/Body/Rate Tests
+
+Path, method, and body policy: unit tests in `tests/unit/lib/posthog/ingest-proxy.spec.ts` (same 33-passed run as Finding 1), including unknown/dot-segment/backslash reject before fetch, 405 before fetch, declared oversized 413, streamed oversized 413 with reader cancel, exact 1 MiB success, and asset-path body reject.
+
+Live Vercel rate-threshold test (crossing the published limit by one or two requests) was **not** run. No attack traffic was sent to production.
+
+### Result
+
+Source relay is no longer unrestricted. Edge rate-limit and method-deny rules were observed as published. Live threshold enforcement is unproven.
+
+### Implemented Fix
+
+Application-owned constrained proxy plus documented dashboard-managed `/ingest` rate-limit and method-deny rules. Rewrites removed.
+
+### Regression Tests
+
+Same ingest-proxy unit suite as Finding 1 (33 passed). Oxlint on changed files and `pnpm check:type` passed in that worker slice.
+
+### Residual Risk
+
+Live rate-limit action, preview/production parity, and fail-open behavior are unverified. Rate limiting does not stop accepted PostHog payloads from polluting analytics below the threshold. Hosted path-normalization variants against the edge rule were not exercised.
+
+### Final Disposition
+
+**Confirmed — Fixed.** Local source and unit proof only. Live rate-threshold remains an open acceptance gate.
+
+## Finding 4: Active-Plan Cap Reactivation
+
+### State Transition
+
+Retry previously restored a hidden plan above `maxActivePlans` because regeneration/reservation failure marked last-good plans `failed` + `isQuotaEligible=false`, retry of ineligible plans did not atomically reserve a cap slot before provider work, and success finalization could set `isQuotaEligible=true` without a reservation.
+
+Current behavior:
+
+- Shared `lockUserPlanAdmission` + `countPlansContributingToCap` + `planOwnsActiveCapSlot` in `src/lib/db/queries/helpers/plan-generation-status.ts`.
+- New-plan insert and `reserveAttemptSlot` take the same per-user advisory lock (namespace 1).
+- `reserveAttemptSlot` locks the plan row; if the plan does not already own a slot (`isQuotaEligible` or `generationStatus === 'generating'`), it rejects with `plan_limit` before provider work.
+- Failure marking is one UPDATE: `generationStatus` is `ready` if currently eligible, otherwise `failed`; `isQuotaEligible` is left unchanged (`applyPlanGenerationFailureUpdate`).
+- Success sets eligible true only when already eligible or `generationStatus=generating`.
+
+### Deterministic Reproduction
+
+`tests/integration/features/plans/lifecycle/quota-cap-reservation.spec.ts`: populated ready plans stay ready and eligible on rate-limited regeneration; failed ineligible retry is blocked when slots are full without invoking the provider; retry reserves a generating slot before provider work; concurrent failed-plan reactivations with one slot admit exactly one; successful regeneration replaces content without hiding last-good from quota; failure after reservation follows last-good policy.
+
+### Result
+
+Confirmed. Populated plans remain quota-accounted during failed regeneration. Every quota-eligibility reactivation is atomically capped. Concurrent retries cannot exceed `maxActivePlans`.
+
+### Implemented Fix
+
+Per-user admission lock shared by insert and reservation; last-good failure UPDATE that never clears eligibility; success eligibility only for plans that already own a slot.
+
+### Concurrency Tests
+
+Integration (quota-cap-reservation, persistence store, cleanup): 22 passed. Worker `oxlint` on `plan-persistence-store.ts`, `pnpm check:type`, and `git diff --check` passed.
+
+### Residual Risk
+
+Preview smoke of plan creation/retry is deferred. Over-cap eligible plans already in the database are kept and still block new inserts (documented in the quota-cap spec).
+
+### Final Disposition
+
+**Confirmed — Fixed.**
+
+## Finding 5: Clerk Entitlement Ordering
+
+### Event Interleaving
+
+Distinct Clerk billing events for one payer could refresh Clerk concurrently, then apply outside a payer-scoped transaction. An older refresh could land last and overwrite a newer entitlement. Reconciliation had the same fetch-then-write gap. After a payer lock existed, a hung `getUserBillingSubscription` could still hold the transaction lock until the function died.
+
+### Deterministic Reproduction
+
+`tests/integration/db/clerk-billing-webhook-claims.spec.ts` serializes distinct billing events for one payer so the latest Clerk snapshot wins; allows different payers to refresh concurrently; serializes reconciliation behind the same payer lock; does not write unlocked state when the lock times out; times out a hung Clerk refresh, releases the lock, and lets a later retry apply. Unit `reconciliation.spec.ts` covers the same timeout/no-write path.
+
+### Result
+
+Confirmed. Clerk projection updates are serialized per payer. The reverse-completion tests prove stale state cannot win. Hung Clerk fetch times out with no entitlement write, event uncompleted, claim released, then retry acquires the released lock.
+
+### Implemented Fix
+
+`lockAndRefreshClerkBillingSource` in `src/features/billing/clerk-billing/reconciliation.ts`:
+
+1. start transaction
+2. `SET LOCAL lock_timeout` (default 15s)
+3. `pg_advisory_xact_lock(2, hashtext(payerUserId))`
+4. fetch Clerk with `Promise.race` plus timeout cleanup (default 10s; Clerk exposes no AbortSignal)
+5. claim/event ledger (webhook only)
+6. select local user → project → update
+7. commit (lock released)
+
+Lock or network timeout rejects the transaction: no entitlement write, webhook not completed, claim released, retryable. Same-event-id dedupe unchanged. Identity events still do not write billing columns. Sole production updater of `subscriptionTier` / `subscriptionStatus` / `subscriptionPeriodEnd` / `cancelAtPeriodEnd` is `applyClerkBillingSource` after this locked refresh.
+
+### Concurrency Tests
+
+- `tests/unit/features/billing/clerk-billing/reconciliation.spec.ts`: 16 passed
+- `tests/integration/db/clerk-billing-webhook-claims.spec.ts`: 17 passed
+- Changed-file oxlint, `pnpm check:type`, `git diff --check` on the three owned files: pass
+
+### Residual Risk
+
+Preview smoke of ordinary billing is deferred. No real billing transitions were performed. Clerk has no AbortSignal; timeout is `Promise.race` plus cleanup.
+
+### Final Disposition
+
+**Confirmed — Fixed.**
+
+## Finding 6: JSON Body Limit
+
+### Post-Scan Code Change
+
+`parseJsonBody` on current develop already accepts optional `maxBytes`, rejects oversized declared `Content-Length` without reading the body, and counts actual streamed UTF-8 bytes. Production `parse-json-body.ts` was not changed in this working tree. Test-only gap closure was added in `tests/unit/lib/api/parse-json-body.spec.ts` and `tests/unit/api/plans.bulk-delete-route.spec.ts`.
+
+### Caller Inventory
+
+No wrappers, aliases, or re-exports. Direct `parseJsonBody` only:
+
+| Path | Route | maxBytes |
+|---|---|---|
+| `src/app/api/internal/maintenance/notifications/email/route.ts` | POST `/api/internal/maintenance/notifications/email` | 256 KiB |
+| `src/app/api/v1/plans/bulk-delete/route.ts` | POST `/api/v1/plans/bulk-delete` | 256 KiB |
+| `src/app/api/v1/user/preferences/notifications/route.ts` | PATCH `/api/v1/user/preferences/notifications` | 256 KiB |
+| `src/app/api/v1/user/preferences/route.ts` | PATCH `/api/v1/user/preferences` | 256 KiB |
+| `src/app/api/v1/user/profile/route.ts` | PUT `/api/v1/user/profile` | 256 KiB |
+| `src/app/api/v1/plans/[planId]/regenerate/route.ts` | POST `/api/v1/plans/:planId/regenerate` | 1 MiB |
+| `src/app/api/v1/plans/stream/route.ts` | POST `/api/v1/plans/stream` | 1 MiB |
+
+No production caller omits `maxBytes` or passes `Infinity`. No `request.json()` / `request.text()` in this route family. Clerk billing webhook uses a separate `WEBHOOK_MAX_BYTES` path, not `parseJsonBody`.
+
+### Test Results
+
+Specs cover below-cap parse, exact-cap parse, oversized Content-Length 413 without reading, invalid/negative/overflow/unsafe Content-Length with bounded over-cap bodies, chunked body that understates Content-Length, undeclared multi-chunk stream over the cap (413 even if cancel rejects), UTF-8 byte counting, omitted-`maxBytes` unbounded `req.json()` behavior, and a bulk-delete route 413 for an oversized declared JSON body.
+
+Focused run: 38 tests passed across `tests/unit/lib/api/parse-json-body.spec.ts` and `tests/unit/api/plans.bulk-delete-route.spec.ts`. Final orchestrator `pnpm test` unit changed phase: 45 test files passed, 410 tests passed (`pnpm test` exit 0).
+
+### Remaining Gaps
+
+A single huge stream chunk is still allocated by the runtime before `byteLength` is visible. Optional `maxBytes` still allows unbounded `req.json()` if a future caller omits it.
+
+### Final Disposition
+
+**Already Remediated After Scan.**
+
+## Full Validation
+
+- Install: Passed (`pnpm install --frozen-lockfile`) at baseline.
+- Typecheck: Passed. Orchestrator reran `pnpm check:full` afterward; `check:type` exit 0. `pnpm check:full` exit 0.
+- Lint: Passed. Same `pnpm check:full` rerun; `check:lint` exit 0.
+- Unit tests: Passed. `pnpm test` exit 0. Unit changed phase: 45 test files passed, 410 tests passed.
+- Integration tests: Passed. `pnpm test` exit 0. Integration changed phase: 52 test files passed, 298 tests passed. Workflow changed phase: 1 test file passed, 4 tests passed. Overall phase runner: Passed: `test:unit:changed` `test:integration:changed`.
+- Preview smoke tests: Deferred — no deployment authorization (normal PostHog, billing, plan creation/retry, and lesson generation not exercised on a preview host)
+- Hosted security tests: Deferred — no deployment authorization (sentinel session-header capture; live Vercel rate-threshold crossing by one or two requests)
+
+Worker slice targeted results after this delta: parser 35 tests, lifecycle lock 9 tests, and abandoned provider-start cleanup 6 tests passed. Changed-file oxlint, `pnpm exec tsc --noEmit`, and `git diff --check` passed. The orchestrator then reran `pnpm test` (exit 0: unit 45/410, integration 52/298, workflow 1/4) and `pnpm check:full` (exit 0). No hosted preview or deployment was authorized.
+
+## Remaining Security Work
+
+- Deferred hosted or operational checks:
+  - Controlled hosted sentinel session-header capture for credential stripping
+  - Live Vercel rate-threshold test crossing the published `/ingest` limit by only one or two requests
+  - Preview smoke tests for normal PostHog, billing, plan creation/retry, and lesson generation
+  - Firewall overview inspection (CLI required an IP bypass)
+- Accepted residual risks:
+  - Hosted proof of Findings 1 and 3 is missing; do not treat production `/ingest` as verified
+  - PostHog function IP/UA replaces browser identity on proxied requests
+  - `loadSiteApp` arbitrary API URLs are not proxied
+  - Analytics pollution via accepted PostHog payloads below the rate threshold
+  - JSON parser: one huge stream chunk may allocate before the cap is visible; omitted `maxBytes` remains unbounded
+  - Over-cap eligible plans already present remain counted and block new inserts
+- Follow-up issues: None opened. Canonical scan artifacts remain historical and unchanged. Fix commit/PR for local remediations is still pending.

--- a/docs/security/codex-scan-verification-2026-08-20.md
+++ b/docs/security/codex-scan-verification-2026-08-20.md
@@ -6,22 +6,46 @@
 - Sealed scan SHA: `ce21da6d24560abcd36f6ad6bfdab6538badf951`
 - Current develop SHA: `0a2a6a3cc23ff6b7f582a171a57de1766984a23e` (`HEAD` and `origin/develop` were identical at report draft; `0/0` divergence)
 - Verification branch: `security/codex-security-scan-fixes`
-- Date: 2026-08-20 (America/Chicago)
-- Test environment: Local working tree on the verification branch, started from the develop SHA above. Focused Vitest unit and integration runs recorded in worker handoffs. No preview or production deployment was authorized. Canonical scan artifacts (`report.md`, `findings.json`, `scan-manifest.json`, `coverage.json`) were not modified.
-- External controls inspected: Read-only. Vercel CLI 53.2.0 listed a published rate-limit rule on `^/ingest(?:/|$)` (100 requests / 60 seconds / IP, action `rate_limit`) and a published method-deny rule on the same path that rejects methods other than GET, HEAD, POST, and OPTIONS. No draft rules; `pendingChanges = 0`. The Firewall overview was unavailable because the CLI required an IP bypass; that limitation is recorded, not inferred. PostHog project `551450` settings were inspected without recording secrets; session replay and masking were enabled. This report records no token, session material, or credential value.
+- Last verified: 2026-08-21 (America/Chicago)
+- Test environment: Local working tree on PR #530 plus its Vercel Preview deployment `dpl_VqU1mXaMqYQS18iDmCHiw3N4MLwG`. Header-boundary proof used isolated Preview deployment `dpl_AUNXhCLZEXUPHEU8e86SLWbnD7d6`, built from the same clean PR source at `cff7097a3`, with only the public PostHog host overridden to a controlled HTTPS echo receiver. Canonical scan artifacts (`report.md`, `findings.json`, `scan-manifest.json`, `coverage.json`) were not modified.
+- External controls inspected: Read-only. Vercel CLI 53.2.0 listed a live fixed-window rate-limit rule on `^/ingest(?:/|$)` (100 requests / 60 seconds / IP, action `rate_limit`) and a live method-deny rule on the same path that rejects methods other than GET, HEAD, POST, and OPTIONS. Both rules were valid; no draft existed and `pendingChanges = 0`. Direct public-domain enforcement was exercised without an automation bypass. PostHog project `551450` settings were inspected without recording secrets; session replay and masking were enabled. This report records no token, session material, or credential value.
 
-This report does **not** declare the scan fully remediated. Local source fixes and automated tests exist for all six findings, and `pnpm test` plus `pnpm check:full` later exited 0 (see Full Validation). Hosted sentinel capture, live Vercel rate-threshold exercise, preview smoke tests, and firewall overview remain deferred without deployment authorization. The scan is not fully remediated until those hosted gates are proven.
+This report closes the material source and hosted acceptance gates for all six findings. It distinguishes the remaining non-material hosted gaps and accepted residual risks below; no finding is marked fixed solely from source inspection.
 
 ## Summary
 
-| Finding ID | Original severity | Final disposition | Current severity | Fix PR/commit | Evidence |
-|---|---:|---|---:|---|---|
-| `csf_fd68543d3520e162ac2643c4` | High | Confirmed — Fixed | Residual until hosted sentinel proof | Pending — local working tree only | Application-owned `/ingest` proxy; unit header-strip tests (33 passed in `ingest-proxy.spec.ts` last worker run). Hosted session-header capture not run. |
-| `csf_d96410ccc4c1e9180d9b2348` | Medium | Confirmed — Fixed | None (local automated) | Pending — local working tree only | `providerStartedAt` settlement + stale-marker cleanup + ns3 lifecycle lock. Unit 33 + 55; lesson boundary 19/19 after stale-assert fix; lifecycle lock integration 9/9; abandoned-marker cleanup integration 6/6. |
-| `csf_5a4d4ce1935028ded77c7665` | Medium | Confirmed — Fixed | Residual until live rate-threshold proof | Pending — local working tree only | Same `/ingest` proxy path/method/body allowlists; Vercel rule inspected read-only. Live threshold not crossed. |
-| `csf_c5b56b8805301b01be4acfa6` | Medium | Confirmed — Fixed | None (local automated) | Pending — local working tree only | Per-user admission lock + atomic last-good failure UPDATE. Quota-cap / persistence / cleanup integration: 22 passed. |
-| `csf_57cb64ce0282ad978f485c72` | Medium | Confirmed — Fixed | None (local automated) | Pending — local working tree only | Namespace-2 payer lock + bounded Clerk refresh. Unit 16; webhook-claims integration 17, including reverse-completion and hung-fetch cases. |
-| `csf_b2d5b3cb56a146e0ea1edbd5` | Low | Already Remediated After Scan | None | Production `maxBytes` already on develop; test-only local additions pending commit | All seven production `parseJsonBody` callers pass a finite cap. Focused run: 38 tests passed across `tests/unit/lib/api/parse-json-body.spec.ts` and `tests/unit/api/plans.bulk-delete-route.spec.ts`, including malformed, negative, overflow, and unsafe `Content-Length` bodies. |
+| Finding ID                     | Original severity | Final disposition             |                    Current severity | Fix PR/commit                                    | Evidence                                                                                                                                                   |
+| ------------------------------ | ----------------: | ----------------------------- | ----------------------------------: | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `csf_fd68543d3520e162ac2643c4` |              High | Confirmed — Fixed             |              Accepted residual only | PR #530                                          | Controlled hosted echo proved Cookie, session, and Authorization sentinels were absent upstream while allowlisted content headers and body were preserved. |
+| `csf_d96410ccc4c1e9180d9b2348` |            Medium | Confirmed — Fixed             |                                None | PR #530                                          | `providerStartedAt` settlement + stale-marker cleanup + ns3 lifecycle lock. Unit and deterministic database race coverage passed.                          |
+| `csf_5a4d4ce1935028ded77c7665` |            Medium | Confirmed — Fixed             |              Accepted residual only | PR #530                                          | Hosted path/method/body checks passed; published firewall configuration matched docs; live threshold returned 100 application responses then 5 edge 429s.  |
+| `csf_c5b56b8805301b01be4acfa6` |            Medium | Confirmed — Fixed             |                                None | PR #530                                          | Per-user admission lock + atomic last-good failure UPDATE. Quota-cap / persistence / cleanup integration: 22 passed.                                       |
+| `csf_57cb64ce0282ad978f485c72` |            Medium | Confirmed — Fixed             |                                None | PR #530                                          | Namespace-2 payer lock + bounded Clerk refresh. Unit 16; webhook-claims integration 17, including reverse-completion and hung-fetch cases.                 |
+| `csf_b2d5b3cb56a146e0ea1edbd5` |               Low | Already Remediated After Scan | Accepted parser allocation residual | PR #530 tests; production cap already on develop | All seven production `parseJsonBody` callers pass a finite cap. Focused parser/route coverage passed.                                                      |
+
+## Hosted Acceptance Evidence (2026-08-21)
+
+### Verified
+
+- PR deployment identity: PR #530 head `cff7097a3` deployed ready as `dpl_VqU1mXaMqYQS18iDmCHiw3N4MLwG` before the final test/report-only delta.
+- Credential boundary: a controlled echo upstream received the request body plus `content-type` / `content-encoding`, but did not receive the sentinel `Authorization`, `Cookie` (including `__session`), or `X-Session-Id` headers.
+- Browser ingestion: a real browser reload requested PostHog config and SDK assets plus `/ingest/e/` and `/ingest/flags/?v=2&compression=base64`; every observed response was 200. A browser-shaped capture using the Preview environment's public project token also returned `200 {"status":"Ok"}`.
+- Normal application smoke: `/` redirected to `/landing`; the landing page rendered meaningful content with no Next.js error overlay and no browser console errors.
+- Hosted proxy policy: valid capture returned 200; capture over 1 MiB returned 413; unknown path returned 404; unsupported route method returned 405; invalid content type returned 400; the edge method rule returned 403 for PUT.
+- Firewall state: live rules matched `docs/api/rate-limiting.md` exactly, with no draft or pending changes. A direct public-domain fresh-window test sent 105 harmless HEAD requests in five seconds and received 100 application responses followed by 5 HTTP 429 responses.
+
+### Still Unverified
+
+- No real Clerk billing transition, plan mutation, or paid lesson-provider invocation was performed on Preview. Those paths retain deterministic unit/integration coverage and were excluded to avoid changing shared billing/user data or incurring provider cost.
+- Redirect rejection was verified in the proxy unit suite (`redirect: 'manual'`, 3xx mapped to 502 with no `Location`/`Set-Cookie`), but the controlled hosted receiver used for header proof did not expose a safe prefix-wide redirect endpoint.
+- Vercel's Firewall overview endpoint was unavailable on this plan; live rule listing, zero-draft diff, direct method enforcement, and direct threshold enforcement supplied the operational evidence instead.
+
+### Accepted Residual Risk
+
+- Accepted PostHog payloads can pollute analytics below 100 requests per minute per IP; the application allowlist and PostHog project controls reduce but do not eliminate that product-integrity risk.
+- Vercel automation-bypass tokens intentionally bypass ordinary custom firewall blocks. Such tokens remain privileged project credentials and cannot be used to prove WAF enforcement; the threshold test therefore used the public production domain without a bypass.
+- PostHog sees the Vercel function IP/user agent rather than the browser identity, by design.
+- `loadSiteApp` arbitrary API URLs are not routed through `/ingest`.
 
 ## Finding 1: PostHog Credential Forwarding
 
@@ -40,17 +64,17 @@ Origins come from `resolvePostHogRewriteDestinations` only. HTTPS is required ex
 
 ### Reproduction Method
 
-Local unit tests in `tests/unit/lib/posthog/ingest-proxy.spec.ts` send mocked requests that include session, identity, Clerk-prefixed, and forwarding headers, then assert those names are absent from the upstream `fetch` headers. Downstream tests assert Set-Cookie, WWW-Authenticate, Server, Location, and tracing headers are stripped from the client response.
+Local unit tests in `tests/unit/lib/posthog/ingest-proxy.spec.ts` send mocked requests that include session, identity, Clerk-prefixed, and forwarding headers, then assert those names are absent from the upstream `fetch` headers. Downstream tests assert Set-Cookie, WWW-Authenticate, Server, Location, and tracing headers are stripped from the client response. The public route wiring is covered directly in `tests/unit/api/ingest-route.spec.ts`.
 
-Controlled hosted reproduction (preview deployment, non-production sentinel session headers, disposable upstream receiver) was **not** executed. No deployment was authorized.
+Controlled hosted reproduction used isolated Preview deployment `dpl_AUNXhCLZEXUPHEU8e86SLWbnD7d6` with a controlled HTTPS echo receiver. The inbound request included non-secret sentinel values in `Authorization`, `Cookie` (including `__session`), and `X-Session-Id`.
 
 ### Sanitized Hosted Evidence
 
-Not collected. Hosted sentinel session-header capture against a controlled receiver is deferred without deployment authorization. No session material was generated or retained.
+The echo response reported all three sensitive header classes absent upstream. The body and the two intended content headers were present. Only non-secret sentinels were used; no real session material or credential was generated, forwarded, or retained.
 
 ### Result
 
-Confirmed in source: the rewrite vector is gone, and the application proxy does not forward session-bearing headers. Hosted Vercel behavior of this new function path is unproven.
+Confirmed in source, unit tests, the public route test, and hosted execution: the rewrite vector is gone and the deployed function did not forward the credential sentinels.
 
 ### Root Cause
 
@@ -62,15 +86,15 @@ One constrained PostHog proxy (shared with Finding 3). Outbound headers are buil
 
 ### Regression Tests
 
-Last worker run: `SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit tests/unit/lib/posthog/ingest-proxy.spec.ts` — 33 passed. Coverage includes inbound session/identity/Clerk/forwarding strip, outbound Set-Cookie strip, known capture/replay/flags/asset paths, unknown/backslash/dot-segment reject before fetch, 405 for unsupported methods, declared and streamed 1 MiB body caps, exact-at-cap success, redirect reject, and timeout 504.
+Coverage includes inbound session/identity/Clerk/forwarding strip, outbound Set-Cookie strip, known capture/replay/flags/asset paths, route wiring, unknown/backslash/dot-segment reject before fetch, 405 for unsupported methods, malformed and oversized body declarations, streamed 1 MiB cap, invalid content type/encoding, redirect reject, timeout 504, generic upstream 502, and client-abort 499. The final full unit run passed 235 files / 2,334 tests.
 
 ### Residual Risk
 
-Hosted proof that the deployed Vercel function actually runs this code, and that no platform hop re-attaches credentials, is missing. `loadSiteApp` arbitrary API URLs are not proxied. Nested `/s/*` and slashless `/ingest/s` are rejected; only exact `/ingest/s/` is allowed. Upstream PostHog sees the Vercel function IP/UA, not the browser (intentional).
+`loadSiteApp` arbitrary API URLs are not proxied. Nested `/s/*` and slashless `/ingest/s` are rejected; only exact `/ingest/s/` is allowed. Upstream PostHog sees the Vercel function IP/UA, not the browser (intentional). A project automation-bypass credential could intentionally bypass Vercel WAF controls, but it does not change the application-owned outbound header allowlist.
 
 ### Final Disposition
 
-**Confirmed — Fixed.** Local automated proof only. Hosted sentinel evidence remains an open acceptance gate.
+**Confirmed — Fixed.** Source, automated, and controlled hosted sentinel evidence agree.
 
 ## Finding 2: Provider Work Refund
 
@@ -137,23 +161,23 @@ Unknown paths return 404 before fetch. Unsupported methods return 405 with `Allo
 
 ### Current Vercel Controls
 
-Read-only CLI inspection (Vercel CLI 53.2.0), not a dashboard overview:
+Read-only CLI inspection (Vercel CLI 53.2.0):
 
-- Rate-limit rule: path `^/ingest(?:/|$)`, 100 requests / 60 seconds / IP, action `rate_limit`.
+- Rate-limit rule: path `^/ingest(?:/|$)`, 100 requests / 60 seconds / IP, fixed-window action `rate_limit`.
 - Method-deny rule on the same path: methods other than GET, HEAD, POST, and OPTIONS rejected.
 - No draft rules; `pendingChanges = 0`.
-- Firewall overview unavailable (CLI required an IP bypass). Coverage of preview vs production, fail-open behavior, and regional durability were therefore not confirmed from the overview UI.
+- Firewall overview unavailable on this plan. Direct public-domain method and threshold tests confirmed production enforcement; protected Preview requests made with `vercel curl` cannot prove WAF enforcement because its automation token intentionally bypasses ordinary firewall blocks.
 - Neither rule is encoded in application source or `vercel.json`.
 
 ### Path/Method/Body/Rate Tests
 
-Path, method, and body policy: unit tests in `tests/unit/lib/posthog/ingest-proxy.spec.ts` (same 33-passed run as Finding 1), including unknown/dot-segment/backslash reject before fetch, 405 before fetch, declared oversized 413, streamed oversized 413 with reader cancel, exact 1 MiB success, and asset-path body reject.
+Path, method, and body policy passed in unit tests and on the PR Preview. Hosted responses were 200 for valid capture, 404 for unknown path, 405 for an unsupported route method, 400 for invalid content type, 413 for a real 1 MiB + 1 byte body, and 403 from the edge method rule for PUT.
 
-Live Vercel rate-threshold test (crossing the published limit by one or two requests) was **not** run. No attack traffic was sent to production.
+A direct public-domain threshold test used 105 harmless HEAD requests to a maintenance-redirected `/ingest` path after a fresh window. It produced exactly 100 HTTP 307 application responses and 5 HTTP 429 edge responses in five seconds. The HEAD probe created no PostHog event and did not follow the application redirect.
 
 ### Result
 
-Source relay is no longer unrestricted. Edge rate-limit and method-deny rules were observed as published. Live threshold enforcement is unproven.
+Source relay is no longer unrestricted. Edge rate-limit and method-deny rules were observed as published and directly enforced at the documented threshold.
 
 ### Implemented Fix
 
@@ -161,15 +185,15 @@ Application-owned constrained proxy plus documented dashboard-managed `/ingest` 
 
 ### Regression Tests
 
-Same ingest-proxy unit suite as Finding 1 (33 passed). Oxlint on changed files and `pnpm check:type` passed in that worker slice.
+Same ingest-proxy and route unit coverage as Finding 1. The final full unit run passed 235 files / 2,334 tests.
 
 ### Residual Risk
 
-Live rate-limit action, preview/production parity, and fail-open behavior are unverified. Rate limiting does not stop accepted PostHog payloads from polluting analytics below the threshold. Hosted path-normalization variants against the edge rule were not exercised.
+Rate limiting does not stop accepted PostHog payloads from polluting analytics below the threshold. Regional fail-open behavior during a Vercel control-plane incident was not induced. Preview WAF enforcement cannot be isolated while Vercel Authentication requires an automation bypass, so direct public production enforcement is the authoritative threshold proof.
 
 ### Final Disposition
 
-**Confirmed — Fixed.** Local source and unit proof only. Live rate-threshold remains an open acceptance gate.
+**Confirmed — Fixed.** Source, Preview behavior, live rule state, and direct threshold enforcement agree.
 
 ## Finding 4: Active-Plan Cap Reactivation
 
@@ -292,25 +316,25 @@ A single huge stream chunk is still allocated by the runtime before `byteLength`
 - Install: Passed (`pnpm install --frozen-lockfile`) at baseline.
 - Typecheck: Passed. Orchestrator reran `pnpm check:full` afterward; `check:type` exit 0. `pnpm check:full` exit 0.
 - Lint: Passed. Same `pnpm check:full` rerun; `check:lint` exit 0.
-- Unit tests: Passed. `pnpm test` exit 0. Unit changed phase: 45 test files passed, 410 tests passed.
-- Integration tests: Passed. `pnpm test` exit 0. Integration changed phase: 52 test files passed, 298 tests passed. Workflow changed phase: 1 test file passed, 4 tests passed. Overall phase runner: Passed: `test:unit:changed` `test:integration:changed`.
-- Preview smoke tests: Deferred — no deployment authorization (normal PostHog, billing, plan creation/retry, and lesson generation not exercised on a preview host)
-- Hosted security tests: Deferred — no deployment authorization (sentinel session-header capture; live Vercel rate-threshold crossing by one or two requests)
+- Unit tests: Passed. The 2026-08-21 full unit rerun passed 235 test files / 2,334 tests after route, proxy-error, and pre-provider persistence coverage was added.
+- Targeted coverage: Passed. The `/ingest` route reached 100% statements/lines (8/8); the focused proxy slice reached 91.21% line coverage; the three security-relevant specs passed 54 tests.
+- Changed tests: Passed. `pnpm test` exit 0: unit 46 files / 421 tests; integration 52 files / 298 tests; workflow 1 file / 4 tests.
+- Preview smoke tests: Passed for the normal unauthenticated app shell and PostHog browser traffic. Real billing transitions, plan mutations, and paid lesson generation were intentionally not performed.
+- Hosted security tests: Passed for credential stripping, valid browser ingestion, path/method/body controls, edge method denial, live rule state, and the 100-per-60-second threshold.
 
-Worker slice targeted results after this delta: parser 35 tests, lifecycle lock 9 tests, and abandoned provider-start cleanup 6 tests passed. Changed-file oxlint, `pnpm exec tsc --noEmit`, and `git diff --check` passed. The orchestrator then reran `pnpm test` (exit 0: unit 45/410, integration 52/298, workflow 1/4) and `pnpm check:full` (exit 0). No hosted preview or deployment was authorized.
+Earlier worker slice results remain valid: parser 35 tests, lifecycle lock 9 tests, and abandoned provider-start cleanup 6 tests passed. Changed-file oxlint, `pnpm exec tsc --noEmit`, and `git diff --check` passed. The final 2026-08-21 lint, type, changed-test, coverage, and pushed-head checks are recorded in PR #530.
 
 ## Remaining Security Work
 
-- Deferred hosted or operational checks:
-  - Controlled hosted sentinel session-header capture for credential stripping
-  - Live Vercel rate-threshold test crossing the published `/ingest` limit by only one or two requests
-  - Preview smoke tests for normal PostHog, billing, plan creation/retry, and lesson generation
-  - Firewall overview inspection (CLI required an IP bypass)
+- Still unverified:
+  - Real Preview billing transitions, plan mutations, and paid lesson generation (excluded to avoid shared-data mutation and provider cost)
+  - Hosted redirect rejection against a prefix-wide redirect receiver; unit regression proof covers the boundary
+  - Firewall overview UI on the current plan; direct live configuration and enforcement evidence replaces it
 - Accepted residual risks:
-  - Hosted proof of Findings 1 and 3 is missing; do not treat production `/ingest` as verified
   - PostHog function IP/UA replaces browser identity on proxied requests
   - `loadSiteApp` arbitrary API URLs are not proxied
   - Analytics pollution via accepted PostHog payloads below the rate threshold
+  - Vercel automation-bypass tokens intentionally bypass ordinary WAF rules and must remain protected credentials
   - JSON parser: one huge stream chunk may allocate before the cap is visible; omitted `maxBytes` remains unbounded
   - Over-cap eligible plans already present remain counted and block new inserts
-- Follow-up issues: None opened. Canonical scan artifacts remain historical and unchanged. Fix commit/PR for local remediations is still pending.
+- Follow-up issues: None opened. Canonical scan artifacts remain historical and unchanged. Remediation and verification are tracked in PR #530.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,6 @@
 import type { NextConfig } from 'next';
 
 import { isHostedDeployEnv } from './src/lib/config/env/shared';
-import { resolvePostHogRewriteDestinations } from './src/lib/posthog-rewrite-destinations';
 import { withSentryConfig } from '@sentry/nextjs';
 import path from 'node:path';
 import { withWorkflow } from 'workflow/next';
@@ -88,29 +87,8 @@ const nextConfig: NextConfig = {
       },
     ];
   },
-  async rewrites() {
-    const { ingestOrigin, assetsOrigin } = resolvePostHogRewriteDestinations(
-      process.env.NEXT_PUBLIC_POSTHOG_HOST,
-    );
-
-    return [
-      // PostHog reverse proxy — routes ingestion through the app to avoid ad-blockers.
-      {
-        source: '/ingest/static/:path*',
-        destination: `${assetsOrigin}/static/:path*`,
-      },
-      {
-        source: '/ingest/array/:path*',
-        destination: `${assetsOrigin}/array/:path*`,
-      },
-      {
-        source: '/ingest/:path*',
-        destination: `${ingestOrigin}/:path*`,
-      },
-    ];
-  },
-  // Required to support PostHog trailing-slash API requests (global; Next cannot scope this to /ingest).
-  // Proxy exact-path policies in middleware-policy.ts slash-normalize pathnames.
+  // Global; Next cannot scope this to /ingest. Required so PostHog's exact
+  // `/e/`, `/s/`, and `/flags/` endpoints are not redirected before the ingest proxy.
   skipTrailingSlashRedirect: true,
 };
 

--- a/src/app/(app)/plans/components/BulkDeletePlansDialog.tsx
+++ b/src/app/(app)/plans/components/BulkDeletePlansDialog.tsx
@@ -26,7 +26,11 @@ const bulkRemovePlanResultSchema = z.discriminatedUnion('success', [
   z.object({
     planId: z.string(),
     success: z.literal(false),
-    reason: z.enum(['not_found', 'currently_generating']),
+    reason: z.enum([
+      'not_found',
+      'currently_generating',
+      'active_child_generation',
+    ]),
     message: z.string(),
   }),
 ]);

--- a/src/app/ingest/[...path]/route.ts
+++ b/src/app/ingest/[...path]/route.ts
@@ -1,0 +1,11 @@
+import { proxyIngestRequest } from '@/lib/posthog/ingest-proxy';
+
+export const dynamic = 'force-dynamic';
+
+export const GET = proxyIngestRequest;
+export const HEAD = proxyIngestRequest;
+export const POST = proxyIngestRequest;
+export const PUT = proxyIngestRequest;
+export const PATCH = proxyIngestRequest;
+export const DELETE = proxyIngestRequest;
+export const OPTIONS = proxyIngestRequest;

--- a/src/features/ai/orchestrator/reservation.ts
+++ b/src/features/ai/orchestrator/reservation.ts
@@ -22,6 +22,10 @@ const RESERVATION_REJECTION_DETAILS: Record<
     classification: 'capped',
     message: () => 'Generation attempt cap reached',
   },
+  plan_limit: {
+    classification: 'capped',
+    message: () => 'Active plan limit reached for this subscription tier',
+  },
   rate_limited: {
     classification: 'rate_limit',
     message: () => 'Generation rate limit exceeded for this user',
@@ -30,6 +34,11 @@ const RESERVATION_REJECTION_DETAILS: Record<
     classification: 'rate_limit',
     message: () =>
       'A generation is already in progress for this plan (concurrent conflict)',
+  },
+  active_child_generation: {
+    classification: 'rate_limit',
+    message: () =>
+      'A module lesson generation is already in progress for this plan (concurrent conflict)',
   },
   invalid_status: {
     classification: 'validation',

--- a/src/features/billing/clerk-billing/reconciliation.ts
+++ b/src/features/billing/clerk-billing/reconciliation.ts
@@ -27,11 +27,14 @@ import { randomUUID } from 'node:crypto';
 
 type ServiceRoleDb = typeof serviceRoleDb;
 type ReconciliationDb = Pick<DbTransaction, 'select' | 'update'>;
+type PayerLockDb = Pick<DbTransaction, 'select' | 'update' | 'execute'>;
 
 type ReconciliationDeps = {
   db?: ReconciliationDb;
   clerkClient?: ClerkBillingClient;
   logger: Logger;
+  payerLockTimeoutMs?: number;
+  payerNetworkTimeoutMs?: number;
 };
 
 type ApplyVerifiedClerkBillingEventDeps = Omit<ReconciliationDeps, 'db'> & {
@@ -50,6 +53,10 @@ type ClerkBillingClient = {
 const DEFAULT_RECONCILIATION_LIMIT = 100;
 const MAX_RECONCILIATION_LIMIT = 100;
 export const CLERK_BILLING_WEBHOOK_LEASE_MS = 2 * 60 * 1000;
+// attempts.ts uses namespace 1 for generation reservations.
+export const CLERK_BILLING_PAYER_LOCK_NAMESPACE = 2;
+export const CLERK_BILLING_PAYER_LOCK_TIMEOUT_MS = 15_000;
+export const CLERK_BILLING_PAYER_NETWORK_TIMEOUT_MS = 10_000;
 
 export type ClerkBillingApplyResult =
   | 'updated'
@@ -82,8 +89,97 @@ export class ClerkWebhookLeaseLostError extends Error {
   }
 }
 
+export class ClerkBillingRefreshTimeoutError extends Error {
+  constructor() {
+    super('Clerk Billing subscription refresh timed out');
+    this.name = 'ClerkBillingRefreshTimeoutError';
+  }
+}
+
 function leaseExpirySql() {
   return sql<Date>`now() + ${CLERK_BILLING_WEBHOOK_LEASE_MS} * interval '1 millisecond'`;
+}
+
+async function withBoundedTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  timeoutError: Error,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(timeoutError), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeout]);
+  } catch (error) {
+    if (error === timeoutError) {
+      void promise.catch(() => undefined);
+    }
+    throw error;
+  } finally {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+function postgresErrorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object') {
+    return undefined;
+  }
+  if ('code' in error && typeof error.code === 'string') {
+    return error.code;
+  }
+  if ('cause' in error) {
+    return postgresErrorCode(error.cause);
+  }
+  return undefined;
+}
+
+async function acquireClerkBillingPayerLock(
+  tx: Pick<DbTransaction, 'execute'>,
+  payerUserId: string,
+  deps: Pick<ReconciliationDeps, 'logger' | 'payerLockTimeoutMs'>,
+): Promise<void> {
+  const timeoutMs = Math.max(
+    1,
+    Math.trunc(deps.payerLockTimeoutMs ?? CLERK_BILLING_PAYER_LOCK_TIMEOUT_MS),
+  );
+
+  await tx.execute(
+    sql`SELECT set_config('lock_timeout', ${`${timeoutMs}ms`}, true)`,
+  );
+
+  try {
+    // Namespace 2: Clerk billing payers. Do not reuse namespace 1 (attempts).
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(
+        ${sql.raw(String(CLERK_BILLING_PAYER_LOCK_NAMESPACE))},
+        hashtext(${payerUserId})
+      )`,
+    );
+  } catch (error) {
+    if (postgresErrorCode(error) === '55P03') {
+      deps.logger.warn(
+        { payerUserId },
+        'Clerk Billing payer lock timed out; retry requested',
+      );
+    }
+    throw error;
+  }
+}
+
+async function lockAndRefreshClerkBillingSource(
+  source: ClerkBillingProjectionSource,
+  deps: ReconciliationDeps & { db: PayerLockDb },
+): Promise<ClerkBillingProjectionSource> {
+  if (source.payerUserId === null) {
+    return source;
+  }
+
+  await acquireClerkBillingPayerLock(deps.db, source.payerUserId, deps);
+  return refreshClerkBillingSource(source, deps);
 }
 
 async function claimClerkWebhookEvent(
@@ -205,6 +301,18 @@ async function finalizeClerkWebhookEvent(
   const db = deps.db ?? serviceRoleDb;
 
   return db.transaction(async (tx) => {
+    let billingSource =
+      args.projectionSource?.kind === 'billing'
+        ? args.projectionSource.source
+        : null;
+
+    if (billingSource !== null && billingSource.payerUserId !== null) {
+      billingSource = await lockAndRefreshClerkBillingSource(billingSource, {
+        ...deps,
+        db: tx,
+      });
+    }
+
     const [ownedClaim] = await tx
       .delete(clerkWebhookEventClaims)
       .where(
@@ -251,7 +359,7 @@ async function finalizeClerkWebhookEvent(
 
     if (args.projectionSource.kind === 'billing') {
       const result = await applyClerkBillingSource(
-        args.projectionSource.source,
+        billingSource ?? args.projectionSource.source,
         {
           ...deps,
           db: tx,
@@ -293,9 +401,30 @@ async function refreshClerkBillingSource(
   }
 
   const client = deps.clerkClient ?? (await getClerkClient());
-  const subscription = await client.billing.getUserBillingSubscription(
-    source.payerUserId,
+  const timeoutError = new ClerkBillingRefreshTimeoutError();
+  const timeoutMs = Math.max(
+    1,
+    Math.trunc(
+      deps.payerNetworkTimeoutMs ?? CLERK_BILLING_PAYER_NETWORK_TIMEOUT_MS,
+    ),
   );
+
+  let subscription: BackendBillingSubscription;
+  try {
+    subscription = await withBoundedTimeout(
+      client.billing.getUserBillingSubscription(source.payerUserId),
+      timeoutMs,
+      timeoutError,
+    );
+  } catch (error) {
+    if (error === timeoutError) {
+      deps.logger.warn(
+        { payerUserId: source.payerUserId },
+        'Clerk Billing subscription refresh timed out; retry requested',
+      );
+    }
+    throw error;
+  }
   const refreshedSource =
     clerkBillingSourceFromBackendSubscription(subscription);
 
@@ -308,6 +437,10 @@ async function refreshClerkBillingSource(
   };
 }
 
+/**
+ * Applies a prepared billing projection. Production webhook and
+ * reconciliation callers must hold the payer xact lock first.
+ */
 export async function applyClerkBillingSource(
   source: ClerkBillingProjectionSource,
   deps: ReconciliationDeps,
@@ -402,7 +535,7 @@ export async function applyVerifiedClerkBillingEvent(
     const projectionSource: ClerkWebhookProjectionSource | null = billingSource
       ? {
           kind: 'billing',
-          source: await refreshClerkBillingSource(billingSource, deps),
+          source: billingSource,
         }
       : userSource
         ? { kind: 'user', source: userSource }
@@ -441,8 +574,11 @@ export async function reconcileClerkBillingEntitlements({
   db = serviceRoleDb,
   limit = DEFAULT_RECONCILIATION_LIMIT,
   logger,
+  payerLockTimeoutMs,
+  payerNetworkTimeoutMs,
   startingAfterAuthUserId,
-}: ReconciliationDeps & {
+}: Omit<ReconciliationDeps, 'db'> & {
+  db?: ServiceRoleDb;
   limit?: number;
   startingAfterAuthUserId?: string;
 }): Promise<{
@@ -492,16 +628,25 @@ export async function reconcileClerkBillingEntitlements({
     totals.checked += 1;
 
     try {
-      const subscription = await client.billing.getUserBillingSubscription(
-        localUser.authUserId,
-      );
-      const result = await applyClerkBillingSource(
-        {
-          ...clerkBillingSourceFromBackendSubscription(subscription),
-          payerUserId: localUser.authUserId,
-        },
-        { db, logger },
-      );
+      const result = await db.transaction(async (tx) => {
+        const source = await lockAndRefreshClerkBillingSource(
+          {
+            type: 'reconciliation',
+            payerUserId: localUser.authUserId,
+            subscriptionStatus: null,
+            paymentAttemptStatus: null,
+            items: [],
+          },
+          {
+            clerkClient: client,
+            db: tx,
+            logger,
+            payerLockTimeoutMs,
+            payerNetworkTimeoutMs,
+          },
+        );
+        return applyClerkBillingSource(source, { db: tx, logger });
+      });
 
       if (result === 'skipped_no_payer' || result === 'skipped_no_user') {
         totals.skipped += 1;

--- a/src/features/lesson-content/run-module-lesson-generation-work.ts
+++ b/src/features/lesson-content/run-module-lesson-generation-work.ts
@@ -27,12 +27,15 @@ import { parseModuleLessonBatchFromStream } from '@/features/lesson-content/pars
 import {
   commitModuleLessonBatchSuccess,
   commitModuleLessonGenerationFailure,
+  markModuleLessonProviderStarted,
   revertModuleLessonGeneratingToNotGenerated,
 } from '@/lib/db/queries/module-lesson-generation';
 import { logger } from '@/lib/logging/logger';
 import { db as serviceRoleDb } from '@supabase/service-role';
 
-type LessonQuotaConsumed = { durationMs: number };
+type LessonQuotaConsumed =
+  | { kind: 'success'; durationMs: number }
+  | { kind: 'provider_started_failure' };
 type LessonQuotaReverted = { kind: 'failed' };
 
 /**
@@ -122,6 +125,7 @@ export async function runModuleLessonGenerationWork(
       > => {
         const attemptClockStart = clock();
         let lifecycle: ReturnType<typeof setupAbortAndTimeout> | undefined;
+        let providerStarted = false;
 
         try {
           const provider =
@@ -139,6 +143,14 @@ export async function runModuleLessonGenerationWork(
             userPrompt,
             taskIds: expectedTaskIds,
           };
+
+          await markModuleLessonProviderStarted(serverDbClient, {
+            userId: params.userId,
+            planId: params.planId,
+            moduleId: params.moduleId,
+            providerStartedAt: nowFn().toISOString(),
+          });
+          providerStarted = true;
 
           const providerResult =
             await generateModuleLessonBatchWithInstrumentation(
@@ -172,6 +184,7 @@ export async function runModuleLessonGenerationWork(
           return {
             disposition: 'consumed',
             value: {
+              kind: 'success',
               durationMs: Math.max(0, clock() - attemptClockStart),
             },
           };
@@ -197,7 +210,16 @@ export async function runModuleLessonGenerationWork(
               },
               'Failed to persist module lesson generation failure state',
             );
-            throw persistErr;
+            if (!providerStarted) {
+              throw persistErr;
+            }
+          }
+
+          if (providerStarted) {
+            return {
+              disposition: 'consumed',
+              value: { kind: 'provider_started_failure' },
+            };
           }
 
           return {
@@ -270,7 +292,10 @@ export async function runModuleLessonGenerationWork(
   }
 
   if (quotaResult.consumed) {
-    return { kind: 'success', durationMs: quotaResult.value.durationMs };
+    if (quotaResult.value.kind === 'success') {
+      return { kind: 'success', durationMs: quotaResult.value.durationMs };
+    }
+    return { kind: 'failed' };
   }
 
   if (quotaResult.reconciliationRequired) {

--- a/src/features/plans/cleanup.ts
+++ b/src/features/plans/cleanup.ts
@@ -4,9 +4,11 @@ import { and, eq, inArray, isNull, lt } from 'drizzle-orm';
 import type { DbClient } from '@/lib/db/types';
 
 import { markPlanGenerationFailuresInTx } from '@/features/plans/lifecycle/plan-persistence-store';
+import { lockPlanLifecycle } from '@/lib/db/queries/helpers/plan-lifecycle-lock';
 import { logger } from '@/lib/logging/logger';
-import { generationAttempts, learningPlans } from '@supabase/schema';
+import { generationAttempts, learningPlans, modules } from '@supabase/schema';
 import { db as serviceRoleDb } from '@supabase/service-role';
+import { sql } from 'drizzle-orm';
 
 /** Plans stuck in 'generating' longer than this are considered abandoned. */
 export const STUCK_PLAN_THRESHOLD_MS = 15 * 60 * 1000; // 15 minutes
@@ -25,6 +27,17 @@ export const ORPHANED_ATTEMPT_THRESHOLD_MS = 15 * 60 * 1000; // 15 minutes
  * each maintenance transaction stays bounded.
  */
 export const ORPHANED_ATTEMPT_CLEANUP_BATCH_SIZE = 1000;
+
+/** Module lesson generations with a durable provider-start marker use the same maintenance window. */
+export const ORPHANED_MODULE_LESSON_GENERATION_THRESHOLD_MS =
+  ORPHANED_ATTEMPT_THRESHOLD_MS;
+
+/** Keep provider-started module reconciliation bounded like the existing cleanup batches. */
+export const ORPHANED_MODULE_LESSON_GENERATION_CLEANUP_BATCH_SIZE =
+  ORPHANED_ATTEMPT_CLEANUP_BATCH_SIZE;
+
+export const ABANDONED_MODULE_LESSON_GENERATION_ERROR =
+  'Provider-started lesson generation was interrupted; retry required.';
 
 /**
  * Marks plans stuck in 'generating' status for longer than the threshold as 'failed'.
@@ -196,6 +209,113 @@ export async function cleanupOrphanedAttempts(
   });
 }
 
+type CleanupAbandonedModuleLessonGenerationsDependencies = {
+  batchSize?: number;
+};
+
+/**
+ * Settles stale module work that durably crossed the provider boundary before a
+ * worker disappeared. This only changes the module lifecycle state; it never
+ * compensates lesson-generation usage. A later retry must reserve a new slot.
+ */
+export async function cleanupAbandonedModuleLessonGenerations(
+  dbClient: DbClient,
+  thresholdMs: number = ORPHANED_MODULE_LESSON_GENERATION_THRESHOLD_MS,
+  deps: CleanupAbandonedModuleLessonGenerationsDependencies = {},
+): Promise<{ cleaned: number }> {
+  const cutoff = new Date(Date.now() - thresholdMs);
+  const batchSize =
+    deps.batchSize ?? ORPHANED_MODULE_LESSON_GENERATION_CLEANUP_BATCH_SIZE;
+  const providerStarted = sql`${modules.lessonGenerationMetadata}->>'providerStartedAt' IS NOT NULL`;
+  const staleProviderStarted = and(
+    eq(modules.lessonGenerationStatus, 'generating'),
+    lt(modules.lessonGenerationStartedAt, cutoff),
+    providerStarted,
+  );
+
+  return dbClient.transaction(async (tx) => {
+    // Lock the shared plan lifecycle key before locking module rows so cleanup
+    // cannot race child claims, parent deletion, or parent replacement.
+    const candidatePlans = await tx
+      .select({ planId: modules.planId })
+      .from(modules)
+      .where(staleProviderStarted)
+      .limit(batchSize);
+    const planIds = [
+      ...new Set(candidatePlans.map((row) => row.planId)),
+    ].sort();
+
+    for (const planId of planIds) {
+      await lockPlanLifecycle(tx, planId);
+    }
+
+    if (planIds.length === 0) {
+      return { cleaned: 0 };
+    }
+
+    const abandonedModules = await tx
+      .select({ id: modules.id })
+      .from(modules)
+      .where(and(staleProviderStarted, inArray(modules.planId, planIds)))
+      .limit(batchSize)
+      .for('update');
+
+    if (abandonedModules.length === 0) {
+      return { cleaned: 0 };
+    }
+
+    const abandonedModuleIds = abandonedModules.map((module) => module.id);
+    const failedAt = new Date();
+    const result = await tx
+      .update(modules)
+      .set({
+        lessonGenerationStatus: 'failed',
+        lessonGenerationFailedAt: failedAt,
+        lessonGenerationCompletedAt: null,
+        lessonGenerationError: ABANDONED_MODULE_LESSON_GENERATION_ERROR,
+      })
+      .where(and(inArray(modules.id, abandonedModuleIds), staleProviderStarted))
+      .returning({ id: modules.id });
+
+    if (result.length !== abandonedModuleIds.length) {
+      logger.error(
+        {
+          source: 'cleanup',
+          event: 'abandoned_module_lesson_generation_cleanup_partial_failure',
+          expected: abandonedModuleIds.length,
+          cleaned: result.length,
+        },
+        'Plan cleanup failed to settle all abandoned provider-started module generations',
+      );
+      throw new Error(
+        'Plan cleanup failed to settle all abandoned provider-started module generations',
+      );
+    }
+
+    logger.info(
+      {
+        source: 'cleanup',
+        event: 'abandoned_module_lesson_generations_cleaned',
+        count: result.length,
+      },
+      `Settled ${result.length} abandoned provider-started module generation(s)`,
+    );
+
+    if (result.length === batchSize) {
+      logger.warn(
+        {
+          source: 'cleanup',
+          event: 'abandoned_module_lesson_generation_cleanup_batch_full',
+          batchSize,
+        },
+        'Plan cleanup filled its abandoned module-generation batch; backlog may remain',
+      );
+    }
+
+    return { cleaned: result.length };
+  });
+}
+
 /**
  * Service-role entrypoint for the internal plan cleanup maintenance route.
  */
@@ -205,6 +325,7 @@ export async function runPlanCleanupMaintenance(): Promise<{
 }> {
   const stuckPlans = await cleanupStuckPlans(serviceRoleDb);
   const orphanedAttempts = await cleanupOrphanedAttempts(serviceRoleDb);
+  await cleanupAbandonedModuleLessonGenerations(serviceRoleDb);
 
   return {
     stuckPlansCleaned: stuckPlans.cleaned,

--- a/src/features/plans/lifecycle/plan-persistence-store.ts
+++ b/src/features/plans/lifecycle/plan-persistence-store.ts
@@ -9,12 +9,15 @@ import type { PlanGenerationCoreFields } from '@/shared/types/ai-provider.types'
 import { getGenerationAttemptCap } from '@/features/ai/generation-policy';
 import { selectUserSubscriptionTierForUpdate } from '@/features/billing/metered-reservation';
 import { PlanCreationError } from '@/features/plans/errors';
-import { countPlansContributingToCap } from '@/features/plans/quota/check-plan-limit';
-import { PLAN_GENERATING_INSERT_DEFAULTS } from '@/lib/db/queries/helpers/plan-generation-status';
+import {
+  countPlansContributingToCap,
+  lockUserPlanAdmission,
+  PLAN_GENERATING_INSERT_DEFAULTS,
+} from '@/lib/db/queries/helpers/plan-generation-status';
 import { logger } from '@/lib/logging/logger';
 import { TIER_LIMITS } from '@/shared/constants/tier-limits';
 import { generationAttempts, learningPlans, modules } from '@supabase/schema';
-import { and, count, eq, gte, inArray, notExists, sql } from 'drizzle-orm';
+import { and, count, eq, gte, inArray, notExists, or, sql } from 'drizzle-orm';
 
 /** Window (in seconds) for detecting duplicate plan submissions. */
 const DUPLICATE_DETECTION_WINDOW_SECONDS = 60;
@@ -27,6 +30,7 @@ async function updatePlanGenerationSuccess(
   planId: string,
   timestamp: Date,
 ): Promise<number> {
+  // Eligibility may flip false→true only when the plan already owns a cap slot.
   const updated = await dbClient
     .update(learningPlans)
     .set({
@@ -35,7 +39,15 @@ async function updatePlanGenerationSuccess(
       finalizedAt: timestamp,
       updatedAt: timestamp,
     })
-    .where(eq(learningPlans.id, planId))
+    .where(
+      and(
+        eq(learningPlans.id, planId),
+        or(
+          eq(learningPlans.isQuotaEligible, true),
+          eq(learningPlans.generationStatus, 'generating'),
+        ),
+      ),
+    )
     .returning({ id: learningPlans.id });
 
   return updated.length;
@@ -81,8 +93,14 @@ export async function markPlanGenerationFailureInTx(
   }
 }
 
-export async function markPlanGenerationFailuresInTx(
-  tx: PlanUpdateTx,
+/**
+ * Failure policy after reservation / generation:
+ * - Last-good (`isQuotaEligible=true`): restore `ready`, keep eligible, leave modules.
+ * - Never-usable (`isQuotaEligible=false`): mark `failed`, stay ineligible (releases
+ *   a generating reservation). Attempt/job rows record the failure separately.
+ */
+async function applyPlanGenerationFailureUpdate(
+  dbClient: PlanWriteClient | PlanUpdateTx,
   planIds: readonly string[],
   timestamp: Date,
 ): Promise<number> {
@@ -90,17 +108,24 @@ export async function markPlanGenerationFailuresInTx(
     return 0;
   }
 
-  const updated = await tx
+  const updated = await dbClient
     .update(learningPlans)
     .set({
-      generationStatus: 'failed',
-      isQuotaEligible: false,
+      generationStatus: sql`CASE WHEN ${learningPlans.isQuotaEligible} THEN 'ready'::generation_status ELSE 'failed'::generation_status END`,
       updatedAt: timestamp,
     })
     .where(inArray(learningPlans.id, planIds))
     .returning({ id: learningPlans.id });
 
   return updated.length;
+}
+
+export async function markPlanGenerationFailuresInTx(
+  tx: PlanUpdateTx,
+  planIds: readonly string[],
+  timestamp: Date,
+): Promise<number> {
+  return applyPlanGenerationFailureUpdate(tx, planIds, timestamp);
 }
 
 export async function atomicCheckAndInsertPlan(
@@ -112,6 +137,7 @@ export async function atomicCheckAndInsertPlan(
   dbClient: DbClient,
 ): Promise<AtomicInsertResult> {
   return dbClient.transaction(async (tx) => {
+    await lockUserPlanAdmission(tx, userId);
     const user = await selectUserSubscriptionTierForUpdate(tx, userId);
 
     const windowStart = new Date(
@@ -193,17 +219,13 @@ export async function markPlanGenerationFailure(
 ): Promise<void> {
   const timestamp = now();
 
-  const updated = await dbClient
-    .update(learningPlans)
-    .set({
-      generationStatus: 'failed',
-      isQuotaEligible: false,
-      updatedAt: timestamp,
-    })
-    .where(eq(learningPlans.id, planId))
-    .returning({ id: learningPlans.id });
+  const updatedCount = await applyPlanGenerationFailureUpdate(
+    dbClient,
+    [planId],
+    timestamp,
+  );
 
-  if (updated.length === 0) {
+  if (updatedCount === 0) {
     logger.warn(
       { planId },
       'markPlanGenerationFailure: no rows updated — plan may have been deleted',

--- a/src/features/plans/lifecycle/service.ts
+++ b/src/features/plans/lifecycle/service.ts
@@ -170,7 +170,11 @@ function shouldMarkPlanFailedAfterGenerationFailure(
   result: Extract<GenerationRunResult, { status: 'failure' }>,
 ): boolean {
   const reason = result.reservationRejectionReason;
-  return reason !== 'in_progress' && reason !== 'invalid_status';
+  return (
+    reason !== 'in_progress' &&
+    reason !== 'invalid_status' &&
+    reason !== 'active_child_generation'
+  );
 }
 
 function deterministicCompletedAt(startedAt: Date, durationMs: number): string {

--- a/src/features/plans/quota/check-plan-limit.ts
+++ b/src/features/plans/quota/check-plan-limit.ts
@@ -5,39 +5,10 @@
 import type { DbClient } from '@/lib/db/types';
 
 import { resolveUserTier } from '@/features/billing/tier';
+import { countPlansContributingToCap } from '@/lib/db/queries/helpers/plan-generation-status';
 import { TIER_LIMITS } from '@/shared/constants/tier-limits';
-import { learningPlans } from '@supabase/schema';
-import { eq, sql } from 'drizzle-orm';
 
-/**
- * Count plans that consume the user's plan quota (eligible + in-flight generating).
- * Accepts a DB handle or transaction for atomic check-and-insert.
- */
-export async function countPlansContributingToCap(
-  dbOrTx: Pick<DbClient, 'select'>,
-  userId: string,
-): Promise<number> {
-  const [result] = await dbOrTx
-    .select({
-      count: sql`
-        (
-          count(*) FILTER (WHERE ${learningPlans.isQuotaEligible} = true)
-          +
-          count(*) FILTER (
-            WHERE ${learningPlans.generationStatus} = 'generating'
-              AND ${learningPlans.isQuotaEligible} = false
-          )
-        )::int
-      `,
-    })
-    .from(learningPlans)
-    .where(eq(learningPlans.userId, userId));
-
-  const raw = result?.count;
-  if (raw == null) return 0;
-  const parsed = Number(raw);
-  return Number.isFinite(parsed) ? parsed : 0;
-}
+export { countPlansContributingToCap };
 
 export async function checkPlanLimit(
   userId: string,

--- a/src/features/plans/write-service/index.ts
+++ b/src/features/plans/write-service/index.ts
@@ -2,7 +2,10 @@ import { ConflictError, NotFoundError } from '@/lib/api/errors';
 import { deletePlan, type DeletePlanDbClient } from '@/lib/db/queries/plans';
 import { db as serviceRoleDb } from '@supabase/service-role';
 
-export type BulkRemovePlanFailureReason = 'not_found' | 'currently_generating';
+export type BulkRemovePlanFailureReason =
+  | 'not_found'
+  | 'currently_generating'
+  | 'active_child_generation';
 
 export type BulkRemovePlanResult =
   | { planId: string; success: true }
@@ -19,6 +22,8 @@ const REMOVE_PLAN_FAILURE_MESSAGES: Record<
 > = {
   not_found: 'Learning plan not found.',
   currently_generating: 'Cannot delete a plan that is currently generating.',
+  active_child_generation:
+    'Cannot delete a plan while a module lesson is generating.',
 };
 
 /**
@@ -39,7 +44,7 @@ export async function removePlanForWrite(params: {
     throw new NotFoundError(REMOVE_PLAN_FAILURE_MESSAGES.not_found);
   }
 
-  throw new ConflictError(REMOVE_PLAN_FAILURE_MESSAGES.currently_generating);
+  throw new ConflictError(REMOVE_PLAN_FAILURE_MESSAGES[result.reason]);
 }
 
 async function removePlanForBulkWrite(params: {

--- a/src/lib/db/queries/attempts.ts
+++ b/src/lib/db/queries/attempts.ts
@@ -25,8 +25,17 @@ import {
   computeRetryAfterSeconds,
   selectUserGenerationAttemptWindowStats,
 } from '@/lib/db/queries/helpers/attempts-rate-limit';
-import { setLearningPlanGenerating } from '@/lib/db/queries/helpers/plan-generation-status';
-import { selectOwnedPlanById } from '@/lib/db/queries/helpers/plans-helpers';
+import {
+  countPlansContributingToCap,
+  lockUserPlanAdmission,
+  planOwnsActiveCapSlot,
+  setLearningPlanGenerating,
+} from '@/lib/db/queries/helpers/plan-generation-status';
+import {
+  hasActiveChildModuleGeneration,
+  lockPlanLifecycle,
+} from '@/lib/db/queries/helpers/plan-lifecycle-lock';
+import { lockOwnedPlanById } from '@/lib/db/queries/helpers/plans-helpers';
 import {
   prepareRlsTransactionContext,
   reapplyJwtClaimsInTransaction,
@@ -36,7 +45,8 @@ import {
   getPlanGenerationWindowStart,
   PLAN_GENERATION_LIMIT,
 } from '@/shared/constants/generation';
-import { generationAttempts } from '@supabase/schema';
+import { TIER_LIMITS } from '@/shared/constants/tier-limits';
+import { generationAttempts, users } from '@supabase/schema';
 import { count, eq, sql } from 'drizzle-orm';
 import { createHash } from 'node:crypto';
 
@@ -53,12 +63,15 @@ import { createHash } from 'node:crypto';
 /**
  * Atomically reserves an attempt slot for a plan within a single transaction.
  *
- * 1. Acquires a transaction-scoped advisory lock per user to serialize concurrent reservations.
- * 2. Reads the owned plan row and verifies ownership.
- * 3. Enforces durable per-user window limit.
- * 4. Enforces per-plan attempt cap and rejects in-progress duplicates.
- * 5. Inserts a placeholder attempt with status 'in_progress'.
- * 6. Sets the plan's generation_status to 'generating'.
+ * 1. Acquires namespace-1 per-user admission lock, then namespace-3 plan lifecycle lock.
+ * 2. Locks and re-reads the owned plan row.
+ * 3. Rejects when an owned module is still `lessonGenerationStatus = 'generating'`.
+ * 4. Enforces the active-plan cap when the target does not already own a slot.
+ * 5. Enforces durable per-user window limit.
+ * 6. Enforces per-plan attempt cap and rejects in-progress duplicates.
+ * 7. Inserts a placeholder attempt with status 'in_progress'.
+ * 8. Sets the plan's generation_status to 'generating' (durable cap reservation
+ *    when the plan was ineligible).
  *
  * @returns AttemptReservation on success, AttemptRejection with reason on rejection.
  */
@@ -88,13 +101,10 @@ export async function reserveAttemptSlot(
     const startedAt = nowFn();
     await reapplyJwtClaimsInTransaction(tx, rlsCtx);
 
-    // Acquire per-user advisory lock to serialize concurrent reservations.
-    // Uses the two-int4 overload so namespace 1 is separated from the
-    // per-user key, avoiding cross-domain collisions that the single-bigint
-    // form (hashtext → bigint) would allow with only 32-bit entropy.
-    await tx.execute(sql`SELECT pg_advisory_xact_lock(1, hashtext(${userId}))`);
+    await lockUserPlanAdmission(tx, userId);
+    await lockPlanLifecycle(tx, planId);
 
-    const plan = await selectOwnedPlanById({
+    const plan = await lockOwnedPlanById({
       planId,
       ownerUserId: userId,
       dbClient: tx,
@@ -124,6 +134,32 @@ export async function reserveAttemptSlot(
         reason: 'invalid_status',
         currentStatus: plan.generationStatus,
       } as const;
+    }
+
+    if (await hasActiveChildModuleGeneration(tx, planId)) {
+      return { reserved: false, reason: 'active_child_generation' } as const;
+    }
+
+    if (!planOwnsActiveCapSlot(plan)) {
+      const [user] = await tx
+        .select({ subscriptionTier: users.subscriptionTier })
+        .from(users)
+        .where(eq(users.id, userId))
+        .limit(1);
+      if (!user) {
+        throw new Error('Learning plan not found or inaccessible for user');
+      }
+      const tierConfig = TIER_LIMITS[user.subscriptionTier];
+      if (!tierConfig) {
+        throw new Error(`Unknown subscription tier: ${user.subscriptionTier}`);
+      }
+      const limit = tierConfig.maxActivePlans;
+      if (limit !== Infinity) {
+        const currentCount = await countPlansContributingToCap(tx, userId);
+        if (currentCount >= limit) {
+          return { reserved: false, reason: 'plan_limit' } as const;
+        }
+      }
     }
 
     const windowStart = getPlanGenerationWindowStart(startedAt);

--- a/src/lib/db/queries/helpers/attempts-persistence-success.ts
+++ b/src/lib/db/queries/helpers/attempts-persistence-success.ts
@@ -8,6 +8,10 @@ import type {
 import type { DbTransaction } from '@/lib/db/types';
 
 import {
+  hasActiveChildModuleGeneration,
+  lockPlanLifecycle,
+} from '@/lib/db/queries/helpers/plan-lifecycle-lock';
+import {
   prepareRlsTransactionContext,
   reapplyJwtClaimsInTransaction,
 } from '@/lib/db/queries/helpers/rls-jwt-claims';
@@ -63,6 +67,13 @@ export async function persistSuccessfulAttemptInTx(
     durationMs,
     metadata,
   } = params;
+
+  await lockPlanLifecycle(tx, planId);
+  if (await hasActiveChildModuleGeneration(tx, planId)) {
+    throw new Error(
+      `Cannot persist successful generation for plan ${planId}: active child module lesson generation is in progress.`,
+    );
+  }
 
   await tx.delete(modules).where(eq(modules.planId, planId));
 

--- a/src/lib/db/queries/helpers/plan-generation-status.ts
+++ b/src/lib/db/queries/helpers/plan-generation-status.ts
@@ -1,9 +1,14 @@
-import type { DbClient } from '@/lib/db/types';
+import type { DbClient, DbTransaction } from '@/lib/db/types';
 
 import { learningPlans } from '@supabase/schema';
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 
 type LearningPlanInsert = typeof learningPlans.$inferInsert;
+
+export type PlanCapSlotState = {
+  readonly isQuotaEligible: boolean;
+  readonly generationStatus: LearningPlanInsert['generationStatus'];
+};
 
 // ─── Shared insert defaults ─────────────────────────────────────
 
@@ -12,7 +17,8 @@ type LearningPlanInsert = typeof learningPlans.$inferInsert;
  * state for the first time (INSERT in {@link atomicCheckAndInsertPlan}).
  *
  * `isQuotaEligible` starts as `false` and flips to `true` only after
- * generation succeeds ({@link markPlanGenerationSuccess}).
+ * generation succeeds for a plan that already owns a cap reservation
+ * ({@link markPlanGenerationSuccess}).
  */
 export const PLAN_GENERATING_INSERT_DEFAULTS = {
   generationStatus: 'generating',
@@ -21,6 +27,55 @@ export const PLAN_GENERATING_INSERT_DEFAULTS = {
   LearningPlanInsert,
   'generationStatus' | 'isQuotaEligible'
 >;
+
+/**
+ * Per-user admission lock shared by new-plan insert and attempt reservation.
+ * Namespace `1` matches `reserveAttemptSlot`.
+ */
+export async function lockUserPlanAdmission(
+  tx: Pick<DbTransaction, 'execute'>,
+  userId: string,
+): Promise<void> {
+  await tx.execute(sql`SELECT pg_advisory_xact_lock(1, hashtext(${userId}))`);
+}
+
+/**
+ * Count plans that consume the user's plan quota (eligible + in-flight generating).
+ * Accepts a DB handle or transaction for atomic check-and-insert.
+ */
+export async function countPlansContributingToCap(
+  dbOrTx: Pick<DbClient, 'select'>,
+  userId: string,
+): Promise<number> {
+  const [result] = await dbOrTx
+    .select({
+      count: sql`
+        (
+          count(*) FILTER (WHERE ${learningPlans.isQuotaEligible} = true)
+          +
+          count(*) FILTER (
+            WHERE ${learningPlans.generationStatus} = 'generating'
+              AND ${learningPlans.isQuotaEligible} = false
+          )
+        )::int
+      `,
+    })
+    .from(learningPlans)
+    .where(eq(learningPlans.userId, userId));
+
+  const raw = result?.count;
+  if (raw == null) return 0;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/**
+ * Eligible plans already occupy a cap slot. `generating` + ineligible is the
+ * durable pending reservation created by insert or retry admission.
+ */
+export function planOwnsActiveCapSlot(plan: PlanCapSlotState): boolean {
+  return plan.isQuotaEligible || plan.generationStatus === 'generating';
+}
 
 // ─── UPDATE helper ──────────────────────────────────────────────
 
@@ -31,8 +86,8 @@ type PlanStatusUpdateClient = Pick<DbClient, 'update'>;
  *
  * Called from {@link reserveAttemptSlot} inside its advisory-lock
  * transaction. On the first creation attempt this is idempotent (plan is
- * already `generating` from the INSERT). On retries it transitions from
- * `failed` / `pending_retry` → `generating`.
+ * already `generating` from the INSERT). On retries of ineligible plans it
+ * is the durable cap reservation (`generating` + `isQuotaEligible=false`).
  *
  * Only touches `generationStatus` and `updatedAt` — callers retain full
  * control of transaction boundaries, advisory locks, and JWT claim

--- a/src/lib/db/queries/helpers/plan-lifecycle-lock.ts
+++ b/src/lib/db/queries/helpers/plan-lifecycle-lock.ts
@@ -1,0 +1,38 @@
+import type { DbClient, DbTransaction } from '@/lib/db/types';
+
+import { modules } from '@supabase/schema';
+import { and, eq, sql } from 'drizzle-orm';
+
+/** Namespace `3`: plan lifecycle (claim, reservation, success persist, delete). */
+export const PLAN_LIFECYCLE_LOCK_NAMESPACE = 3;
+const PLAN_LIFECYCLE_LOCK_TIMEOUT_MS = 15_000;
+
+export async function lockPlanLifecycle(
+  tx: Pick<DbTransaction, 'execute'>,
+  planId: string,
+): Promise<void> {
+  await tx.execute(
+    sql`SELECT set_config('lock_timeout', ${`${PLAN_LIFECYCLE_LOCK_TIMEOUT_MS}ms`}, true)`,
+  );
+  await tx.execute(
+    sql`SELECT pg_advisory_xact_lock(${sql.raw(String(PLAN_LIFECYCLE_LOCK_NAMESPACE))}, hashtext(${planId}))`,
+  );
+}
+
+export async function hasActiveChildModuleGeneration(
+  dbOrTx: Pick<DbClient, 'select'>,
+  planId: string,
+): Promise<boolean> {
+  const [row] = await dbOrTx
+    .select({ id: modules.id })
+    .from(modules)
+    .where(
+      and(
+        eq(modules.planId, planId),
+        eq(modules.lessonGenerationStatus, 'generating'),
+      ),
+    )
+    .limit(1);
+
+  return row != null;
+}

--- a/src/lib/db/queries/helpers/plans-helpers.ts
+++ b/src/lib/db/queries/helpers/plans-helpers.ts
@@ -10,6 +10,7 @@ interface LockedOwnedPlanRecord {
   id: string;
   userId: string;
   generationStatus: OwnedPlanRecord['generationStatus'];
+  isQuotaEligible: boolean;
 }
 
 interface OwnedPlanQueryParams {
@@ -70,6 +71,7 @@ export async function lockOwnedPlanById({
       id: learningPlans.id,
       userId: learningPlans.userId,
       generationStatus: learningPlans.generationStatus,
+      isQuotaEligible: learningPlans.isQuotaEligible,
     })
     .from(learningPlans)
     .where(ownedPlanWhere(planId, ownerUserId))

--- a/src/lib/db/queries/module-lesson-generation.ts
+++ b/src/lib/db/queries/module-lesson-generation.ts
@@ -9,6 +9,7 @@ import {
   canonicalUsageToRecordParams,
   recordUsageInTx,
 } from '../../../../supabase/usage';
+import { lockPlanLifecycle } from '@/lib/db/queries/helpers/plan-lifecycle-lock';
 import {
   prepareRlsTransactionContext,
   reapplyJwtClaimsInTransaction,
@@ -231,6 +232,45 @@ export async function revertModuleLessonGeneratingToNotGenerated(
     );
 }
 
+/**
+ * CAS: merge `providerStartedAt` into owned module JSON metadata while status
+ * is `generating`. Throws unless exactly one row matches.
+ */
+export async function markModuleLessonProviderStarted(
+  dbClient: GenerationDb,
+  args: {
+    readonly userId: string;
+    readonly planId: string;
+    readonly moduleId: string;
+    readonly providerStartedAt: string;
+  },
+): Promise<void> {
+  const updated = await dbClient
+    .update(modules)
+    .set({
+      lessonGenerationMetadata: sql`jsonb_set(
+        coalesce(${modules.lessonGenerationMetadata}, '{"version":1}'::jsonb),
+        '{providerStartedAt}',
+        to_jsonb(${args.providerStartedAt}::text)
+      )`,
+    })
+    .where(
+      and(
+        eq(modules.id, args.moduleId),
+        eq(modules.planId, args.planId),
+        eq(modules.lessonGenerationStatus, 'generating'),
+        moduleOwnedByUser(args.userId),
+      ),
+    )
+    .returning({ id: modules.id });
+
+  if (updated.length !== 1) {
+    throw new Error(
+      'Module lesson generation provider-start marker did not match exactly one row',
+    );
+  }
+}
+
 async function readScopedModuleState(
   dbClient: GenerationDb,
   planId: string,
@@ -284,6 +324,7 @@ function classifyModuleLessonGenerationClaimState(
 /**
  * CAS: `not_generated` | `failed` → `generating` for an owned module row.
  * Surfaces `already_ready`, `in_flight`, and `not_found` without mutating.
+ * Requires an owned parent plan with `generationStatus = 'ready'`.
  */
 export async function claimModuleLessonGenerationOrDescribe(
   dbClient: GenerationDb,
@@ -309,47 +350,73 @@ export async function claimModuleLessonGenerationOrDescribe(
   const claimStartedAt = options?.workflow
     ? new Date(options.workflow.startedAt)
     : now();
-  const attemptClaim = async (): Promise<boolean> => {
-    const touched = await dbClient
-      .update(modules)
-      .set({
-        lessonGenerationStatus: 'generating',
-        lessonGenerationStartedAt: claimStartedAt,
-        lessonGenerationCompletedAt: null,
-        lessonGenerationFailedAt: null,
-        lessonGenerationError: null,
-        ...(workflowMetadata
-          ? { lessonGenerationMetadata: workflowMetadata }
-          : {}),
-      })
+
+  const rlsCtx = await prepareRlsTransactionContext(dbClient);
+
+  return dbClient.transaction(async (tx) => {
+    await reapplyJwtClaimsInTransaction(tx, rlsCtx);
+    await lockPlanLifecycle(tx, planId);
+
+    const [parent] = await tx
+      .select({ generationStatus: learningPlans.generationStatus })
+      .from(learningPlans)
       .where(
-        and(
-          eq(modules.id, moduleId),
-          eq(modules.planId, planId),
-          inArray(modules.lessonGenerationStatus, [...claimableStatuses]),
-          moduleOwnedByUser(userId),
-        ),
+        and(eq(learningPlans.id, planId), eq(learningPlans.userId, userId)),
       )
-      .returning({ id: modules.id });
+      .limit(1);
 
-    return touched.length === 1;
-  };
-
-  for (let attempt = 0; attempt < 2; attempt++) {
-    if (await attemptClaim()) {
-      return {
-        kind: 'claimed',
-        workflowStartedAt: options?.workflow?.startedAt ?? null,
-      };
+    if (!parent) {
+      return { kind: 'not_found' };
+    }
+    if (parent.generationStatus !== 'ready') {
+      return { kind: 'in_flight' };
     }
 
-    const state = await readScopedModuleState(
-      dbClient,
-      planId,
-      moduleId,
-      userId,
-    );
+    const attemptClaim = async (): Promise<boolean> => {
+      const touched = await tx
+        .update(modules)
+        .set({
+          lessonGenerationStatus: 'generating',
+          lessonGenerationStartedAt: claimStartedAt,
+          lessonGenerationCompletedAt: null,
+          lessonGenerationFailedAt: null,
+          lessonGenerationError: null,
+          ...(workflowMetadata
+            ? { lessonGenerationMetadata: workflowMetadata }
+            : {}),
+        })
+        .where(
+          and(
+            eq(modules.id, moduleId),
+            eq(modules.planId, planId),
+            inArray(modules.lessonGenerationStatus, [...claimableStatuses]),
+            moduleOwnedByUser(userId),
+          ),
+        )
+        .returning({ id: modules.id });
 
+      return touched.length === 1;
+    };
+
+    for (let attempt = 0; attempt < 2; attempt++) {
+      if (await attemptClaim()) {
+        return {
+          kind: 'claimed',
+          workflowStartedAt: options?.workflow?.startedAt ?? null,
+        };
+      }
+
+      const state = await readScopedModuleState(tx, planId, moduleId, userId);
+      const result = classifyModuleLessonGenerationClaimState(
+        state,
+        options?.workflow,
+      );
+      if (result) {
+        return result;
+      }
+    }
+
+    const state = await readScopedModuleState(tx, planId, moduleId, userId);
     const result = classifyModuleLessonGenerationClaimState(
       state,
       options?.workflow,
@@ -357,20 +424,11 @@ export async function claimModuleLessonGenerationOrDescribe(
     if (result) {
       return result;
     }
-  }
 
-  const state = await readScopedModuleState(dbClient, planId, moduleId, userId);
-  const result = classifyModuleLessonGenerationClaimState(
-    state,
-    options?.workflow,
-  );
-  if (result) {
-    return result;
-  }
-
-  throw new Error(
-    `Unexpected module lesson_generation_status after claim retries: ${String(state?.status)}`,
-  );
+    throw new Error(
+      `Unexpected module lesson_generation_status after claim retries: ${String(state?.status)}`,
+    );
+  });
 }
 
 export type CommitModuleLessonBatchSuccessInput = {

--- a/src/lib/db/queries/plans.ts
+++ b/src/lib/db/queries/plans.ts
@@ -20,6 +20,10 @@ import type {
   TaskProgress,
 } from '@/shared/types/db.types';
 
+import {
+  hasActiveChildModuleGeneration,
+  lockPlanLifecycle,
+} from '@/lib/db/queries/helpers/plan-lifecycle-lock';
 import { selectOwnedPlanById } from '@/lib/db/queries/helpers/plans-helpers';
 import {
   fetchModuleTaskMetricsRows,
@@ -40,7 +44,10 @@ import {
 import { db as serviceRoleDb } from '@supabase/service-role';
 import { and, asc, count, desc, eq, inArray, sql } from 'drizzle-orm';
 
-export type DeletePlanDbClient = Pick<DbClient, 'delete' | 'select'>;
+export type DeletePlanDbClient = Pick<
+  DbClient,
+  'delete' | 'select' | 'execute' | 'transaction'
+>;
 
 type PlanSummaryRows = {
   planRows: LearningPlan[];
@@ -457,7 +464,10 @@ export async function getPlanStatusRowsForUser(
 }
 
 /** Explicit failure reasons returned by deletePlan. */
-type DeletePlanFailureReason = 'not_found' | 'currently_generating';
+type DeletePlanFailureReason =
+  | 'not_found'
+  | 'currently_generating'
+  | 'active_child_generation';
 
 /** Result of a plan deletion attempt. */
 type DeletePlanResult =
@@ -484,46 +494,54 @@ export async function deletePlan(
 ): Promise<DeletePlanResult> {
   const client = dbClient ?? serviceRoleDb;
 
-  const plan = await deps.selectOwnedPlanById({
-    planId,
-    ownerUserId: userId,
-    dbClient: client,
-  });
+  return client.transaction(async (tx) => {
+    await lockPlanLifecycle(tx, planId);
 
-  if (!plan) {
+    const plan = await deps.selectOwnedPlanById({
+      planId,
+      ownerUserId: userId,
+      dbClient: tx,
+    });
+
+    if (!plan) {
+      return { success: false, reason: 'not_found' };
+    }
+
+    if (!isDeletablePlanStatus(plan.generationStatus)) {
+      return { success: false, reason: 'currently_generating' };
+    }
+
+    if (await hasActiveChildModuleGeneration(tx, planId)) {
+      return { success: false, reason: 'active_child_generation' };
+    }
+
+    const deletedPlans = await tx
+      .delete(learningPlans)
+      .where(
+        and(
+          eq(learningPlans.id, planId),
+          eq(learningPlans.userId, userId),
+          inArray(learningPlans.generationStatus, DELETABLE_PLAN_STATUSES),
+        ),
+      )
+      .returning({ id: learningPlans.id });
+
+    if (deletedPlans.length > 0) {
+      return { success: true };
+    }
+
+    const currentPlan = await deps.selectOwnedPlanById({
+      planId,
+      ownerUserId: userId,
+      dbClient: tx,
+    });
+
+    if (currentPlan?.generationStatus === 'generating') {
+      return { success: false, reason: 'currently_generating' };
+    }
+
     return { success: false, reason: 'not_found' };
-  }
-
-  if (!isDeletablePlanStatus(plan.generationStatus)) {
-    return { success: false, reason: 'currently_generating' };
-  }
-
-  const deletedPlans = await client
-    .delete(learningPlans)
-    .where(
-      and(
-        eq(learningPlans.id, planId),
-        eq(learningPlans.userId, userId),
-        inArray(learningPlans.generationStatus, DELETABLE_PLAN_STATUSES),
-      ),
-    )
-    .returning({ id: learningPlans.id });
-
-  if (deletedPlans.length > 0) {
-    return { success: true };
-  }
-
-  const currentPlan = await deps.selectOwnedPlanById({
-    planId,
-    ownerUserId: userId,
-    dbClient: client,
   });
-
-  if (currentPlan?.generationStatus === 'generating') {
-    return { success: false, reason: 'currently_generating' };
-  }
-
-  return { success: false, reason: 'not_found' };
 }
 
 /**

--- a/src/lib/db/queries/types/attempts.types.ts
+++ b/src/lib/db/queries/types/attempts.types.ts
@@ -44,7 +44,13 @@ export interface AttemptReservation {
 
 export interface AttemptRejection {
   reserved: false;
-  reason: 'capped' | 'in_progress' | 'invalid_status' | 'rate_limited';
+  reason:
+    | 'capped'
+    | 'in_progress'
+    | 'invalid_status'
+    | 'rate_limited'
+    | 'plan_limit'
+    | 'active_child_generation';
   currentStatus?: InferSelectModel<
     DbSchemaModule['learningPlans']
   >['generationStatus'];

--- a/src/lib/posthog-server.ts
+++ b/src/lib/posthog-server.ts
@@ -21,7 +21,7 @@ function resolvePostHogNodeSdkHost(rawHost: string | undefined): string {
  *
  * Returns null when the project token is missing so callers can skip capture
  * without breaking the request. Host may be omitted; the Node SDK then uses
- * the same US Cloud ingest origin as `/ingest` rewrites.
+ * the same US Cloud ingest origin as the `/ingest` proxy.
  */
 export function getPostHogClient(): PostHog | null {
   const token = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;

--- a/src/lib/posthog/ingest-proxy.ts
+++ b/src/lib/posthog/ingest-proxy.ts
@@ -1,0 +1,689 @@
+/**
+ * Application-owned PostHog ingest proxy.
+ *
+ * Installed posthog-js 1.415.1 surface only: POST /e/, POST /s/, POST /flags/,
+ * GET/HEAD /array/{token}/config(.js), GET/HEAD /static/{version}/{kind}.js
+ * and /static/{kind}.js. Origins come from resolvePostHogRewriteDestinations.
+ */
+
+import { AppError, toErrorResponse } from '@/lib/api/errors';
+import { getProcessEnvSource, parseNodeEnv } from '@/lib/config/env/shared';
+import { isAbortError } from '@/lib/errors';
+import { logger } from '@/lib/logging/logger';
+import { resolvePostHogRewriteDestinations } from '@/lib/posthog-rewrite-destinations';
+
+export const POSTHOG_INGEST_MAX_BODY_BYTES = 1024 * 1024;
+export const POSTHOG_INGEST_UPSTREAM_TIMEOUT_MS = 10_000;
+
+const INGEST_PREFIX = '/ingest';
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
+
+const STATIC_KINDS = new Set([
+  'conversations',
+  'crisp-chat-integration',
+  'dead-clicks-autocapture',
+  'exception-autocapture',
+  'intercom-integration',
+  'lazy-recorder',
+  'logs',
+  'product-tours',
+  'recorder',
+  'surveys',
+  'toolbar',
+  'tracing-headers',
+  'web-vitals',
+  'web-vitals-soft-navs',
+  'web-vitals-with-attribution',
+  'web-vitals-with-attribution-soft-navs',
+]);
+
+const ONE_SEGMENT = /^[0-9A-Za-z][0-9A-Za-z._-]{0,199}$/;
+const ALLOWED_CONTENT_TYPES = new Set([
+  'application/json',
+  'application/x-www-form-urlencoded',
+  'text/plain',
+]);
+const ALLOWED_CONTENT_ENCODINGS = new Set(['gzip']);
+const ALLOWED_COMPRESSION_QUERY = new Set(['gzip-js', 'base64']);
+const RESPONSE_HEADER_ALLOWLIST = new Set([
+  'cache-control',
+  'content-encoding',
+  'content-type',
+  'etag',
+  'last-modified',
+]);
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+type OriginKind = 'ingest' | 'assets';
+
+type ResolvedTarget = {
+  originKind: OriginKind;
+  upstreamPath: string;
+  allowedMethods: readonly string[];
+  allowsBody: boolean;
+  query: URLSearchParams;
+};
+
+type RejectReason =
+  | 'unknown_path'
+  | 'method_not_allowed'
+  | 'options_not_relayed'
+  | 'unexpected_body'
+  | 'payload_too_large'
+  | 'invalid_content_type'
+  | 'invalid_origin'
+  | 'upstream_redirect'
+  | 'upstream_timeout'
+  | 'upstream_failure';
+
+function isLoopbackHostname(hostname: string): boolean {
+  return LOOPBACK_HOSTS.has(hostname.toLowerCase());
+}
+
+function isAllowedUpstreamOrigin(url: URL): boolean {
+  if (url.username || url.password || url.hash) {
+    return false;
+  }
+  if (url.protocol === 'https:') {
+    return true;
+  }
+  if (url.protocol !== 'http:') {
+    return false;
+  }
+  return (
+    isLoopbackHostname(url.hostname) &&
+    parseNodeEnv(getProcessEnvSource()) !== 'production'
+  );
+}
+
+function mediaType(value: string): string {
+  return value.split(';', 1)[0]?.trim().toLowerCase() ?? '';
+}
+
+function parseDeclaredContentLength(value: string | null): number | null {
+  if (value === null) {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (trimmed === '') {
+    return null;
+  }
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || n < 0) {
+    return null;
+  }
+  return n;
+}
+
+function logReject(
+  reason: RejectReason,
+  request: Request,
+  extra?: Record<string, unknown>,
+): void {
+  let pathname = '';
+  try {
+    pathname = new URL(request.url).pathname.slice(0, 200);
+  } catch {
+    pathname = '';
+  }
+  logger.warn(
+    { reason, method: request.method, pathname, ...extra },
+    'PostHog ingest proxy rejected request',
+  );
+}
+
+function reject(
+  request: Request,
+  reason: RejectReason,
+  message: string,
+  options: {
+    status: number;
+    code: string;
+    headers?: Record<string, string>;
+  },
+): AppError {
+  logReject(reason, request);
+  return new AppError(message, {
+    status: options.status,
+    code: options.code,
+    headers: options.headers,
+  });
+}
+
+function allowHeader(methods: readonly string[]): Record<string, string> {
+  return { Allow: methods.join(', ') };
+}
+
+function matchStaticKindFile(segment: string): string | null {
+  if (!segment.endsWith('.js')) {
+    return null;
+  }
+  const kind = segment.slice(0, -3);
+  return STATIC_KINDS.has(kind) ? kind : null;
+}
+
+function parseAllowedQuery(
+  searchParams: URLSearchParams,
+  endpoint: 'capture' | 'flags' | 'array' | 'static-versioned' | 'static-kind',
+): URLSearchParams | null {
+  const allowed = new URLSearchParams();
+  const keys = [...new Set(searchParams.keys())];
+
+  for (const key of keys) {
+    const values = searchParams.getAll(key);
+    if (values.length !== 1) {
+      return null;
+    }
+    const value = values[0] ?? '';
+
+    if (endpoint === 'capture') {
+      if (key === 'compression' && ALLOWED_COMPRESSION_QUERY.has(value)) {
+        allowed.set(key, value);
+        continue;
+      }
+      if ((key === 'sent_at' || key === '_') && /^\d{1,16}$/.test(value)) {
+        allowed.set(key, value);
+        continue;
+      }
+      return null;
+    }
+
+    if (endpoint === 'flags') {
+      if (key === 'v' && value === '2') {
+        allowed.set(key, value);
+        continue;
+      }
+      if (key === 'only_evaluate_survey_feature_flags' && value === 'true') {
+        allowed.set(key, value);
+        continue;
+      }
+      if (key === 'compression' && ALLOWED_COMPRESSION_QUERY.has(value)) {
+        allowed.set(key, value);
+        continue;
+      }
+      if ((key === 'sent_at' || key === '_') && /^\d{1,16}$/.test(value)) {
+        allowed.set(key, value);
+        continue;
+      }
+      return null;
+    }
+
+    if (endpoint === 'static-kind' || endpoint === 'static-versioned') {
+      if (key === 'v' && ONE_SEGMENT.test(value)) {
+        allowed.set(key, value);
+        continue;
+      }
+      if (
+        endpoint === 'static-kind' &&
+        key === 't' &&
+        /^\d{1,16}$/.test(value)
+      ) {
+        allowed.set(key, value);
+        continue;
+      }
+      return null;
+    }
+
+    return null;
+  }
+
+  if (endpoint === 'array' && keys.length > 0) {
+    return null;
+  }
+
+  return allowed;
+}
+
+function resolveTarget(request: Request): ResolvedTarget {
+  let url: URL;
+  try {
+    url = new URL(request.url);
+  } catch {
+    throw reject(request, 'unknown_path', 'Not Found', {
+      status: 404,
+      code: 'NOT_FOUND',
+    });
+  }
+
+  const pathname = url.pathname;
+  if (
+    pathname.includes('\\') ||
+    pathname.includes('%') ||
+    pathname.includes('//')
+  ) {
+    throw reject(request, 'unknown_path', 'Not Found', {
+      status: 404,
+      code: 'NOT_FOUND',
+    });
+  }
+
+  if (pathname === INGEST_PREFIX || pathname === `${INGEST_PREFIX}/`) {
+    throw reject(request, 'unknown_path', 'Not Found', {
+      status: 404,
+      code: 'NOT_FOUND',
+    });
+  }
+
+  if (!pathname.startsWith(`${INGEST_PREFIX}/`)) {
+    throw reject(request, 'unknown_path', 'Not Found', {
+      status: 404,
+      code: 'NOT_FOUND',
+    });
+  }
+
+  const remainder = pathname.slice(`${INGEST_PREFIX}/`.length);
+  const segments = remainder.split('/');
+  if (segments.some((segment) => segment === '.' || segment === '..')) {
+    throw reject(request, 'unknown_path', 'Not Found', {
+      status: 404,
+      code: 'NOT_FOUND',
+    });
+  }
+
+  const trailingSlash = remainder.endsWith('/');
+  const meaningful = trailingSlash ? segments.slice(0, -1) : segments;
+
+  if (meaningful.length === 1 && meaningful[0] === 'e') {
+    const query = parseAllowedQuery(url.searchParams, 'capture');
+    if (!query) {
+      throw reject(request, 'unknown_path', 'Not Found', {
+        status: 404,
+        code: 'NOT_FOUND',
+      });
+    }
+    return {
+      originKind: 'ingest',
+      upstreamPath: '/e/',
+      allowedMethods: ['POST'],
+      allowsBody: true,
+      query,
+    };
+  }
+
+  if (meaningful.length === 1 && meaningful[0] === 's' && trailingSlash) {
+    const query = parseAllowedQuery(url.searchParams, 'capture');
+    if (!query) {
+      throw reject(request, 'unknown_path', 'Not Found', {
+        status: 404,
+        code: 'NOT_FOUND',
+      });
+    }
+    return {
+      originKind: 'ingest',
+      upstreamPath: '/s/',
+      allowedMethods: ['POST'],
+      allowsBody: true,
+      query,
+    };
+  }
+
+  if (meaningful.length === 1 && meaningful[0] === 'flags') {
+    const query = parseAllowedQuery(url.searchParams, 'flags');
+    if (!query) {
+      throw reject(request, 'unknown_path', 'Not Found', {
+        status: 404,
+        code: 'NOT_FOUND',
+      });
+    }
+    return {
+      originKind: 'ingest',
+      upstreamPath: '/flags/',
+      allowedMethods: ['POST'],
+      allowsBody: true,
+      query,
+    };
+  }
+
+  if (
+    meaningful.length === 3 &&
+    meaningful[0] === 'array' &&
+    ONE_SEGMENT.test(meaningful[1] ?? '') &&
+    (meaningful[2] === 'config' || meaningful[2] === 'config.js') &&
+    !trailingSlash
+  ) {
+    const query = parseAllowedQuery(url.searchParams, 'array');
+    if (!query) {
+      throw reject(request, 'unknown_path', 'Not Found', {
+        status: 404,
+        code: 'NOT_FOUND',
+      });
+    }
+    return {
+      originKind: 'assets',
+      upstreamPath: `/array/${meaningful[1]}/${meaningful[2]}`,
+      allowedMethods: ['GET', 'HEAD'],
+      allowsBody: false,
+      query,
+    };
+  }
+
+  if (
+    meaningful.length === 3 &&
+    meaningful[0] === 'static' &&
+    ONE_SEGMENT.test(meaningful[1] ?? '') &&
+    matchStaticKindFile(meaningful[2] ?? '') &&
+    !trailingSlash
+  ) {
+    const query = parseAllowedQuery(url.searchParams, 'static-versioned');
+    if (!query) {
+      throw reject(request, 'unknown_path', 'Not Found', {
+        status: 404,
+        code: 'NOT_FOUND',
+      });
+    }
+    return {
+      originKind: 'assets',
+      upstreamPath: `/static/${meaningful[1]}/${meaningful[2]}`,
+      allowedMethods: ['GET', 'HEAD'],
+      allowsBody: false,
+      query,
+    };
+  }
+
+  if (
+    meaningful.length === 2 &&
+    meaningful[0] === 'static' &&
+    matchStaticKindFile(meaningful[1] ?? '') &&
+    !trailingSlash
+  ) {
+    const query = parseAllowedQuery(url.searchParams, 'static-kind');
+    if (!query) {
+      throw reject(request, 'unknown_path', 'Not Found', {
+        status: 404,
+        code: 'NOT_FOUND',
+      });
+    }
+    return {
+      originKind: 'assets',
+      upstreamPath: `/static/${meaningful[1]}`,
+      allowedMethods: ['GET', 'HEAD'],
+      allowsBody: false,
+      query,
+    };
+  }
+
+  throw reject(request, 'unknown_path', 'Not Found', {
+    status: 404,
+    code: 'NOT_FOUND',
+  });
+}
+
+function buildOutboundHeaders(request: Request, allowsBody: boolean): Headers {
+  const outbound = new Headers();
+  if (!allowsBody) {
+    return outbound;
+  }
+
+  const contentType = request.headers.get('content-type');
+  if (contentType !== null) {
+    if (!ALLOWED_CONTENT_TYPES.has(mediaType(contentType))) {
+      throw reject(request, 'invalid_content_type', 'Bad Request', {
+        status: 400,
+        code: 'BAD_REQUEST',
+      });
+    }
+    outbound.set('content-type', contentType);
+  }
+
+  const contentEncoding = request.headers.get('content-encoding');
+  if (contentEncoding !== null) {
+    if (!ALLOWED_CONTENT_ENCODINGS.has(contentEncoding.trim().toLowerCase())) {
+      throw reject(request, 'invalid_content_type', 'Bad Request', {
+        status: 400,
+        code: 'BAD_REQUEST',
+      });
+    }
+    outbound.set('content-encoding', contentEncoding);
+  }
+
+  return outbound;
+}
+
+function buildDownstreamHeaders(upstream: Headers): Headers {
+  const headers = new Headers();
+  for (const name of RESPONSE_HEADER_ALLOWLIST) {
+    const value = upstream.get(name);
+    if (value !== null) {
+      headers.set(name, value);
+    }
+  }
+  return headers;
+}
+
+function joinUpstreamUrl(
+  originBase: string,
+  upstreamPath: string,
+  query: URLSearchParams,
+): URL {
+  const base = new URL(originBase);
+  if (!isAllowedUpstreamOrigin(base)) {
+    throw new Error('invalid origin');
+  }
+  const prefix = base.pathname === '/' ? '' : base.pathname.replace(/\/+$/, '');
+  const combinedPath = `${prefix}${upstreamPath}`;
+  const upstream = new URL(base.origin);
+  upstream.pathname = combinedPath;
+  for (const [key, value] of query.entries()) {
+    upstream.searchParams.append(key, value);
+  }
+  if (
+    upstream.origin !== base.origin ||
+    upstream.username ||
+    upstream.password ||
+    (upstream.pathname !== combinedPath &&
+      `${upstream.pathname}/` !== combinedPath)
+  ) {
+    throw new Error('invalid origin');
+  }
+  return upstream;
+}
+
+async function readBodyCapped(
+  request: Request,
+  maxBytes: number,
+): Promise<Uint8Array | null> {
+  if (request.body == null) {
+    return new Uint8Array();
+  }
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let length = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    length += value.byteLength;
+    if (length > maxBytes) {
+      await reader.cancel().catch(() => undefined);
+      return null;
+    }
+    chunks.push(value);
+  }
+
+  const body = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return body;
+}
+
+function isTimeoutAbort(
+  error: unknown,
+  timeoutSignal: AbortSignal,
+  requestSignal: AbortSignal,
+): boolean {
+  if (requestSignal.aborted && !timeoutSignal.aborted) {
+    return false;
+  }
+  if (timeoutSignal.aborted) {
+    return true;
+  }
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'name' in error &&
+    error.name === 'TimeoutError'
+  );
+}
+
+async function handle(request: Request): Promise<Response> {
+  const target = resolveTarget(request);
+  const method = request.method.toUpperCase();
+
+  if (method === 'OPTIONS') {
+    throw reject(request, 'options_not_relayed', 'Method Not Allowed', {
+      status: 405,
+      code: 'METHOD_NOT_ALLOWED',
+      headers: allowHeader(target.allowedMethods),
+    });
+  }
+
+  if (!target.allowedMethods.includes(method)) {
+    throw reject(request, 'method_not_allowed', 'Method Not Allowed', {
+      status: 405,
+      code: 'METHOD_NOT_ALLOWED',
+      headers: allowHeader(target.allowedMethods),
+    });
+  }
+
+  const declared = parseDeclaredContentLength(
+    request.headers.get('content-length'),
+  );
+  if (request.headers.has('content-length') && declared === null) {
+    throw reject(request, 'unexpected_body', 'Bad Request', {
+      status: 400,
+      code: 'BAD_REQUEST',
+    });
+  }
+
+  let body: Uint8Array | undefined;
+  if (!target.allowsBody) {
+    if (declared !== null && declared > 0) {
+      if (request.body != null) {
+        await request.body.cancel().catch(() => undefined);
+      }
+      throw reject(request, 'unexpected_body', 'Bad Request', {
+        status: 400,
+        code: 'BAD_REQUEST',
+      });
+    }
+    if (request.body != null) {
+      await request.body.cancel().catch(() => undefined);
+    }
+  } else {
+    if (declared !== null && declared > POSTHOG_INGEST_MAX_BODY_BYTES) {
+      if (request.body != null) {
+        await request.body.cancel().catch(() => undefined);
+      }
+      throw reject(request, 'payload_too_large', 'payload too large', {
+        status: 413,
+        code: 'PAYLOAD_TOO_LARGE',
+      });
+    }
+    const bytes = await readBodyCapped(request, POSTHOG_INGEST_MAX_BODY_BYTES);
+    if (bytes === null) {
+      throw reject(request, 'payload_too_large', 'payload too large', {
+        status: 413,
+        code: 'PAYLOAD_TOO_LARGE',
+      });
+    }
+    body = bytes;
+  }
+
+  let destinations;
+  try {
+    destinations = resolvePostHogRewriteDestinations(
+      process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    );
+  } catch {
+    throw reject(request, 'invalid_origin', 'Bad Gateway', {
+      status: 502,
+      code: 'BAD_GATEWAY',
+    });
+  }
+
+  const originBase =
+    target.originKind === 'assets'
+      ? destinations.assetsOrigin
+      : destinations.ingestOrigin;
+
+  let upstreamUrl: URL;
+  try {
+    upstreamUrl = joinUpstreamUrl(
+      originBase,
+      target.upstreamPath,
+      target.query,
+    );
+  } catch {
+    throw reject(request, 'invalid_origin', 'Bad Gateway', {
+      status: 502,
+      code: 'BAD_GATEWAY',
+    });
+  }
+
+  const outboundHeaders = buildOutboundHeaders(request, target.allowsBody);
+  const timeoutSignal = AbortSignal.timeout(POSTHOG_INGEST_UPSTREAM_TIMEOUT_MS);
+  const signal = AbortSignal.any([request.signal, timeoutSignal]);
+
+  let upstream: Response;
+  try {
+    const init: RequestInit = {
+      method,
+      headers: outboundHeaders,
+      redirect: 'manual',
+      credentials: 'omit',
+      signal,
+    };
+    if (target.allowsBody && body !== undefined) {
+      // ponytail: TS 5.7 ArrayBuffer generics reject Uint8Array as BodyInit
+      init.body = body as unknown as BodyInit;
+    }
+    upstream = await fetch(upstreamUrl, init);
+  } catch (error) {
+    if (isTimeoutAbort(error, timeoutSignal, request.signal)) {
+      throw reject(request, 'upstream_timeout', 'Gateway Timeout', {
+        status: 504,
+        code: 'GATEWAY_TIMEOUT',
+      });
+    }
+    if (isAbortError(error) && request.signal.aborted) {
+      throw error;
+    }
+    throw reject(request, 'upstream_failure', 'Bad Gateway', {
+      status: 502,
+      code: 'BAD_GATEWAY',
+    });
+  }
+
+  if (REDIRECT_STATUSES.has(upstream.status)) {
+    await upstream.body?.cancel().catch(() => undefined);
+    throw reject(request, 'upstream_redirect', 'Bad Gateway', {
+      status: 502,
+      code: 'BAD_GATEWAY',
+    });
+  }
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: buildDownstreamHeaders(upstream.headers),
+  });
+}
+
+export async function proxyIngestRequest(request: Request): Promise<Response> {
+  try {
+    return await handle(request);
+  } catch (error) {
+    if (isAbortError(error) && request.signal.aborted) {
+      return new Response(null, {
+        status: 499,
+        headers: { Connection: 'close' },
+      });
+    }
+    return toErrorResponse(error);
+  }
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -177,7 +177,7 @@ export default proxy;
 export const config = {
   matcher: [
     // Catch-all for app routes including /.well-known/workflow. Skip /ingest so
-    // PostHog rewrites run (maintenance would otherwise 307 capture endpoints).
+    // the public PostHog proxy stays outside Clerk; that route owns validation.
     '/((?!_next|ingest(?:/|$)|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
     '/(api|trpc)(.*)',
   ],

--- a/src/shared/schemas/lesson-content.schemas.ts
+++ b/src/shared/schemas/lesson-content.schemas.ts
@@ -80,6 +80,7 @@ export const ModuleLessonGenerationMetadataSchema = z.strictObject({
   version: z.literal(1),
   batchRequestId: z.string().max(128).optional(),
   workflow: WorkflowSdkMetadataSchema.optional(),
+  providerStartedAt: z.iso.datetime().optional(),
 });
 
 const ModuleLessonGenerationApiBaseSchema = z.strictObject({

--- a/tests/integration/api/plan-cleanup-process.spec.ts
+++ b/tests/integration/api/plan-cleanup-process.spec.ts
@@ -135,6 +135,7 @@ describe('POST /api/internal/maintenance/plans/cleanup', () => {
       userId: user.id,
       topic: 'Route stuck plan',
       generationStatus: 'generating',
+      isQuotaEligible: false,
     });
     const attemptPlan = await createTestPlan({
       userId: user.id,

--- a/tests/integration/db/clerk-billing-webhook-claims.spec.ts
+++ b/tests/integration/db/clerk-billing-webhook-claims.spec.ts
@@ -3,7 +3,11 @@ import type { WebhookEvent } from '@clerk/nextjs/webhooks';
 
 import {
   applyVerifiedClerkBillingEvent,
+  CLERK_BILLING_PAYER_LOCK_NAMESPACE,
   CLERK_BILLING_WEBHOOK_LEASE_MS,
+  ClerkBillingRefreshTimeoutError,
+  ClerkWebhookLeaseLostError,
+  reconcileClerkBillingEntitlements,
 } from '@/features/billing/clerk-billing/reconciliation';
 import {
   clerkWebhookEventClaims,
@@ -12,18 +16,19 @@ import {
 } from '@supabase/schema';
 import { db } from '@supabase/service-role';
 import { ensureUser } from '@tests/helpers/db/users';
+import { createDeferredPromise } from '@tests/helpers/deferred-promise';
 import { buildTestAuthUserId, buildTestEmail } from '@tests/helpers/testIds';
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { describe, expect, it, vi } from 'vitest';
 
-function billingEvent(): WebhookEvent {
+function billingEvent(payerUserId = 'billing_claim_user'): WebhookEvent {
   return {
     type: 'subscription.updated',
     data: {
       id: 'sub_claim_fixture',
       status: 'active',
-      payer: { user_id: 'billing_claim_user' },
-      payer_id: 'billing_claim_user',
+      payer: { user_id: payerUserId },
+      payer_id: payerUserId,
       items: [],
     },
   } as unknown as WebhookEvent;
@@ -97,6 +102,60 @@ function logger() {
     info: vi.fn(),
     warn: vi.fn(),
   } as never;
+}
+
+async function waitForPayerLockWaiter(payerUserId: string): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const rows = await db.execute(sql`
+      SELECT granted
+      FROM pg_locks
+      WHERE locktype = 'advisory'
+        AND classid = ${sql.raw(String(CLERK_BILLING_PAYER_LOCK_NAMESPACE))}
+        AND objid = hashtext(${payerUserId})
+    `);
+    const list = Array.isArray(rows) ? rows : [];
+    const granted = list.some(
+      (row) => (row as { granted?: unknown }).granted === true,
+    );
+    const waiting = list.some(
+      (row) => (row as { granted?: unknown }).granted === false,
+    );
+    if (granted && waiting) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`Timed out waiting for payer lock waiter (${payerUserId})`);
+}
+
+async function currentTier(authUserId: string): Promise<string | undefined> {
+  const [user] = await db
+    .select({ subscriptionTier: users.subscriptionTier })
+    .from(users)
+    .where(eq(users.authUserId, authUserId));
+  return user?.subscriptionTier;
+}
+
+function isLockTimeoutError(error: unknown): boolean {
+  let current = error;
+  for (let depth = 0; depth < 5; depth += 1) {
+    if (!current || typeof current !== 'object') {
+      return false;
+    }
+    if ('code' in current && current.code === '55P03') {
+      return true;
+    }
+    if (
+      'message' in current &&
+      typeof current.message === 'string' &&
+      /lock timeout/i.test(current.message)
+    ) {
+      return true;
+    }
+    current = 'cause' in current ? current.cause : undefined;
+  }
+  return false;
 }
 
 async function seedBillingUser(): Promise<void> {
@@ -519,13 +578,15 @@ describe('Clerk billing webhook claims', () => {
       logger: logger(),
       createClaimToken: () => '00000000-0000-4000-8000-000000000042',
     });
+    await waitForPayerLockWaiter('billing_claim_user');
+    expect(secondGet).not.toHaveBeenCalled();
+
+    releaseRefresh();
+    await expect(first).rejects.toBeInstanceOf(ClerkWebhookLeaseLostError);
     await expect(second).resolves.toEqual({
       status: 'inserted',
       result: 'updated',
     });
-
-    releaseRefresh();
-    await expect(first).resolves.toEqual({ status: 'duplicate' });
     expect(firstGet).toHaveBeenCalledTimes(1);
     expect(secondGet).toHaveBeenCalledTimes(1);
     expect(
@@ -578,6 +639,13 @@ describe('Clerk billing webhook claims', () => {
         logger: logger(),
       }),
     ).rejects.toBe(processingError);
+    await expect(currentTier('billing_claim_user')).resolves.toBe('starter');
+    await expect(
+      db
+        .select({ eventId: clerkWebhookEvents.eventId })
+        .from(clerkWebhookEvents)
+        .where(eq(clerkWebhookEvents.eventId, eventId)),
+    ).resolves.toEqual([]);
     await expect(
       db
         .select({ eventId: clerkWebhookEventClaims.eventId })
@@ -632,5 +700,293 @@ describe('Clerk billing webhook claims', () => {
         .from(clerkWebhookEventClaims)
         .where(eq(clerkWebhookEventClaims.eventId, eventId)),
     ).toEqual([]);
+  });
+
+  it('serializes distinct billing events for one payer so the latest Clerk snapshot wins', async () => {
+    const payerUserId = buildTestAuthUserId('clerk-payer-serialize');
+    await ensureUser({
+      authUserId: payerUserId,
+      email: buildTestEmail(payerUserId),
+      subscriptionTier: 'starter',
+    });
+    const firstRefresh = createDeferredPromise<void>();
+    const firstRelease = createDeferredPromise<BackendBillingSubscription>();
+    const firstGet = vi.fn(async () => {
+      firstRefresh.resolve();
+      return firstRelease.promise;
+    });
+    const secondGet = vi
+      .fn()
+      .mockResolvedValue(subscription({ payerId: payerUserId }));
+    const staleSubscription = subscription({
+      payerId: payerUserId,
+      status: 'past_due',
+      subscriptionItems: [
+        {
+          ...subscription().subscriptionItems[0]!,
+          status: 'past_due',
+        },
+      ],
+    });
+
+    const first = applyVerifiedClerkBillingEvent(
+      billingEvent(payerUserId),
+      `evt_stale_${payerUserId}`,
+      {
+        clerkClient: { billing: { getUserBillingSubscription: firstGet } },
+        db,
+        logger: logger(),
+      },
+    );
+    await firstRefresh.promise;
+
+    const second = applyVerifiedClerkBillingEvent(
+      billingEvent(payerUserId),
+      `evt_latest_${payerUserId}`,
+      {
+        clerkClient: { billing: { getUserBillingSubscription: secondGet } },
+        db,
+        logger: logger(),
+      },
+    );
+    await waitForPayerLockWaiter(payerUserId);
+    expect(secondGet).not.toHaveBeenCalled();
+
+    firstRelease.resolve(staleSubscription);
+    await expect(first).resolves.toEqual({
+      status: 'inserted',
+      result: 'updated',
+    });
+    await expect(second).resolves.toEqual({
+      status: 'inserted',
+      result: 'updated',
+    });
+    expect(secondGet).toHaveBeenCalledTimes(1);
+    await expect(currentTier(payerUserId)).resolves.toBe('pro');
+  });
+
+  it('allows different payers to refresh Clerk concurrently', async () => {
+    const firstPayer = buildTestAuthUserId('clerk-payer-a');
+    const secondPayer = buildTestAuthUserId('clerk-payer-b');
+    await ensureUser({
+      authUserId: firstPayer,
+      email: buildTestEmail(firstPayer),
+      subscriptionTier: 'starter',
+    });
+    await ensureUser({
+      authUserId: secondPayer,
+      email: buildTestEmail(secondPayer),
+      subscriptionTier: 'starter',
+    });
+    const firstRefresh = createDeferredPromise<void>();
+    const secondRefresh = createDeferredPromise<void>();
+    const firstRelease = createDeferredPromise<BackendBillingSubscription>();
+    const secondRelease = createDeferredPromise<BackendBillingSubscription>();
+    const firstGet = vi.fn(async () => {
+      firstRefresh.resolve();
+      return firstRelease.promise;
+    });
+    const secondGet = vi.fn(async () => {
+      secondRefresh.resolve();
+      return secondRelease.promise;
+    });
+
+    const first = applyVerifiedClerkBillingEvent(
+      billingEvent(firstPayer),
+      `evt_${firstPayer}`,
+      {
+        clerkClient: { billing: { getUserBillingSubscription: firstGet } },
+        db,
+        logger: logger(),
+      },
+    );
+    const second = applyVerifiedClerkBillingEvent(
+      billingEvent(secondPayer),
+      `evt_${secondPayer}`,
+      {
+        clerkClient: { billing: { getUserBillingSubscription: secondGet } },
+        db,
+        logger: logger(),
+      },
+    );
+
+    await Promise.all([firstRefresh.promise, secondRefresh.promise]);
+    firstRelease.resolve(subscription({ payerId: firstPayer }));
+    secondRelease.resolve(subscription({ payerId: secondPayer }));
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { status: 'inserted', result: 'updated' },
+      { status: 'inserted', result: 'updated' },
+    ]);
+    await expect(currentTier(firstPayer)).resolves.toBe('pro');
+    await expect(currentTier(secondPayer)).resolves.toBe('pro');
+  });
+
+  it('serializes reconciliation behind the same payer lock as webhooks', async () => {
+    const payerUserId = buildTestAuthUserId('clerk-payer-reconcile');
+    await ensureUser({
+      authUserId: payerUserId,
+      email: buildTestEmail(payerUserId),
+      subscriptionTier: 'starter',
+    });
+    const webhookRefresh = createDeferredPromise<void>();
+    const webhookRelease = createDeferredPromise<BackendBillingSubscription>();
+    const webhookGet = vi.fn(async () => {
+      webhookRefresh.resolve();
+      return webhookRelease.promise;
+    });
+    const reconcileGet = vi
+      .fn()
+      .mockResolvedValue(subscription({ payerId: payerUserId }));
+
+    const webhook = applyVerifiedClerkBillingEvent(
+      billingEvent(payerUserId),
+      `evt_webhook_${payerUserId}`,
+      {
+        clerkClient: { billing: { getUserBillingSubscription: webhookGet } },
+        db,
+        logger: logger(),
+      },
+    );
+    await webhookRefresh.promise;
+
+    const reconcile = reconcileClerkBillingEntitlements({
+      clerkClient: { billing: { getUserBillingSubscription: reconcileGet } },
+      db,
+      logger: logger(),
+      limit: 1,
+    });
+    await waitForPayerLockWaiter(payerUserId);
+    expect(reconcileGet).not.toHaveBeenCalled();
+
+    webhookRelease.resolve(
+      subscription({
+        payerId: payerUserId,
+        status: 'past_due',
+        subscriptionItems: [
+          {
+            ...subscription().subscriptionItems[0]!,
+            status: 'past_due',
+          },
+        ],
+      }),
+    );
+    await expect(webhook).resolves.toEqual({
+      status: 'inserted',
+      result: 'updated',
+    });
+    await expect(reconcile).resolves.toMatchObject({
+      checked: 1,
+      updated: 1,
+      failed: 0,
+    });
+    expect(reconcileGet).toHaveBeenCalledTimes(1);
+    await expect(currentTier(payerUserId)).resolves.toBe('pro');
+  });
+
+  it('does not write unlocked state when the payer lock times out', async () => {
+    const payerUserId = buildTestAuthUserId('clerk-payer-lock-timeout');
+    await ensureUser({
+      authUserId: payerUserId,
+      email: buildTestEmail(payerUserId),
+      subscriptionTier: 'starter',
+    });
+    const firstRefresh = createDeferredPromise<void>();
+    const firstRelease = createDeferredPromise<BackendBillingSubscription>();
+    const firstGet = vi.fn(async () => {
+      firstRefresh.resolve();
+      return firstRelease.promise;
+    });
+    const secondGet = vi
+      .fn()
+      .mockResolvedValue(subscription({ payerId: payerUserId }));
+
+    const first = applyVerifiedClerkBillingEvent(
+      billingEvent(payerUserId),
+      `evt_hold_${payerUserId}`,
+      {
+        clerkClient: { billing: { getUserBillingSubscription: firstGet } },
+        db,
+        logger: logger(),
+      },
+    );
+    await firstRefresh.promise;
+
+    const secondEventId = `evt_timeout_${payerUserId}`;
+    const second = applyVerifiedClerkBillingEvent(
+      billingEvent(payerUserId),
+      secondEventId,
+      {
+        clerkClient: { billing: { getUserBillingSubscription: secondGet } },
+        db,
+        logger: logger(),
+        payerLockTimeoutMs: 250,
+      },
+    );
+
+    try {
+      await expect(second).rejects.toSatisfy(isLockTimeoutError);
+      expect(secondGet).not.toHaveBeenCalled();
+      await expect(currentTier(payerUserId)).resolves.toBe('starter');
+      await expect(
+        db
+          .select({ eventId: clerkWebhookEvents.eventId })
+          .from(clerkWebhookEvents)
+          .where(eq(clerkWebhookEvents.eventId, secondEventId)),
+      ).resolves.toEqual([]);
+    } finally {
+      firstRelease.resolve(subscription({ payerId: payerUserId }));
+      await first;
+    }
+  });
+
+  it('times out a hung Clerk refresh and releases the payer lock for retry', async () => {
+    const payerUserId = buildTestAuthUserId('clerk-payer-network-timeout');
+    await ensureUser({
+      authUserId: payerUserId,
+      email: buildTestEmail(payerUserId),
+      subscriptionTier: 'starter',
+    });
+    const eventId = `evt_hung_${payerUserId}`;
+    const hungGet = vi.fn(
+      () => new Promise<BackendBillingSubscription>(() => undefined),
+    );
+
+    await expect(
+      applyVerifiedClerkBillingEvent(billingEvent(payerUserId), eventId, {
+        clerkClient: { billing: { getUserBillingSubscription: hungGet } },
+        db,
+        logger: logger(),
+        payerNetworkTimeoutMs: 150,
+      }),
+    ).rejects.toBeInstanceOf(ClerkBillingRefreshTimeoutError);
+
+    await expect(currentTier(payerUserId)).resolves.toBe('starter');
+    await expect(
+      db
+        .select({ eventId: clerkWebhookEvents.eventId })
+        .from(clerkWebhookEvents)
+        .where(eq(clerkWebhookEvents.eventId, eventId)),
+    ).resolves.toEqual([]);
+    await expect(
+      db
+        .select({ eventId: clerkWebhookEventClaims.eventId })
+        .from(clerkWebhookEventClaims)
+        .where(eq(clerkWebhookEventClaims.eventId, eventId)),
+    ).resolves.toEqual([]);
+
+    await expect(
+      applyVerifiedClerkBillingEvent(billingEvent(payerUserId), eventId, {
+        clerkClient: {
+          billing: {
+            getUserBillingSubscription: vi
+              .fn()
+              .mockResolvedValue(subscription({ payerId: payerUserId })),
+          },
+        },
+        db,
+        logger: logger(),
+      }),
+    ).resolves.toEqual({ status: 'inserted', result: 'updated' });
+    await expect(currentTier(payerUserId)).resolves.toBe('pro');
   });
 });

--- a/tests/integration/db/generation-finalization.spec.ts
+++ b/tests/integration/db/generation-finalization.spec.ts
@@ -50,6 +50,7 @@ describe('plan generation finalization (single transaction)', () => {
       visibility: 'private',
       origin: 'ai',
       generationStatus: 'failed',
+      isQuotaEligible: false,
     });
     planId = plan.id;
   });

--- a/tests/integration/db/module-lesson-generation.boundary.spec.ts
+++ b/tests/integration/db/module-lesson-generation.boundary.spec.ts
@@ -829,7 +829,7 @@ describe('module lesson generation boundary (integration)', () => {
     expect(metrics?.n).toBe(1);
   });
 
-  it('parser failure compensates lesson_modules_generated back to prior count', async () => {
+  it('parser failure after provider start keeps the lesson_modules_generated reservation', async () => {
     const authUserId = buildTestAuthUserId('mod-lesson-usage-fail');
     const userId = await ensureUser({
       authUserId,
@@ -871,7 +871,7 @@ describe('module lesson generation boundary (integration)', () => {
       .where(
         sql`${usageMetrics.userId} = ${userId} AND ${usageMetrics.month} = ${month}`,
       );
-    expect(metrics?.n).toBe(2);
+    expect(metrics?.n).toBe(3);
   });
 
   it('already_ready does not change lesson_modules_generated', async () => {

--- a/tests/integration/db/plan-cleanup.spec.ts
+++ b/tests/integration/db/plan-cleanup.spec.ts
@@ -1,18 +1,28 @@
+import { getCurrentMonth } from '@/features/billing/usage-metrics';
+import { generateModuleLessons } from '@/features/lesson-content/generate-module-lessons';
 import {
+  cleanupAbandonedModuleLessonGenerations,
   cleanupOrphanedAttempts,
   cleanupStuckPlans,
   ORPHANED_ATTEMPT_THRESHOLD_MS,
+  ORPHANED_MODULE_LESSON_GENERATION_THRESHOLD_MS,
   STUCK_PLAN_THRESHOLD_MS,
 } from '@/features/plans/cleanup';
-import { generationAttempts, learningPlans } from '@supabase/schema';
+import {
+  generationAttempts,
+  learningPlans,
+  modules,
+  usageMetrics,
+} from '@supabase/schema';
 import { db } from '@supabase/service-role';
+import { createTestModule, createTestTask } from '@tests/fixtures/modules';
 import { createTestPlan } from '@tests/fixtures/plans';
 import { createTestUser } from '@tests/fixtures/users';
 import { eq, inArray } from 'drizzle-orm';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 describe('cleanupStuckPlans (integration)', () => {
-  it('marks only old generating plans failed with a shared timestamp', async () => {
+  it('restores last-good stuck plans and fails never-usable stuck plans', async () => {
     const user = await createTestUser();
     const thresholdMs = STUCK_PLAN_THRESHOLD_MS;
     const stuckCutoff = new Date(Date.now() - thresholdMs - 60_000);
@@ -28,7 +38,7 @@ describe('cleanupStuckPlans (integration)', () => {
       userId: user.id,
       topic: 'Stuck two',
       generationStatus: 'generating',
-      isQuotaEligible: true,
+      isQuotaEligible: false,
     });
     const recentGenerating = await createTestPlan({
       userId: user.id,
@@ -90,8 +100,8 @@ describe('cleanupStuckPlans (integration)', () => {
     const byId = new Map(rows.map((row) => [row.id, row]));
 
     expect(byId.get(stuckOne.id)).toMatchObject({
-      generationStatus: 'failed',
-      isQuotaEligible: false,
+      generationStatus: 'ready',
+      isQuotaEligible: true,
     });
     expect(byId.get(stuckTwo.id)).toMatchObject({
       generationStatus: 'failed',
@@ -137,6 +147,98 @@ describe('cleanupStuckPlans (integration)', () => {
       .where(eq(learningPlans.id, plan.id));
 
     expect(row?.generationStatus).toBe('generating');
+  });
+});
+
+describe('cleanupAbandonedModuleLessonGenerations (integration)', () => {
+  it('settles stale provider-started work without refunding the budget and permits a charged retry', async () => {
+    const user = await createTestUser();
+    const plan = await createTestPlan({
+      userId: user.id,
+      topic: 'Abandoned module lesson generation',
+    });
+    const mod = await createTestModule({ planId: plan.id });
+    await createTestTask({ moduleId: mod.id });
+    const month = getCurrentMonth();
+    const staleStartedAt = new Date(
+      Date.now() - ORPHANED_MODULE_LESSON_GENERATION_THRESHOLD_MS - 60_000,
+    );
+
+    await db.insert(usageMetrics).values({
+      userId: user.id,
+      month,
+      lessonModulesGenerated: 1,
+    });
+    await db
+      .update(modules)
+      .set({
+        lessonGenerationStatus: 'generating',
+        lessonGenerationStartedAt: staleStartedAt,
+        lessonGenerationCompletedAt: null,
+        lessonGenerationFailedAt: null,
+        lessonGenerationError: null,
+        lessonGenerationMetadata: {
+          version: 1,
+          providerStartedAt: staleStartedAt.toISOString(),
+        },
+      })
+      .where(eq(modules.id, mod.id));
+
+    const cleanupResult = await cleanupAbandonedModuleLessonGenerations(db);
+    expect(cleanupResult.cleaned).toBe(1);
+
+    const [settledModule] = await db
+      .select({
+        status: modules.lessonGenerationStatus,
+        error: modules.lessonGenerationError,
+        metadata: modules.lessonGenerationMetadata,
+      })
+      .from(modules)
+      .where(eq(modules.id, mod.id));
+    expect(settledModule).toMatchObject({
+      status: 'failed',
+      error:
+        'Provider-started lesson generation was interrupted; retry required.',
+      metadata: {
+        version: 1,
+        providerStartedAt: staleStartedAt.toISOString(),
+      },
+    });
+
+    const [afterCleanup] = await db
+      .select({ lessonModulesGenerated: usageMetrics.lessonModulesGenerated })
+      .from(usageMetrics)
+      .where(eq(usageMetrics.userId, user.id));
+    expect(afterCleanup?.lessonModulesGenerated).toBe(1);
+
+    const provider = {
+      generateModuleLessonBatch: vi.fn(async () => {
+        throw new Error('retry provider failure');
+      }),
+    };
+    await expect(
+      generateModuleLessons(
+        {
+          dbClient: db,
+          userId: user.id,
+          planId: plan.id,
+          moduleId: mod.id,
+          userTier: 'free',
+        },
+        {
+          provider,
+          serverDbClient: db,
+          resolveGenerationEnabled: async () => true,
+        },
+      ),
+    ).resolves.toEqual({ kind: 'failed' });
+    expect(provider.generateModuleLessonBatch).toHaveBeenCalledOnce();
+
+    const [afterRetry] = await db
+      .select({ lessonModulesGenerated: usageMetrics.lessonModulesGenerated })
+      .from(usageMetrics)
+      .where(eq(usageMetrics.userId, user.id));
+    expect(afterRetry?.lessonModulesGenerated).toBe(2);
   });
 });
 

--- a/tests/integration/db/plan-lifecycle-lock.spec.ts
+++ b/tests/integration/db/plan-lifecycle-lock.spec.ts
@@ -1,0 +1,522 @@
+import { createReservationRejectionResult } from '@/features/ai/orchestrator/reservation';
+import { runModuleLessonGenerationWork } from '@/features/lesson-content/run-module-lesson-generation-work';
+import { reserveAttemptSlot } from '@/lib/db/queries/attempts';
+import { buildMetadata } from '@/lib/db/queries/helpers/attempts-input';
+import { persistSuccessfulAttemptInTx } from '@/lib/db/queries/helpers/attempts-persistence-success';
+import {
+  lockPlanLifecycle,
+  PLAN_LIFECYCLE_LOCK_NAMESPACE,
+} from '@/lib/db/queries/helpers/plan-lifecycle-lock';
+import { selectOwnedPlanById } from '@/lib/db/queries/helpers/plans-helpers';
+import { claimModuleLessonGenerationOrDescribe } from '@/lib/db/queries/module-lesson-generation';
+import { deletePlan } from '@/lib/db/queries/plans';
+import { generationAttempts, learningPlans, modules } from '@supabase/schema';
+import { db } from '@supabase/service-role';
+import { createTestModule, createTestTask } from '@tests/fixtures/modules';
+import { createTestPlan } from '@tests/fixtures/plans';
+import { ensureUser } from '@tests/helpers/db/users';
+import { createDeferredPromise } from '@tests/helpers/deferred-promise';
+import { buildTestAuthUserId, buildTestEmail } from '@tests/helpers/testIds';
+import { eq, sql } from 'drizzle-orm';
+import { describe, expect, it, vi } from 'vitest';
+
+const TEST_INPUT = {
+  topic: 'Lifecycle lock',
+  skillLevel: 'beginner' as const,
+  weeklyHours: 5,
+  learningStyle: 'mixed' as const,
+};
+
+async function markModuleGenerating(moduleId: string): Promise<void> {
+  await db
+    .update(modules)
+    .set({ lessonGenerationStatus: 'generating' })
+    .where(eq(modules.id, moduleId));
+}
+
+async function waitForPlanLifecycleLockWaiter(planId: string): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const rows = await db.execute(sql`
+      SELECT granted
+      FROM pg_locks
+      WHERE locktype = 'advisory'
+        AND classid = ${sql.raw(String(PLAN_LIFECYCLE_LOCK_NAMESPACE))}
+        AND objid = hashtext(${planId})
+    `);
+    const list = Array.isArray(rows) ? rows : [];
+    const granted = list.some(
+      (row) => (row as { granted?: unknown }).granted === true,
+    );
+    const waiting = list.some(
+      (row) => (row as { granted?: unknown }).granted === false,
+    );
+    if (granted && waiting) {
+      return;
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, 25);
+    });
+  }
+  throw new Error(
+    `Timed out waiting for plan lifecycle lock waiter (${planId})`,
+  );
+}
+
+describe('plan lifecycle lock (integration)', () => {
+  it('claims a child only when the parent plan is ready', async () => {
+    const authUserId = buildTestAuthUserId('lifecycle-claim-ready');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+      subscriptionTier: 'free',
+    });
+    const plan = await createTestPlan({ userId, topic: 'Ready parent' });
+    const mod = await createTestModule({ planId: plan.id });
+
+    const claim = await claimModuleLessonGenerationOrDescribe(
+      db,
+      plan.id,
+      mod.id,
+      userId,
+    );
+    expect(claim).toEqual({ kind: 'claimed', workflowStartedAt: null });
+
+    const [row] = await db
+      .select({ status: modules.lessonGenerationStatus })
+      .from(modules)
+      .where(eq(modules.id, mod.id));
+    expect(row?.status).toBe('generating');
+  });
+
+  it('returns in_flight and does not mutate when the parent is not ready', async () => {
+    const authUserId = buildTestAuthUserId('lifecycle-claim-generating');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+      subscriptionTier: 'free',
+    });
+    const plan = await createTestPlan({
+      userId,
+      topic: 'Generating parent',
+      generationStatus: 'generating',
+    });
+    const mod = await createTestModule({ planId: plan.id });
+
+    const claim = await claimModuleLessonGenerationOrDescribe(
+      db,
+      plan.id,
+      mod.id,
+      userId,
+    );
+    expect(claim).toEqual({ kind: 'in_flight' });
+
+    const [row] = await db
+      .select({ status: modules.lessonGenerationStatus })
+      .from(modules)
+      .where(eq(modules.id, mod.id));
+    expect(row?.status).toBe('not_generated');
+  });
+
+  it('rejects regeneration reservation while a child is generating', async () => {
+    const authUserId = buildTestAuthUserId('lifecycle-reserve-child');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+      subscriptionTier: 'free',
+    });
+    const plan = await createTestPlan({ userId, topic: 'Last-good ready' });
+    const mod = await createTestModule({ planId: plan.id });
+    await markModuleGenerating(mod.id);
+
+    const reservation = await reserveAttemptSlot({
+      planId: plan.id,
+      userId,
+      input: TEST_INPUT,
+      dbClient: db,
+      requiredGenerationStatus: 'ready',
+    });
+
+    expect(reservation).toEqual({
+      reserved: false,
+      reason: 'active_child_generation',
+    });
+    if (reservation.reserved) {
+      throw new Error('Expected active_child_generation rejection');
+    }
+
+    const rejection = createReservationRejectionResult(
+      { planId: plan.id, userId, input: TEST_INPUT },
+      reservation,
+      0,
+      () => 1,
+      () => new Date(),
+    );
+    expect(rejection.classification).toBe('rate_limit');
+    expect(rejection.reservationRejectionReason).toBe(
+      'active_child_generation',
+    );
+
+    const attempts = await db
+      .select({ id: generationAttempts.id })
+      .from(generationAttempts)
+      .where(eq(generationAttempts.planId, plan.id));
+    expect(attempts).toHaveLength(0);
+
+    const [current] = await db
+      .select({ generationStatus: learningPlans.generationStatus })
+      .from(learningPlans)
+      .where(eq(learningPlans.id, plan.id));
+    expect(current?.generationStatus).toBe('ready');
+  });
+
+  it('refuses successful persistence while a child is generating', async () => {
+    const authUserId = buildTestAuthUserId('lifecycle-persist-child');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+      subscriptionTier: 'free',
+    });
+    const plan = await createTestPlan({
+      userId,
+      topic: 'Persist while child',
+      generationStatus: 'failed',
+      isQuotaEligible: false,
+    });
+
+    const reservation = await reserveAttemptSlot({
+      planId: plan.id,
+      userId,
+      input: TEST_INPUT,
+      dbClient: db,
+    });
+    if (!reservation.reserved) {
+      throw new Error(`Expected reservation, got ${reservation.reason}`);
+    }
+
+    const child = await createTestModule({ planId: plan.id });
+    await markModuleGenerating(child.id);
+
+    const finishedAt = new Date();
+    await expect(
+      db.transaction(async (tx) =>
+        persistSuccessfulAttemptInTx(tx, {
+          attemptId: reservation.attemptId,
+          planId: plan.id,
+          preparation: reservation,
+          normalizedModules: [
+            {
+              title: 'Replacement',
+              description: 'Should not land',
+              estimatedMinutes: 10,
+              tasks: [],
+            },
+          ],
+          normalizationFlags: { modulesClamped: false, tasksClamped: false },
+          modulesCount: 1,
+          tasksCount: 0,
+          durationMs: 10,
+          metadata: buildMetadata({
+            sanitized: reservation.sanitized,
+            modulesClamped: false,
+            tasksClamped: false,
+            startedAt: reservation.startedAt,
+            finishedAt,
+            extendedTimeout: false,
+          }),
+          finishedAt,
+        }),
+      ),
+    ).rejects.toThrow('active child module lesson generation is in progress');
+
+    const [attempt] = await db
+      .select({ status: generationAttempts.status })
+      .from(generationAttempts)
+      .where(eq(generationAttempts.id, reservation.attemptId));
+    expect(attempt?.status).toBe('in_progress');
+
+    const [childRow] = await db
+      .select({
+        id: modules.id,
+        status: modules.lessonGenerationStatus,
+        title: modules.title,
+      })
+      .from(modules)
+      .where(eq(modules.id, child.id));
+    expect(childRow).toMatchObject({
+      id: child.id,
+      status: 'generating',
+      title: child.title,
+    });
+  });
+
+  it('does not delete a plan while a child module is generating', async () => {
+    const authUserId = buildTestAuthUserId('lifecycle-delete-child');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+      subscriptionTier: 'free',
+    });
+    const plan = await createTestPlan({ userId, topic: 'Delete blocked' });
+    const mod = await createTestModule({ planId: plan.id });
+    await markModuleGenerating(mod.id);
+
+    const result = await deletePlan(plan.id, userId);
+    expect(result).toEqual({
+      success: false,
+      reason: 'active_child_generation',
+    });
+
+    const remaining = await db
+      .select({ id: learningPlans.id })
+      .from(learningPlans)
+      .where(eq(learningPlans.id, plan.id));
+    expect(remaining).toHaveLength(1);
+  });
+
+  it('lets delete win the lifecycle lock before a child claim and never invokes the provider', async () => {
+    const authUserId = buildTestAuthUserId('lifecycle-delete-wins');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+      subscriptionTier: 'free',
+    });
+    const plan = await createTestPlan({ userId, topic: 'Delete wins lock' });
+    const mod = await createTestModule({ planId: plan.id });
+
+    const deleteLocked = createDeferredPromise<void>();
+    const releaseDelete = createDeferredPromise<void>();
+    let paused = false;
+
+    const deletion = deletePlan(plan.id, userId, db, {
+      selectOwnedPlanById: async (args) => {
+        if (!paused) {
+          paused = true;
+          deleteLocked.resolve();
+          await releaseDelete.promise;
+        }
+        return selectOwnedPlanById(args);
+      },
+    });
+
+    await deleteLocked.promise;
+
+    const provider = vi.fn();
+    const claim = (async () => {
+      const result = await claimModuleLessonGenerationOrDescribe(
+        db,
+        plan.id,
+        mod.id,
+        userId,
+      );
+      if (result.kind === 'claimed') {
+        await provider();
+      }
+      return result;
+    })();
+
+    await waitForPlanLifecycleLockWaiter(plan.id);
+
+    const [beforeRelease] = await db
+      .select({ status: modules.lessonGenerationStatus })
+      .from(modules)
+      .where(eq(modules.id, mod.id));
+    expect(beforeRelease?.status).toBe('not_generated');
+
+    releaseDelete.resolve();
+
+    await expect(deletion).resolves.toEqual({ success: true });
+    await expect(claim).resolves.toEqual({ kind: 'not_found' });
+    expect(provider).not.toHaveBeenCalled();
+  });
+
+  it('blocks deletion after a child provider-start marker wins first', async () => {
+    const authUserId = buildTestAuthUserId('lifecycle-provider-delete');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+      subscriptionTier: 'free',
+    });
+    const plan = await createTestPlan({
+      userId,
+      topic: 'Provider then delete',
+    });
+    const mod = await createTestModule({ planId: plan.id });
+    const task = await createTestTask({ moduleId: mod.id });
+
+    const providerStarted = createDeferredPromise<void>();
+    const releaseProvider = createDeferredPromise<void>();
+    const provider = {
+      generateModuleLessonBatch: vi.fn(async () => {
+        providerStarted.resolve();
+        await releaseProvider.promise;
+        throw new Error('stop fake provider');
+      }),
+    };
+
+    await expect(
+      claimModuleLessonGenerationOrDescribe(db, plan.id, mod.id, userId),
+    ).resolves.toEqual({ kind: 'claimed', workflowStartedAt: null });
+
+    const generation = runModuleLessonGenerationWork(
+      {
+        load: {
+          plan: {
+            id: plan.id,
+            topic: plan.topic,
+            skillLevel: plan.skillLevel,
+            learningStyle: plan.learningStyle,
+          },
+          module: mod,
+          tasks: [task],
+          isUnlocked: true,
+        },
+        userId,
+        planId: plan.id,
+        moduleId: mod.id,
+        userTier: 'free',
+      },
+      {
+        serverDbClient: db,
+        provider,
+        resolveGenerationEnabled: async () => true,
+      },
+    );
+
+    await providerStarted.promise;
+
+    const [startedModule] = await db
+      .select({
+        status: modules.lessonGenerationStatus,
+        metadata: modules.lessonGenerationMetadata,
+      })
+      .from(modules)
+      .where(eq(modules.id, mod.id));
+    expect(startedModule).toMatchObject({
+      status: 'generating',
+      metadata: { providerStartedAt: expect.any(String) },
+    });
+
+    await expect(deletePlan(plan.id, userId, db)).resolves.toEqual({
+      success: false,
+      reason: 'active_child_generation',
+    });
+    expect(provider.generateModuleLessonBatch).toHaveBeenCalledOnce();
+
+    releaseProvider.resolve();
+    await expect(generation).resolves.toEqual({ kind: 'failed' });
+  });
+
+  it('blocks regeneration after a child provider-start marker wins first', async () => {
+    const authUserId = buildTestAuthUserId('lifecycle-provider-regenerate');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+      subscriptionTier: 'free',
+    });
+    const plan = await createTestPlan({
+      userId,
+      topic: 'Provider then regenerate',
+      generationStatus: 'ready',
+      isQuotaEligible: true,
+    });
+    const mod = await createTestModule({ planId: plan.id });
+    const task = await createTestTask({ moduleId: mod.id });
+
+    const providerStarted = createDeferredPromise<void>();
+    const releaseProvider = createDeferredPromise<void>();
+    const provider = {
+      generateModuleLessonBatch: vi.fn(async () => {
+        providerStarted.resolve();
+        await releaseProvider.promise;
+        throw new Error('stop fake provider');
+      }),
+    };
+
+    await expect(
+      claimModuleLessonGenerationOrDescribe(db, plan.id, mod.id, userId),
+    ).resolves.toEqual({ kind: 'claimed', workflowStartedAt: null });
+
+    const generation = runModuleLessonGenerationWork(
+      {
+        load: {
+          plan: {
+            id: plan.id,
+            topic: plan.topic,
+            skillLevel: plan.skillLevel,
+            learningStyle: plan.learningStyle,
+          },
+          module: mod,
+          tasks: [task],
+          isUnlocked: true,
+        },
+        userId,
+        planId: plan.id,
+        moduleId: mod.id,
+        userTier: 'free',
+      },
+      {
+        serverDbClient: db,
+        provider,
+        resolveGenerationEnabled: async () => true,
+      },
+    );
+
+    await providerStarted.promise;
+
+    const reservation = await reserveAttemptSlot({
+      planId: plan.id,
+      userId,
+      input: TEST_INPUT,
+      dbClient: db,
+      requiredGenerationStatus: 'ready',
+    });
+    expect(reservation).toEqual({
+      reserved: false,
+      reason: 'active_child_generation',
+    });
+    expect(provider.generateModuleLessonBatch).toHaveBeenCalledOnce();
+
+    releaseProvider.resolve();
+    await expect(generation).resolves.toEqual({ kind: 'failed' });
+  });
+
+  it('serializes the same plan lock and isolates different plans', async () => {
+    const authUserId = buildTestAuthUserId('lifecycle-lock-serialize');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+      subscriptionTier: 'free',
+    });
+    const planA = await createTestPlan({ userId, topic: 'Lock A' });
+    const planB = await createTestPlan({ userId, topic: 'Lock B' });
+
+    const held = createDeferredPromise<void>();
+    const release = createDeferredPromise<void>();
+    let secondAcquired = false;
+
+    const first = db.transaction(async (tx) => {
+      await lockPlanLifecycle(tx, planA.id);
+      held.resolve();
+      await release.promise;
+    });
+
+    await held.promise;
+
+    await db.transaction(async (tx) => {
+      await lockPlanLifecycle(tx, planB.id);
+    });
+
+    const second = db.transaction(async (tx) => {
+      await lockPlanLifecycle(tx, planA.id);
+      secondAcquired = true;
+    });
+
+    await waitForPlanLifecycleLockWaiter(planA.id);
+    expect(secondAcquired).toBe(false);
+
+    release.resolve();
+    await Promise.all([first, second]);
+    expect(secondAcquired).toBe(true);
+  });
+});

--- a/tests/integration/features/plans/lifecycle/plan-persistence-store.spec.ts
+++ b/tests/integration/features/plans/lifecycle/plan-persistence-store.spec.ts
@@ -213,6 +213,64 @@ describe('plan persistence store', () => {
     expect(failedRow?.isQuotaEligible).toBe(false);
   });
 
+  it('markGenerationFailure keeps a last-good eligible plan ready', async () => {
+    const authUserId = buildTestAuthUserId('persist-adapter-last-good');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+      subscriptionTier: 'pro',
+    });
+    const inserted = await atomicCheckAndInsertPlan(
+      userId,
+      {
+        ...planPayload,
+        topic: `${planPayload.topic} last-good`,
+      },
+      db,
+    );
+    expect(inserted.status).toBe('created');
+    if (inserted.status !== 'created') return;
+
+    await markPlanGenerationSuccess(inserted.id, db);
+    await markPlanGenerationFailure(inserted.id, db);
+
+    const [row] = await db
+      .select()
+      .from(learningPlans)
+      .where(eq(learningPlans.id, inserted.id));
+    expect(row?.generationStatus).toBe('ready');
+    expect(row?.isQuotaEligible).toBe(true);
+  });
+
+  it('markGenerationSuccess does not restore an ineligible plan without a reservation', async () => {
+    const authUserId = buildTestAuthUserId('persist-adapter-no-slot');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+      subscriptionTier: 'free',
+    });
+    const inserted = await atomicCheckAndInsertPlan(
+      userId,
+      {
+        ...planPayload,
+        topic: `${planPayload.topic} no-slot`,
+      },
+      db,
+    );
+    expect(inserted.status).toBe('created');
+    if (inserted.status !== 'created') return;
+
+    await markPlanGenerationFailure(inserted.id, db);
+    await markPlanGenerationSuccess(inserted.id, db);
+
+    const [row] = await db
+      .select()
+      .from(learningPlans)
+      .where(eq(learningPlans.id, inserted.id));
+    expect(row?.generationStatus).toBe('failed');
+    expect(row?.isQuotaEligible).toBe(false);
+  });
+
   it('findCappedPlanWithoutModules returns plan id when attempt cap hit and no modules', async () => {
     const authUserId = buildTestAuthUserId('persist-adapter-capped');
     const userId = await ensureUser({

--- a/tests/integration/features/plans/lifecycle/quota-cap-reservation.spec.ts
+++ b/tests/integration/features/plans/lifecycle/quota-cap-reservation.spec.ts
@@ -1,0 +1,468 @@
+import { MockGenerationProvider } from '@/features/ai/providers/mock';
+import { createPlanLifecycleService } from '@/features/plans/lifecycle/factory';
+import { commitPlanGenerationFailure } from '@/features/plans/lifecycle/generation-finalization/store';
+import {
+  atomicCheckAndInsertPlan,
+  markPlanGenerationSuccess,
+} from '@/features/plans/lifecycle/plan-persistence-store';
+import { reserveAttemptSlot } from '@/lib/db/queries/attempts';
+import { countPlansContributingToCap } from '@/lib/db/queries/helpers/plan-generation-status';
+import { TIER_LIMITS } from '@/shared/constants/tier-limits';
+import { learningPlans, modules } from '@supabase/schema';
+import { db } from '@supabase/service-role';
+import { seedFailedAttemptsForDurableWindow } from '@tests/fixtures/attempts';
+import { createTestModule } from '@tests/fixtures/modules';
+import { createPlan } from '@tests/fixtures/plans';
+import { ensureUser } from '@tests/helpers/db/users';
+import { createDeferredPromise } from '@tests/helpers/deferred-promise';
+import { buildTestAuthUserId, buildTestEmail } from '@tests/helpers/testIds';
+import { eq } from 'drizzle-orm';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+const TEST_INPUT = {
+  topic: 'Cap reservation topic',
+  skillLevel: 'beginner' as const,
+  weeklyHours: 5,
+  learningStyle: 'mixed' as const,
+};
+
+const PLAN_CORE = {
+  topic: 'Cap core topic',
+  skillLevel: 'beginner' as const,
+  weeklyHours: 5,
+  learningStyle: 'mixed' as const,
+  visibility: 'private' as const,
+  origin: 'ai' as const,
+};
+
+async function fillEligibleReadyPlans(userId: string, count: number) {
+  const plans = [];
+  for (let i = 0; i < count; i += 1) {
+    plans.push(
+      await createPlan(userId, {
+        topic: `Eligible ready ${i}`,
+        generationStatus: 'ready',
+        isQuotaEligible: true,
+      }),
+    );
+  }
+  return plans;
+}
+
+async function createFailedIneligiblePlan(userId: string, topic: string) {
+  return createPlan(userId, {
+    topic,
+    generationStatus: 'failed',
+    isQuotaEligible: false,
+  });
+}
+
+describe('last-good plan vs active-plan cap', () => {
+  beforeAll(() => {
+    vi.stubEnv('AI_PROVIDER', 'mock');
+    vi.stubEnv('MOCK_GENERATION_DELAY_MS', '25');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('rate-limited regeneration of a populated ready plan stays ready and eligible', async () => {
+    const authUserId = buildTestAuthUserId('cap-last-good-rate-limit');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+      subscriptionTier: 'free',
+    });
+    const plan = await createPlan(userId, {
+      topic: 'Populated ready plan',
+      generationStatus: 'ready',
+      isQuotaEligible: true,
+    });
+    const module = await createTestModule({
+      planId: plan.id,
+      title: 'Keep me',
+    });
+    await seedFailedAttemptsForDurableWindow(plan.id, {
+      promptHashPrefix: 'cap-last-good-rate-limit',
+    });
+
+    const lifecycle = createPlanLifecycleService({ dbClient: db });
+    const result = await lifecycle.processGenerationAttempt({
+      planId: plan.id,
+      userId,
+      tier: 'free',
+      input: {
+        topic: plan.topic,
+        skillLevel: plan.skillLevel,
+        weeklyHours: plan.weeklyHours,
+        learningStyle: plan.learningStyle,
+      },
+    });
+
+    expect(result.status).toBe('retryable_failure');
+
+    const [row] = await db
+      .select()
+      .from(learningPlans)
+      .where(eq(learningPlans.id, plan.id));
+    expect(row?.generationStatus).toBe('ready');
+    expect(row?.isQuotaEligible).toBe(true);
+
+    const remainingModules = await db
+      .select({ title: modules.title })
+      .from(modules)
+      .where(eq(modules.planId, plan.id));
+    expect(remainingModules).toEqual([{ title: module.title }]);
+  });
+
+  it('initial never-usable plan may become failed and ineligible', async () => {
+    const authUserId = buildTestAuthUserId('cap-initial-fail');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+      subscriptionTier: 'free',
+    });
+    const inserted = await atomicCheckAndInsertPlan(
+      userId,
+      { ...PLAN_CORE, topic: 'Never usable' },
+      db,
+    );
+    expect(inserted.status).toBe('created');
+    if (inserted.status !== 'created') return;
+
+    await commitPlanGenerationFailure(db, {
+      variant: 'plan_only',
+      planId: inserted.id,
+      userId,
+      classification: 'rate_limit',
+      error: new Error('rate limited'),
+      durationMs: 1,
+      usageKind: 'plan',
+      retryable: true,
+    });
+
+    const [row] = await db
+      .select()
+      .from(learningPlans)
+      .where(eq(learningPlans.id, inserted.id));
+    expect(row?.generationStatus).toBe('failed');
+    expect(row?.isQuotaEligible).toBe(false);
+  });
+
+  it('failed ineligible plan cannot retry when slots are full and provider is not invoked', async () => {
+    const authUserId = buildTestAuthUserId('cap-retry-blocked');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+      subscriptionTier: 'free',
+    });
+    await fillEligibleReadyPlans(userId, TIER_LIMITS.free.maxActivePlans);
+    const failed = await createFailedIneligiblePlan(userId, 'Hidden leftover');
+    const generateSpy = vi.spyOn(MockGenerationProvider.prototype, 'generate');
+
+    const lifecycle = createPlanLifecycleService({ dbClient: db });
+    const result = await lifecycle.processGenerationAttempt({
+      planId: failed.id,
+      userId,
+      tier: 'free',
+      allowedGenerationStatuses: ['failed', 'pending_retry'],
+      input: TEST_INPUT,
+    });
+
+    expect(result.status).toBe('permanent_failure');
+    expect(generateSpy).not.toHaveBeenCalled();
+    expect(await countPlansContributingToCap(db, userId)).toBe(
+      TIER_LIMITS.free.maxActivePlans,
+    );
+
+    const [row] = await db
+      .select()
+      .from(learningPlans)
+      .where(eq(learningPlans.id, failed.id));
+    expect(row?.generationStatus).toBe('failed');
+    expect(row?.isQuotaEligible).toBe(false);
+  });
+
+  it('retry reserves a generating slot before provider work', async () => {
+    const authUserId = buildTestAuthUserId('cap-retry-before-provider');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+      subscriptionTier: 'free',
+    });
+    await fillEligibleReadyPlans(userId, TIER_LIMITS.free.maxActivePlans - 1);
+    const failed = await createFailedIneligiblePlan(userId, 'Retry me');
+    const originalGenerate = MockGenerationProvider.prototype.generate;
+    const sawReservation = createDeferredPromise<void>();
+    const releaseProvider = createDeferredPromise<void>();
+    const generateSpy = vi
+      .spyOn(MockGenerationProvider.prototype, 'generate')
+      .mockImplementation(
+        async function generate(this: MockGenerationProvider, input, options) {
+          const [row] = await db
+            .select()
+            .from(learningPlans)
+            .where(eq(learningPlans.id, failed.id));
+          expect(row?.generationStatus).toBe('generating');
+          expect(row?.isQuotaEligible).toBe(false);
+          expect(await countPlansContributingToCap(db, userId)).toBe(
+            TIER_LIMITS.free.maxActivePlans,
+          );
+          sawReservation.resolve();
+          await releaseProvider.promise;
+          return originalGenerate.call(this, input, options);
+        },
+      );
+
+    const lifecycle = createPlanLifecycleService({ dbClient: db });
+    const run = lifecycle.processGenerationAttempt({
+      planId: failed.id,
+      userId,
+      tier: 'free',
+      allowedGenerationStatuses: ['failed', 'pending_retry'],
+      input: TEST_INPUT,
+    });
+
+    await sawReservation.promise;
+    expect(generateSpy).toHaveBeenCalledTimes(1);
+    const [mid] = await db
+      .select()
+      .from(learningPlans)
+      .where(eq(learningPlans.id, failed.id));
+    expect(mid?.generationStatus).toBe('generating');
+    expect(mid?.isQuotaEligible).toBe(false);
+
+    releaseProvider.resolve();
+    const result = await run;
+
+    expect(result.status).toBe('generation_success');
+    expect(await countPlansContributingToCap(db, userId)).toBe(
+      TIER_LIMITS.free.maxActivePlans,
+    );
+
+    const [row] = await db
+      .select()
+      .from(learningPlans)
+      .where(eq(learningPlans.id, failed.id));
+    expect(row?.generationStatus).toBe('ready');
+    expect(row?.isQuotaEligible).toBe(true);
+  });
+
+  it('concurrent failed-plan reactivations with one slot admit exactly one', async () => {
+    const authUserId = buildTestAuthUserId('cap-retry-race');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+      subscriptionTier: 'free',
+    });
+    await fillEligibleReadyPlans(userId, TIER_LIMITS.free.maxActivePlans - 1);
+    const failedA = await createFailedIneligiblePlan(userId, 'Race A');
+    const failedB = await createFailedIneligiblePlan(userId, 'Race B');
+    const generateSpy = vi.spyOn(MockGenerationProvider.prototype, 'generate');
+    const lifecycle = createPlanLifecycleService({ dbClient: db });
+
+    const results = await Promise.all([
+      lifecycle.processGenerationAttempt({
+        planId: failedA.id,
+        userId,
+        tier: 'free',
+        allowedGenerationStatuses: ['failed', 'pending_retry'],
+        input: TEST_INPUT,
+      }),
+      lifecycle.processGenerationAttempt({
+        planId: failedB.id,
+        userId,
+        tier: 'free',
+        allowedGenerationStatuses: ['failed', 'pending_retry'],
+        input: TEST_INPUT,
+      }),
+    ]);
+
+    expect(
+      results.filter((result) => result.status === 'generation_success'),
+    ).toHaveLength(1);
+    expect(
+      results.filter((result) => result.status === 'permanent_failure'),
+    ).toHaveLength(1);
+    expect(generateSpy).toHaveBeenCalledTimes(1);
+    expect(await countPlansContributingToCap(db, userId)).toBe(
+      TIER_LIMITS.free.maxActivePlans,
+    );
+  });
+
+  it('successful regeneration replaces content without hiding last-good from quota', async () => {
+    const authUserId = buildTestAuthUserId('cap-regen-success');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+      subscriptionTier: 'free',
+    });
+    const [target] = await fillEligibleReadyPlans(
+      userId,
+      TIER_LIMITS.free.maxActivePlans,
+    );
+    await createTestModule({ planId: target.id, title: 'Old module' });
+
+    const lifecycle = createPlanLifecycleService({ dbClient: db });
+    const result = await lifecycle.processGenerationAttempt({
+      planId: target.id,
+      userId,
+      tier: 'free',
+      input: {
+        topic: target.topic,
+        skillLevel: target.skillLevel,
+        weeklyHours: target.weeklyHours,
+        learningStyle: target.learningStyle,
+      },
+    });
+
+    expect(result.status).toBe('generation_success');
+    expect(await countPlansContributingToCap(db, userId)).toBe(
+      TIER_LIMITS.free.maxActivePlans,
+    );
+
+    const [row] = await db
+      .select()
+      .from(learningPlans)
+      .where(eq(learningPlans.id, target.id));
+    expect(row?.generationStatus).toBe('ready');
+    expect(row?.isQuotaEligible).toBe(true);
+
+    const titles = await db
+      .select({ title: modules.title })
+      .from(modules)
+      .where(eq(modules.planId, target.id));
+    expect(titles.some((module) => module.title === 'Old module')).toBe(false);
+    expect(titles.length).toBeGreaterThan(0);
+  });
+
+  it('failure after reservation follows last-good policy and cannot enable a cap bypass', async () => {
+    const authUserId = buildTestAuthUserId('cap-fail-policy');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+      subscriptionTier: 'free',
+    });
+    const [eligible] = await fillEligibleReadyPlans(userId, 2);
+    await createTestModule({ planId: eligible.id, title: 'Keep last-good' });
+    const failed = await createFailedIneligiblePlan(userId, 'Retry then fail');
+
+    const eligibleReservation = await reserveAttemptSlot({
+      planId: eligible.id,
+      userId,
+      input: TEST_INPUT,
+      dbClient: db,
+    });
+    if (!eligibleReservation.reserved) {
+      throw new Error(
+        `Expected eligible reservation, got ${eligibleReservation.reason}`,
+      );
+    }
+
+    await commitPlanGenerationFailure(db, {
+      variant: 'reserved_attempt',
+      planId: eligible.id,
+      userId,
+      attemptId: eligibleReservation.attemptId,
+      preparation: eligibleReservation,
+      classification: 'timeout',
+      error: new Error('timeout'),
+      durationMs: 10,
+      timedOut: true,
+      extendedTimeout: false,
+      usageKind: 'plan',
+      retryable: true,
+    });
+
+    const [eligibleRow] = await db
+      .select()
+      .from(learningPlans)
+      .where(eq(learningPlans.id, eligible.id));
+    expect(eligibleRow?.generationStatus).toBe('ready');
+    expect(eligibleRow?.isQuotaEligible).toBe(true);
+    const kept = await db
+      .select({ title: modules.title })
+      .from(modules)
+      .where(eq(modules.planId, eligible.id));
+    expect(kept).toEqual([{ title: 'Keep last-good' }]);
+
+    const ineligibleReservation = await reserveAttemptSlot({
+      planId: failed.id,
+      userId,
+      input: TEST_INPUT,
+      dbClient: db,
+    });
+    if (!ineligibleReservation.reserved) {
+      throw new Error(
+        `Expected ineligible reservation, got ${ineligibleReservation.reason}`,
+      );
+    }
+    expect(await countPlansContributingToCap(db, userId)).toBe(3);
+
+    await commitPlanGenerationFailure(db, {
+      variant: 'reserved_attempt',
+      planId: failed.id,
+      userId,
+      attemptId: ineligibleReservation.attemptId,
+      preparation: ineligibleReservation,
+      classification: 'timeout',
+      error: new Error('timeout'),
+      durationMs: 10,
+      timedOut: true,
+      extendedTimeout: false,
+      usageKind: 'plan',
+      retryable: true,
+    });
+
+    const [failedRow] = await db
+      .select()
+      .from(learningPlans)
+      .where(eq(learningPlans.id, failed.id));
+    expect(failedRow?.generationStatus).toBe('failed');
+    expect(failedRow?.isQuotaEligible).toBe(false);
+    expect(await countPlansContributingToCap(db, userId)).toBe(2);
+
+    await markPlanGenerationSuccess(failed.id, db);
+
+    const [stillFailed] = await db
+      .select()
+      .from(learningPlans)
+      .where(eq(learningPlans.id, failed.id));
+    expect(stillFailed?.generationStatus).toBe('failed');
+    expect(stillFailed?.isQuotaEligible).toBe(false);
+    expect(await countPlansContributingToCap(db, userId)).toBe(2);
+  });
+
+  it('keeps over-cap eligible plans and still blocks new inserts', async () => {
+    const authUserId = buildTestAuthUserId('cap-over-cap-keep');
+    const userId = await ensureUser({
+      authUserId,
+      email: buildTestEmail(authUserId),
+      subscriptionTier: 'free',
+    });
+    await fillEligibleReadyPlans(userId, TIER_LIMITS.free.maxActivePlans + 2);
+
+    const rejected = await atomicCheckAndInsertPlan(
+      userId,
+      { ...PLAN_CORE, topic: 'Over cap insert' },
+      db,
+    );
+    expect(rejected.status).toBe('limit_reached');
+    expect(await countPlansContributingToCap(db, userId)).toBe(
+      TIER_LIMITS.free.maxActivePlans + 2,
+    );
+  });
+});

--- a/tests/unit/api/ingest-route.spec.ts
+++ b/tests/unit/api/ingest-route.spec.ts
@@ -1,0 +1,42 @@
+import {
+  DELETE,
+  GET,
+  HEAD,
+  OPTIONS,
+  PATCH,
+  POST,
+  PUT,
+  dynamic,
+} from '@/app/ingest/[...path]/route';
+import { proxyIngestRequest } from '@/lib/posthog/ingest-proxy';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('/ingest route', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('routes every exported method through the constrained proxy', () => {
+    expect(dynamic).toBe('force-dynamic');
+    for (const handler of [GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS]) {
+      expect(handler).toBe(proxyIngestRequest);
+    }
+  });
+
+  it('applies proxy path and method rejection at the public route', async () => {
+    vi.stubGlobal('fetch', vi.fn());
+
+    const unknownPath = await POST(
+      new Request('http://localhost/ingest/not-allowed', {
+        method: 'POST',
+      }),
+    );
+    const unsupportedMethod = await DELETE(
+      new Request('http://localhost/ingest/e/', { method: 'DELETE' }),
+    );
+
+    expect(unknownPath.status).toBe(404);
+    expect(unsupportedMethod.status).toBe(405);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/api/plans.bulk-delete-route.spec.ts
+++ b/tests/unit/api/plans.bulk-delete-route.spec.ts
@@ -85,4 +85,29 @@ describe('POST /api/v1/plans/bulk-delete', () => {
     });
     expect(response.status).toBe(200);
   });
+
+  it('returns a controlled 413 for an oversized declared JSON body', async () => {
+    const response = await POST(
+      new Request('http://localhost/api/v1/plans/bulk-delete', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': String(256 * 1024 + 1),
+        },
+        body: new ReadableStream<Uint8Array>({
+          pull() {
+            throw new Error('body should not be read');
+          },
+        }),
+        duplex: 'half',
+      } as RequestInit),
+    );
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toEqual({
+      error: 'payload too large',
+      code: 'PAYLOAD_TOO_LARGE',
+    });
+    expect(removePlansForWrite).not.toHaveBeenCalled();
+  });
 });

--- a/tests/unit/db/attempts-persistence.spec.ts
+++ b/tests/unit/db/attempts-persistence.spec.ts
@@ -106,6 +106,13 @@ function createMockTx(options?: {
 
   return {
     execute: vi.fn().mockResolvedValue(undefined),
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    }),
     delete: vi.fn(() => ({
       where: deleteWhere,
     })),
@@ -222,5 +229,22 @@ describe('persistSuccessfulAttempt', () => {
     expect(mockTx.insert.mock.invocationCallOrder[0]).toBeLessThan(
       mockTx.update.mock.invocationCallOrder[0],
     );
+  });
+
+  it('throws before replacing modules when a child lesson generation is active', async () => {
+    const mockTx = createMockTx();
+    mockTx.select.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([{ id: 'mod-generating' }]),
+        }),
+      }),
+    });
+    useMockTransaction(mockTx);
+
+    await expect(persistSuccessfulAttempt(createBaseParams())).rejects.toThrow(
+      'active child module lesson generation is in progress',
+    );
+    expect(mockTx.delete).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/db/delete-plan.spec.ts
+++ b/tests/unit/db/delete-plan.spec.ts
@@ -12,11 +12,24 @@ const mockReturning = vi.fn();
 const mockWhere = vi.fn();
 const mockDeleteFn = vi.fn();
 const mockSelectFn = vi.fn();
+const mockExecute = vi.fn();
+const mockLimit = vi.fn();
+const mockTransaction = vi.fn();
 const mockDbClient = {
   delete: mockDeleteFn,
   select: mockSelectFn,
+  execute: mockExecute,
+  transaction: mockTransaction,
 } satisfies DeletePlanDbClient;
 const pgDialect = new PgDialect();
+
+function mockNoActiveChild(): void {
+  mockLimit.mockResolvedValue([]);
+}
+
+function mockActiveChild(): void {
+  mockLimit.mockResolvedValue([{ id: 'mod-generating' }]);
+}
 
 describe('deletePlan', () => {
   const userId = createId('user');
@@ -28,8 +41,25 @@ describe('deletePlan', () => {
     mockReturning.mockReset();
     mockWhere.mockReset();
     mockDeleteFn.mockReset();
+    mockSelectFn.mockReset();
+    mockExecute.mockReset();
+    mockLimit.mockReset();
+    mockTransaction.mockReset();
     capturedDeleteWhere = undefined;
 
+    mockNoActiveChild();
+    mockExecute.mockResolvedValue(undefined);
+    mockTransaction.mockImplementation(
+      async (callback: (tx: typeof mockDbClient) => unknown) =>
+        callback(mockDbClient),
+    );
+    mockSelectFn.mockReturnValue({
+      from: () => ({
+        where: () => ({
+          limit: mockLimit,
+        }),
+      }),
+    });
     mockDeleteFn.mockImplementation((_table: unknown) => ({
       where: mockWhere,
     }));
@@ -71,6 +101,26 @@ describe('deletePlan', () => {
     });
 
     expect(result).toEqual({ success: false, reason: 'currently_generating' });
+    expect(mockDeleteFn).not.toHaveBeenCalled();
+  });
+
+  it('returns active_child_generation when a module lesson is generating', async () => {
+    const plan = createTestPlan({
+      id: planId,
+      userId,
+      generationStatus: 'ready',
+    });
+    mockSelectOwnedPlanById.mockResolvedValue(plan);
+    mockActiveChild();
+
+    const result = await deletePlan(planId, userId, mockDbClient, {
+      selectOwnedPlanById: mockSelectOwnedPlanById,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      reason: 'active_child_generation',
+    });
     expect(mockDeleteFn).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/db/plan-generation-status.spec.ts
+++ b/tests/unit/db/plan-generation-status.spec.ts
@@ -1,5 +1,6 @@
 import {
   PLAN_GENERATING_INSERT_DEFAULTS,
+  planOwnsActiveCapSlot,
   setLearningPlanGenerating,
 } from '@/lib/db/queries/helpers/plan-generation-status';
 import { learningPlans } from '@supabase/schema';
@@ -22,6 +23,47 @@ describe('plan-generation-status helpers', () => {
 
     it('sets isQuotaEligible to false', () => {
       expect(PLAN_GENERATING_INSERT_DEFAULTS.isQuotaEligible).toBe(false);
+    });
+  });
+
+  describe('planOwnsActiveCapSlot', () => {
+    it('treats eligible plans as occupying a slot regardless of status', () => {
+      expect(
+        planOwnsActiveCapSlot({
+          isQuotaEligible: true,
+          generationStatus: 'ready',
+        }),
+      ).toBe(true);
+      expect(
+        planOwnsActiveCapSlot({
+          isQuotaEligible: true,
+          generationStatus: 'generating',
+        }),
+      ).toBe(true);
+    });
+
+    it('treats generating ineligible plans as a pending reservation', () => {
+      expect(
+        planOwnsActiveCapSlot({
+          isQuotaEligible: false,
+          generationStatus: 'generating',
+        }),
+      ).toBe(true);
+    });
+
+    it('requires a new slot for failed or pending_retry ineligible plans', () => {
+      expect(
+        planOwnsActiveCapSlot({
+          isQuotaEligible: false,
+          generationStatus: 'failed',
+        }),
+      ).toBe(false);
+      expect(
+        planOwnsActiveCapSlot({
+          isQuotaEligible: false,
+          generationStatus: 'pending_retry',
+        }),
+      ).toBe(false);
     });
   });
 

--- a/tests/unit/features/billing/clerk-billing/reconciliation.spec.ts
+++ b/tests/unit/features/billing/clerk-billing/reconciliation.spec.ts
@@ -2,7 +2,11 @@ import type { BackendBillingSubscription } from '@/features/billing/clerk-billin
 import type { WebhookEvent } from '@clerk/nextjs/webhooks';
 import type { db as serviceRoleDb } from '@supabase/service-role';
 
-import { applyVerifiedClerkBillingEvent } from '@/features/billing/clerk-billing/reconciliation';
+import {
+  applyVerifiedClerkBillingEvent,
+  ClerkBillingRefreshTimeoutError,
+  reconcileClerkBillingEntitlements,
+} from '@/features/billing/clerk-billing/reconciliation';
 import { createLogger } from '@/lib/logging/logger';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -123,6 +127,7 @@ function makeDb(opts: {
   const selectResults = [...(opts.selectResults ?? [])];
   const updateWhere = vi.fn().mockResolvedValue(undefined);
   const updateSet = vi.fn().mockReturnValue({ where: updateWhere });
+  const execute = vi.fn().mockResolvedValue(undefined);
   const deleteWhere = vi.fn().mockReturnValue({
     returning: vi.fn().mockResolvedValue(deleteReturning),
     then: (resolve: (value: undefined) => unknown) => resolve(undefined),
@@ -130,10 +135,15 @@ function makeDb(opts: {
   const insertCallCount = { value: 0 };
   let transactionOpen = false;
   let db: ServiceRoleDb & {
+    execute: typeof execute;
     isTransactionOpen: () => boolean;
     updateSet: typeof updateSet;
     updateWhere: typeof updateWhere;
   };
+
+  const limitFromSelect = vi
+    .fn()
+    .mockImplementation(async () => selectResults.shift() ?? []);
 
   db = Object.assign(
     {
@@ -157,9 +167,13 @@ function makeDb(opts: {
       select: vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
-            limit: vi
-              .fn()
-              .mockImplementation(async () => selectResults.shift() ?? []),
+            limit: limitFromSelect,
+            orderBy: vi.fn().mockReturnValue({
+              limit: limitFromSelect,
+            }),
+          }),
+          orderBy: vi.fn().mockReturnValue({
+            limit: limitFromSelect,
           }),
         }),
       }),
@@ -167,6 +181,7 @@ function makeDb(opts: {
       update: vi.fn().mockReturnValue({
         set: updateSet,
       }),
+      execute,
       transaction: vi.fn(async <T>(callback: (tx: ServiceRoleDb) => T) => {
         transactionOpen = true;
         try {
@@ -177,6 +192,7 @@ function makeDb(opts: {
       }),
     } as unknown as ServiceRoleDb,
     {
+      execute,
       isTransactionOpen: () => transactionOpen,
       updateSet,
       updateWhere,
@@ -364,7 +380,7 @@ describe('applyVerifiedClerkBillingEvent', () => {
     expect(db.delete).toHaveBeenCalledTimes(1);
   });
 
-  it('does not claim the event when the Clerk refresh fails', async () => {
+  it('does not complete the event when the Clerk refresh fails', async () => {
     const processingError = new Error('clerk unavailable');
     const db = makeDb({});
     const clerkClient = makeClerkClient();
@@ -380,7 +396,33 @@ describe('applyVerifiedClerkBillingEvent', () => {
       }),
     ).rejects.toBe(processingError);
 
-    expect(db.transaction).not.toHaveBeenCalled();
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+    expect(db.execute).toHaveBeenCalled();
+    expect(db.update).not.toHaveBeenCalled();
+    expect(db.delete).toHaveBeenCalledTimes(1);
+  });
+
+  it('times out a hung Clerk refresh without completing the webhook', async () => {
+    const db = makeDb({});
+    const clerkClient = {
+      billing: {
+        getUserBillingSubscription: vi.fn(
+          () => new Promise<BackendBillingSubscription>(() => undefined),
+        ),
+      },
+    };
+
+    await expect(
+      applyVerifiedClerkBillingEvent(makeBillingEvent(), 'evt_hung_refresh', {
+        clerkClient,
+        db,
+        logger: makeLogger(),
+        payerNetworkTimeoutMs: 20,
+      }),
+    ).rejects.toBeInstanceOf(ClerkBillingRefreshTimeoutError);
+
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+    expect(db.update).not.toHaveBeenCalled();
     expect(db.delete).toHaveBeenCalledTimes(1);
   });
 
@@ -402,12 +444,13 @@ describe('applyVerifiedClerkBillingEvent', () => {
     expect(db.update).toHaveBeenCalledTimes(1);
   });
 
-  it('refreshes webhook writes from the current Clerk subscription', async () => {
+  it('refreshes webhook writes from the current Clerk subscription after locking', async () => {
     const db = makeDb({ selectResults: [[], [makeLocalUser()]] });
     const clerkClient = makeClerkClient();
     clerkClient.billing.getUserBillingSubscription.mockImplementation(
       async () => {
-        expect(db.isTransactionOpen()).toBe(false);
+        expect(db.isTransactionOpen()).toBe(true);
+        expect(db.execute).toHaveBeenCalled();
         return makeSubscription();
       },
     );
@@ -503,5 +546,72 @@ describe('applyVerifiedClerkBillingEvent', () => {
         subscriptionTier: 'starter',
       }),
     );
+  });
+});
+
+describe('reconcileClerkBillingEntitlements', () => {
+  it('locks the payer before refreshing and applying Clerk state', async () => {
+    const db = makeDb({
+      selectResults: [[{ authUserId: 'user_missing' }], [makeLocalUser()]],
+    });
+    const clerkClient = makeClerkClient();
+    clerkClient.billing.getUserBillingSubscription.mockImplementation(
+      async () => {
+        expect(db.isTransactionOpen()).toBe(true);
+        expect(db.execute).toHaveBeenCalled();
+        return makeSubscription();
+      },
+    );
+
+    await expect(
+      reconcileClerkBillingEntitlements({
+        clerkClient,
+        db,
+        logger: makeLogger(),
+      }),
+    ).resolves.toEqual({
+      checked: 1,
+      updated: 1,
+      skipped: 0,
+      ignored: 0,
+      failed: 0,
+      nextCursor: null,
+    });
+
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+    expect(db.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subscriptionStatus: 'active',
+        subscriptionTier: 'pro',
+      }),
+    );
+  });
+
+  it('leaves entitlements unchanged when the Clerk refresh fails', async () => {
+    const processingError = new Error('clerk unavailable');
+    const db = makeDb({
+      selectResults: [[{ authUserId: 'user_missing' }]],
+    });
+    const clerkClient = makeClerkClient();
+    clerkClient.billing.getUserBillingSubscription.mockRejectedValueOnce(
+      processingError,
+    );
+
+    await expect(
+      reconcileClerkBillingEntitlements({
+        clerkClient,
+        db,
+        logger: makeLogger(),
+      }),
+    ).resolves.toEqual({
+      checked: 1,
+      updated: 0,
+      skipped: 0,
+      ignored: 0,
+      failed: 1,
+      nextCursor: null,
+    });
+
+    expect(db.update).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/features/lesson-content/run-module-lesson-generation-work.spec.ts
+++ b/tests/unit/features/lesson-content/run-module-lesson-generation-work.spec.ts
@@ -377,6 +377,37 @@ describe('runModuleLessonGenerationWork', () => {
     },
   );
 
+  it('compensates and reverts when pre-provider failure persistence also fails', async () => {
+    mocks.markProviderStarted.mockRejectedValue(new Error('marker'));
+    mocks.commitFailure.mockRejectedValue(new Error('failure persist'));
+
+    const result = await runModuleLessonGenerationWork(
+      {
+        load: {
+          plan: { topic: 't', skillLevel: 'beginner', learningStyle: 'mixed' },
+          module: { title: 'm', description: null, order: 1 },
+          tasks: [{ id: createId('task'), title: 'Task', order: 1 }],
+          isUnlocked: true,
+        } as never,
+        userId: createId('user'),
+        planId: createId('plan'),
+        moduleId: createId('module'),
+        userTier: 'free',
+      },
+      {
+        serverDbClient: fakeDb,
+        resolveGenerationEnabled: async () => true,
+        runLessonQuotaReserved,
+        provider: { generateModuleLessonBatch: vi.fn() },
+      },
+    );
+
+    expect(result).toEqual({ kind: 'failed' });
+    expect(mocks.invokeProvider).not.toHaveBeenCalled();
+    expect(mocks.compensate).toHaveBeenCalledWith(baseToken, fakeDb);
+    expect(mocks.revertClaim).toHaveBeenCalledOnce();
+  });
+
   it('reserves again on a second retry after a consumed provider-started failure', async () => {
     mocks.invokeProvider.mockRejectedValue(new Error('provider'));
     const params = {

--- a/tests/unit/features/lesson-content/run-module-lesson-generation-work.spec.ts
+++ b/tests/unit/features/lesson-content/run-module-lesson-generation-work.spec.ts
@@ -1,7 +1,10 @@
+import type { MeteredReservationToken } from '@/features/billing/metered-reservation';
 import type { ModuleLessonGenerationContext } from '@/lib/db/queries/module-lesson-generation';
 import type { DbClient } from '@/lib/db/types';
 
+import { runLessonGenerationQuotaReserved } from '@/features/billing/lesson-generation-quota-boundary';
 import { runModuleLessonGenerationWork } from '@/features/lesson-content/run-module-lesson-generation-work';
+import { makeDbClient } from '@tests/fixtures/db-mocks';
 import { createId } from '@tests/fixtures/ids';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -9,18 +12,121 @@ const mocks = vi.hoisted(() => ({
   commitFailure: vi.fn(),
   commitSuccess: vi.fn(),
   revertClaim: vi.fn(),
+  markProviderStarted: vi.fn(),
+  invokeProvider: vi.fn(),
+  parseBatch: vi.fn(),
+  resolveModelForTier: vi.fn(),
+  setupAbortAndTimeout: vi.fn(),
+  reserve: vi.fn(),
+  compensate: vi.fn(),
 }));
 
 vi.mock('@/lib/db/queries/module-lesson-generation', () => ({
   commitModuleLessonBatchSuccess: mocks.commitSuccess,
   commitModuleLessonGenerationFailure: mocks.commitFailure,
+  markModuleLessonProviderStarted: mocks.markProviderStarted,
   revertModuleLessonGeneratingToNotGenerated: mocks.revertClaim,
 }));
+
+vi.mock('@/features/ai/orchestrator/provider-invocation', () => ({
+  generateModuleLessonBatchWithInstrumentation: mocks.invokeProvider,
+}));
+
+vi.mock('@/features/lesson-content/parse-module-lesson-batch', () => ({
+  parseModuleLessonBatchFromStream: mocks.parseBatch,
+}));
+
+vi.mock('@/features/ai/model-resolver', () => ({
+  resolveModelForTier: mocks.resolveModelForTier,
+}));
+
+vi.mock(
+  '@/features/ai/orchestrator/timeout-lifecycle',
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import('@/features/ai/orchestrator/timeout-lifecycle')
+      >();
+    return {
+      ...actual,
+      setupAbortAndTimeout: mocks.setupAbortAndTimeout,
+    };
+  },
+);
+
+const fakeDb = makeDbClient();
+const baseToken: MeteredReservationToken = {
+  userId: 'user-quota',
+  month: '2026-08',
+  meter: 'lessonGeneration',
+  limit: 3,
+  newCount: 1,
+};
+
+const runLessonQuotaReserved: typeof runLessonGenerationQuotaReserved = (
+  args,
+) =>
+  runLessonGenerationQuotaReserved(args, {
+    reserve: mocks.reserve,
+    compensate: mocks.compensate,
+    reportReconciliation: vi.fn(),
+  });
+
+function fakeLifecycle() {
+  const controller = new AbortController();
+  return {
+    timeout: { cancel: vi.fn(), signal: controller.signal },
+    controller,
+    cleanupTimeoutAbort: vi.fn(),
+    cleanupExternalAbort: undefined,
+  };
+}
+
+function parsedBatch(taskId: string) {
+  return {
+    version: 1 as const,
+    tasks: [
+      {
+        taskId,
+        content: {
+          version: 1 as const,
+          blocks: [{ type: 'heading' as const, text: 'h' }],
+        },
+      },
+    ],
+  };
+}
+
+function providerOk() {
+  return {
+    stream: {} as ReadableStream<Uint8Array>,
+    metadata: {
+      provider: 'mock',
+      model: 'mock-module-lesson-batch-v1',
+      usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+    },
+  };
+}
 
 describe('runModuleLessonGenerationWork', () => {
   beforeEach(() => {
     mocks.revertClaim.mockReset();
     mocks.revertClaim.mockResolvedValue(undefined);
+    mocks.commitFailure.mockReset();
+    mocks.commitFailure.mockResolvedValue(undefined);
+    mocks.commitSuccess.mockReset();
+    mocks.commitSuccess.mockResolvedValue(undefined);
+    mocks.markProviderStarted.mockReset();
+    mocks.markProviderStarted.mockResolvedValue(undefined);
+    mocks.invokeProvider.mockReset();
+    mocks.parseBatch.mockReset();
+    mocks.resolveModelForTier.mockReset();
+    mocks.setupAbortAndTimeout.mockReset();
+    mocks.setupAbortAndTimeout.mockImplementation(fakeLifecycle);
+    mocks.reserve.mockReset();
+    mocks.reserve.mockResolvedValue({ ok: true, token: baseToken });
+    mocks.compensate.mockReset();
+    mocks.compensate.mockResolvedValue(undefined);
   });
 
   it('releases an already-claimed module when generation is disabled', async () => {
@@ -60,5 +166,246 @@ describe('runModuleLessonGenerationWork', () => {
       moduleId,
       workflowRunId,
     });
+    expect(mocks.reserve).not.toHaveBeenCalled();
+  });
+
+  it('persists the provider-start marker before invoking the fake provider', async () => {
+    const userId = createId('user');
+    const planId = createId('plan');
+    const moduleId = createId('module');
+    const taskId = createId('task');
+    const serverDbClient = fakeDb;
+    const order: string[] = [];
+    const now = () => new Date('2026-08-20T18:00:00.000Z');
+
+    mocks.markProviderStarted.mockImplementation(async () => {
+      order.push('marker');
+    });
+    mocks.invokeProvider.mockImplementation(async () => {
+      order.push('provider');
+      throw new Error('provider');
+    });
+
+    await runModuleLessonGenerationWork(
+      {
+        load: {
+          plan: { topic: 't', skillLevel: 'beginner', learningStyle: 'mixed' },
+          module: { title: 'm', description: null, order: 1 },
+          tasks: [{ id: taskId, title: 'Task', order: 1 }],
+          isUnlocked: true,
+        } as never,
+        userId,
+        planId,
+        moduleId,
+        userTier: 'free',
+        now,
+      },
+      {
+        serverDbClient,
+        resolveGenerationEnabled: async () => true,
+        runLessonQuotaReserved,
+        provider: { generateModuleLessonBatch: vi.fn() },
+      },
+    );
+
+    expect(order).toEqual(['marker', 'provider']);
+    expect(mocks.markProviderStarted).toHaveBeenCalledWith(serverDbClient, {
+      userId,
+      planId,
+      moduleId,
+      providerStartedAt: '2026-08-20T18:00:00.000Z',
+    });
+  });
+
+  it.each([
+    {
+      name: 'provider',
+      arrange: () => {
+        mocks.invokeProvider.mockRejectedValue(new Error('provider'));
+      },
+    },
+    {
+      name: 'parser',
+      arrange: () => {
+        mocks.invokeProvider.mockResolvedValue(providerOk());
+        mocks.parseBatch.mockRejectedValue(new Error('parse'));
+      },
+    },
+    {
+      name: 'success persistence',
+      arrange: (taskId: string) => {
+        mocks.invokeProvider.mockResolvedValue(providerOk());
+        mocks.parseBatch.mockResolvedValue(parsedBatch(taskId));
+        mocks.commitSuccess.mockRejectedValue(new Error('persist'));
+      },
+    },
+  ])(
+    '$name failure after marker returns failed, keeps reservation consumed, and never compensates',
+    async ({ arrange }) => {
+      const userId = createId('user');
+      const planId = createId('plan');
+      const moduleId = createId('module');
+      const taskId = createId('task');
+      arrange(taskId);
+
+      const result = await runModuleLessonGenerationWork(
+        {
+          load: {
+            plan: {
+              topic: 't',
+              skillLevel: 'beginner',
+              learningStyle: 'mixed',
+            },
+            module: { title: 'm', description: null, order: 1 },
+            tasks: [{ id: taskId, title: 'Task', order: 1 }],
+            isUnlocked: true,
+          } as never,
+          userId,
+          planId,
+          moduleId,
+          userTier: 'free',
+        },
+        {
+          serverDbClient: fakeDb,
+          resolveGenerationEnabled: async () => true,
+          runLessonQuotaReserved,
+          provider: { generateModuleLessonBatch: vi.fn() },
+        },
+      );
+
+      expect(result).toEqual({ kind: 'failed' });
+      expect(mocks.markProviderStarted).toHaveBeenCalledOnce();
+      expect(mocks.invokeProvider).toHaveBeenCalledOnce();
+      expect(mocks.reserve).toHaveBeenCalledOnce();
+      expect(mocks.compensate).not.toHaveBeenCalled();
+      expect(mocks.revertClaim).not.toHaveBeenCalled();
+    },
+  );
+
+  it('treats failure-state persistence failure after marker as consumed', async () => {
+    mocks.invokeProvider.mockRejectedValue(new Error('provider'));
+    mocks.commitFailure.mockRejectedValue(new Error('failure persist'));
+
+    const result = await runModuleLessonGenerationWork(
+      {
+        load: {
+          plan: { topic: 't', skillLevel: 'beginner', learningStyle: 'mixed' },
+          module: { title: 'm', description: null, order: 1 },
+          tasks: [{ id: createId('task'), title: 'Task', order: 1 }],
+          isUnlocked: true,
+        } as never,
+        userId: createId('user'),
+        planId: createId('plan'),
+        moduleId: createId('module'),
+        userTier: 'free',
+      },
+      {
+        serverDbClient: fakeDb,
+        resolveGenerationEnabled: async () => true,
+        runLessonQuotaReserved,
+        provider: { generateModuleLessonBatch: vi.fn() },
+      },
+    );
+
+    expect(result).toEqual({ kind: 'failed' });
+    expect(mocks.compensate).not.toHaveBeenCalled();
+    expect(mocks.revertClaim).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: 'marker persistence',
+      omitProvider: false,
+      arrange: () => {
+        mocks.markProviderStarted.mockRejectedValue(new Error('marker'));
+      },
+    },
+    {
+      name: 'provider resolution',
+      omitProvider: true,
+      arrange: () => {
+        mocks.resolveModelForTier.mockImplementation(() => {
+          throw new Error('provider init');
+        });
+      },
+    },
+    {
+      name: 'lifecycle setup',
+      omitProvider: false,
+      arrange: () => {
+        mocks.setupAbortAndTimeout.mockImplementation(() => {
+          throw new Error('lifecycle');
+        });
+      },
+    },
+  ])(
+    '$name failure before provider invocation compensates',
+    async ({ omitProvider, arrange }) => {
+      arrange();
+
+      const result = await runModuleLessonGenerationWork(
+        {
+          load: {
+            plan: {
+              topic: 't',
+              skillLevel: 'beginner',
+              learningStyle: 'mixed',
+            },
+            module: { title: 'm', description: null, order: 1 },
+            tasks: [{ id: createId('task'), title: 'Task', order: 1 }],
+            isUnlocked: true,
+          } as never,
+          userId: createId('user'),
+          planId: createId('plan'),
+          moduleId: createId('module'),
+          userTier: 'free',
+        },
+        {
+          serverDbClient: fakeDb,
+          resolveGenerationEnabled: async () => true,
+          runLessonQuotaReserved,
+          ...(omitProvider
+            ? {}
+            : { provider: { generateModuleLessonBatch: vi.fn() } }),
+        },
+      );
+
+      expect(result).toEqual({ kind: 'failed' });
+      expect(mocks.invokeProvider).not.toHaveBeenCalled();
+      expect(mocks.compensate).toHaveBeenCalledOnce();
+      expect(mocks.compensate).toHaveBeenCalledWith(baseToken, fakeDb);
+    },
+  );
+
+  it('reserves again on a second retry after a consumed provider-started failure', async () => {
+    mocks.invokeProvider.mockRejectedValue(new Error('provider'));
+    const params = {
+      load: {
+        plan: { topic: 't', skillLevel: 'beginner', learningStyle: 'mixed' },
+        module: { title: 'm', description: null, order: 1 },
+        tasks: [{ id: createId('task'), title: 'Task', order: 1 }],
+        isUnlocked: true,
+      } as never,
+      userId: createId('user'),
+      planId: createId('plan'),
+      moduleId: createId('module'),
+      userTier: 'free' as const,
+    };
+    const deps = {
+      serverDbClient: fakeDb,
+      resolveGenerationEnabled: async () => true,
+      runLessonQuotaReserved,
+      provider: { generateModuleLessonBatch: vi.fn() },
+    };
+
+    await expect(runModuleLessonGenerationWork(params, deps)).resolves.toEqual({
+      kind: 'failed',
+    });
+    await expect(runModuleLessonGenerationWork(params, deps)).resolves.toEqual({
+      kind: 'failed',
+    });
+
+    expect(mocks.reserve).toHaveBeenCalledTimes(2);
+    expect(mocks.compensate).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/features/plans/lifecycle/process-generation.spec.ts
+++ b/tests/unit/features/plans/lifecycle/process-generation.spec.ts
@@ -487,6 +487,30 @@ describe('PlanLifecycleService.processGenerationAttempt', () => {
     ).not.toHaveBeenCalled();
   });
 
+  it('does not finalize failure when generation fails with active_child_generation reservation rejection', async () => {
+    ports = createMockPorts({
+      generation: {
+        runGeneration: vi.fn().mockResolvedValue({
+          status: 'failure',
+          classification: 'rate_limit',
+          error: new Error('child generating'),
+          durationMs: 1,
+          reservationRejectionReason: 'active_child_generation',
+          timedOut: false,
+          extendedTimeout: false,
+        }),
+      },
+    });
+    service = new PlanLifecycleService(ports);
+
+    const result = await service.processGenerationAttempt(validGenerationInput);
+
+    expect(result.status).toBe('retryable_failure');
+    expect(
+      vi.mocked(ports.generationFinalization.finalizeFailure),
+    ).not.toHaveBeenCalled();
+  });
+
   it('does not finalize failure when generation fails with invalid_status reservation rejection', async () => {
     ports = createMockPorts({
       generation: {

--- a/tests/unit/features/plans/write-service.spec.ts
+++ b/tests/unit/features/plans/write-service.spec.ts
@@ -49,6 +49,17 @@ describe('removePlanForWrite', () => {
       'Cannot delete a plan that is currently generating.',
     );
   });
+
+  it('throws ConflictError when deletePlan returns active_child_generation', async () => {
+    mockDeletePlan.mockResolvedValue({
+      success: false,
+      reason: 'active_child_generation',
+    });
+
+    await expect(removePlanForWrite({ planId, userId })).rejects.toThrow(
+      'Cannot delete a plan while a module lesson is generating.',
+    );
+  });
 });
 
 describe('removePlansForWrite', () => {
@@ -174,6 +185,27 @@ describe('removePlansForWrite', () => {
         success: false,
         reason: 'currently_generating',
         message: 'Cannot delete a plan that is currently generating.',
+      },
+    ]);
+  });
+
+  it('maps active_child_generation failures to readable messages', async () => {
+    mockDeletePlan.mockResolvedValue({
+      success: false,
+      reason: 'active_child_generation',
+    });
+
+    const results = await removePlansForWrite({
+      planIds: [firstPlanId],
+      userId,
+    });
+
+    expect(results).toEqual([
+      {
+        planId: firstPlanId,
+        success: false,
+        reason: 'active_child_generation',
+        message: 'Cannot delete a plan while a module lesson is generating.',
       },
     ]);
   });

--- a/tests/unit/lib/api/parse-json-body.spec.ts
+++ b/tests/unit/lib/api/parse-json-body.spec.ts
@@ -342,6 +342,51 @@ describe('parseJsonBody', () => {
     expect(factory).not.toHaveBeenCalled();
   });
 
+  it.each([
+    {
+      name: 'invalid',
+      contentLength: 'not-a-number',
+    },
+    {
+      name: 'negative',
+      contentLength: '-1',
+    },
+    {
+      name: 'overflow',
+      contentLength: '1e309',
+    },
+    {
+      name: 'unsafe integer',
+      contentLength: '9007199254740993',
+    },
+  ])(
+    'maxBytes: $name Content-Length still produces a bounded 413 result',
+    async ({ contentLength }) => {
+      const encoder = new TextEncoder();
+      const req = jsonBodyRequest(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(encoder.encode('{"pad":"'));
+            controller.enqueue(encoder.encode(`${'x'.repeat(32)}"}`));
+          },
+        }),
+        { 'content-length': contentLength },
+      );
+      const jsonSpy = vi.spyOn(req, 'json');
+      const factory = vi.fn(() => new Error('should not run'));
+
+      const error = await parseJsonBody(req, {
+        mode: 'required',
+        onMalformedJson: factory,
+        maxBytes: 16,
+      }).catch((err: unknown) => err);
+
+      expectPayloadTooLarge(error);
+      expect(jsonSpy).not.toHaveBeenCalled();
+      expect(factory).not.toHaveBeenCalled();
+    },
+  );
+
   it('maxBytes: rejects a chunked body that understates Content-Length', async () => {
     const encoder = new TextEncoder();
     const cancel = vi.fn();
@@ -366,6 +411,34 @@ describe('parseJsonBody', () => {
 
     expectPayloadTooLarge(error);
     expect(factory).not.toHaveBeenCalled();
+  });
+
+  it('maxBytes: rejects an undeclared multi-chunk stream over the cap and still 413s if cancel rejects', async () => {
+    const encoder = new TextEncoder();
+    const cancel = vi.fn(() => Promise.reject(new Error('cancel failed')));
+    const req = jsonBodyRequest(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode('{"pad":"'));
+          controller.enqueue(encoder.encode(`${'x'.repeat(32)}"}`));
+        },
+        cancel,
+      }),
+    );
+    req.headers.delete('content-length');
+    const jsonSpy = vi.spyOn(req, 'json');
+    const factory = vi.fn(() => new Error('should not run'));
+
+    const error = await parseJsonBody(req, {
+      mode: 'required',
+      onMalformedJson: factory,
+      maxBytes: 16,
+    }).catch((err: unknown) => err);
+
+    expectPayloadTooLarge(error);
+    expect(jsonSpy).not.toHaveBeenCalled();
+    expect(factory).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledTimes(1);
   });
 
   it('maxBytes: counts UTF-8 bytes rather than JavaScript characters', async () => {

--- a/tests/unit/lib/db/queries/module-lesson-generation.bulk-write.spec.ts
+++ b/tests/unit/lib/db/queries/module-lesson-generation.bulk-write.spec.ts
@@ -1,7 +1,12 @@
 import type { DbClient } from '@/lib/db/types';
 
-import { commitModuleLessonBatchSuccess } from '@/lib/db/queries/module-lesson-generation';
+import {
+  commitModuleLessonBatchSuccess,
+  markModuleLessonProviderStarted,
+} from '@/lib/db/queries/module-lesson-generation';
 import { SERVICE_ROLE_DB_MARKER } from '@supabase/service-role';
+import { type SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
 import { describe, expect, it, vi } from 'vitest';
 
 describe('commitModuleLessonBatchSuccess bulk task writes', () => {
@@ -65,5 +70,66 @@ describe('commitModuleLessonBatchSuccess bulk task writes', () => {
     });
 
     expect(tx.execute).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('markModuleLessonProviderStarted', () => {
+  const pgDialect = new PgDialect();
+  const providerStartedAt = '2026-08-20T18:00:00.000Z';
+
+  function mockUpdate(returningRows: Array<{ id: string }>) {
+    let capturedSet: { lessonGenerationMetadata?: SQL } | undefined;
+    let capturedWhere: SQL | undefined;
+    const returning = vi.fn().mockResolvedValue(returningRows);
+    const where = vi.fn((clause: SQL) => {
+      capturedWhere = clause;
+      return { returning };
+    });
+    const set = vi.fn((values: { lessonGenerationMetadata?: SQL }) => {
+      capturedSet = values;
+      return { where };
+    });
+    const update = vi.fn().mockReturnValue({ set });
+    const dbClient = { update } as unknown as DbClient;
+    return { dbClient, captured: () => ({ capturedSet, capturedWhere }) };
+  }
+
+  it('merges providerStartedAt into generating owned-module metadata', async () => {
+    const { dbClient, captured } = mockUpdate([{ id: 'module-1' }]);
+
+    await markModuleLessonProviderStarted(dbClient, {
+      userId: 'user-1',
+      planId: 'plan-1',
+      moduleId: 'module-1',
+      providerStartedAt,
+    });
+
+    const { capturedSet, capturedWhere } = captured();
+    const setQuery = pgDialect.sqlToQuery(
+      capturedSet?.lessonGenerationMetadata as SQL,
+    );
+    const whereQuery = pgDialect.sqlToQuery(capturedWhere as SQL);
+
+    expect(setQuery.sql).toContain('jsonb_set');
+    expect(setQuery.sql).toContain('providerStartedAt');
+    expect(setQuery.params).toContain(providerStartedAt);
+    expect(whereQuery.params).toEqual(
+      expect.arrayContaining(['module-1', 'plan-1', 'generating', 'user-1']),
+    );
+  });
+
+  it('throws unless exactly one generating row matches', async () => {
+    const { dbClient } = mockUpdate([]);
+
+    await expect(
+      markModuleLessonProviderStarted(dbClient, {
+        userId: 'user-1',
+        planId: 'plan-1',
+        moduleId: 'module-1',
+        providerStartedAt,
+      }),
+    ).rejects.toThrow(
+      'Module lesson generation provider-start marker did not match exactly one row',
+    );
   });
 });

--- a/tests/unit/lib/posthog/ingest-proxy.spec.ts
+++ b/tests/unit/lib/posthog/ingest-proxy.spec.ts
@@ -1,0 +1,438 @@
+import {
+  POSTHOG_INGEST_MAX_BODY_BYTES,
+  proxyIngestRequest,
+} from '@/lib/posthog/ingest-proxy';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const US_INGEST = 'https://us.i.posthog.com';
+const US_ASSETS = 'https://us-assets.i.posthog.com';
+
+function jsonBodyRequest(
+  url: string,
+  body: BodyInit,
+  headers: Record<string, string> = {},
+): Request {
+  const init: RequestInit & { duplex?: string } = {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      ...headers,
+    },
+    body,
+  };
+  if (body instanceof ReadableStream) {
+    init.duplex = 'half';
+  }
+  return new Request(url, init);
+}
+
+function fetchCall(): { url: string; init: RequestInit } {
+  expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0] ?? [];
+  return { url: String(url), init: init ?? {} };
+}
+
+function outboundHeaders(): Headers {
+  return new Headers(fetchCall().init.headers);
+}
+
+describe('proxyIngestRequest', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response('{"ok":true}', {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('strips Cookie, Authorization, Clerk, and forwarding headers from the upstream request', async () => {
+    const response = await proxyIngestRequest(
+      jsonBodyRequest('http://localhost/ingest/e/', '{"event":"x"}', {
+        Cookie: '__Host-atlaris_proxy_sentinel=secret',
+        Authorization: 'Bearer atlaris-proxy-sentinel',
+        'Proxy-Authorization': 'Basic abc',
+        'Clerk-Db-Jwt': 'clerk-jwt',
+        'x-clerk-auth-status': 'signed-in',
+        Forwarded: 'for=1.1.1.1',
+        'X-Forwarded-For': '8.8.8.8',
+        'X-Forwarded-Host': 'app.example',
+        'X-Real-IP': '9.9.9.9',
+        'X-Vercel-Id': 'id',
+        'CF-Connecting-IP': '7.7.7.7',
+        Host: 'app.example',
+        Connection: 'keep-alive',
+        'Transfer-Encoding': 'chunked',
+        'X-Atlaris-Sentinel': 'header-sentinel',
+        'User-Agent': 'Mozilla/5.0',
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const headers = outboundHeaders();
+    expect(headers.get('content-type')).toBe('application/json');
+    expect(headers.has('cookie')).toBe(false);
+    expect(headers.has('authorization')).toBe(false);
+    expect(headers.has('proxy-authorization')).toBe(false);
+    expect(headers.has('clerk-db-jwt')).toBe(false);
+    expect(headers.has('x-clerk-auth-status')).toBe(false);
+    expect(headers.has('forwarded')).toBe(false);
+    expect(headers.has('x-forwarded-for')).toBe(false);
+    expect(headers.has('x-forwarded-host')).toBe(false);
+    expect(headers.has('x-real-ip')).toBe(false);
+    expect(headers.has('x-vercel-id')).toBe(false);
+    expect(headers.has('cf-connecting-ip')).toBe(false);
+    expect(headers.has('host')).toBe(false);
+    expect(headers.has('connection')).toBe(false);
+    expect(headers.has('transfer-encoding')).toBe(false);
+    expect(headers.has('content-length')).toBe(false);
+    expect(headers.has('x-atlaris-sentinel')).toBe(false);
+    expect(headers.has('user-agent')).toBe(false);
+    expect(fetchCall().url).toBe(`${US_INGEST}/e/`);
+    expect(fetchCall().init.redirect).toBe('manual');
+    expect(fetchCall().init.credentials).toBe('omit');
+  });
+
+  it('strips Set-Cookie, WWW-Authenticate, Server, Location, and tracing from the downstream response', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response('captured', {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'Set-Cookie': 'upstream_proxy_sentinel=1; Path=/; Secure; HttpOnly',
+          'WWW-Authenticate': 'Bearer realm="posthog"',
+          Server: 'nginx',
+          Location: 'https://evil.example/steal',
+          Connection: 'keep-alive',
+          'Transfer-Encoding': 'chunked',
+          'x-request-id': 'upstream-trace',
+          'sentry-trace': 'abc',
+          'cf-ray': 'ray',
+        },
+      }),
+    );
+
+    const response = await proxyIngestRequest(
+      jsonBodyRequest('http://localhost/ingest/e/', '{"event":"x"}'),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('captured');
+    expect(response.headers.get('content-type')).toBe('application/json');
+    expect(response.headers.get('set-cookie')).toBeNull();
+    expect(response.headers.get('www-authenticate')).toBeNull();
+    expect(response.headers.get('server')).toBeNull();
+    expect(response.headers.get('location')).toBeNull();
+    expect(response.headers.get('connection')).toBeNull();
+    expect(response.headers.get('x-request-id')).toBeNull();
+    expect(response.headers.get('sentry-trace')).toBeNull();
+    expect(response.headers.get('cf-ray')).toBeNull();
+  });
+
+  it('forwards a capture POST to the configured ingest origin', async () => {
+    const response = await proxyIngestRequest(
+      jsonBodyRequest(
+        'http://localhost/ingest/e/?compression=gzip-js',
+        '{"batch":[]}',
+        { 'content-encoding': 'gzip' },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchCall().url).toBe(`${US_INGEST}/e/?compression=gzip-js`);
+    expect(fetchCall().init.method).toBe('POST');
+    expect(outboundHeaders().get('content-encoding')).toBe('gzip');
+  });
+
+  it('forwards a session-replay POST to the exact /s/ ingest path', async () => {
+    const response = await proxyIngestRequest(
+      jsonBodyRequest(
+        'http://localhost/ingest/s/?compression=gzip-js',
+        '{"batch":[]}',
+        { 'content-encoding': 'gzip' },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchCall().url).toBe(`${US_INGEST}/s/?compression=gzip-js`);
+    expect(fetchCall().init.method).toBe('POST');
+    expect(outboundHeaders().get('content-encoding')).toBe('gzip');
+  });
+
+  it('rejects /ingest/s without the trailing slash before fetch', async () => {
+    const response = await proxyIngestRequest(
+      jsonBodyRequest('http://localhost/ingest/s', '{"batch":[]}'),
+    );
+    expect(response.status).toBe(404);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('forwards a flags POST with the installed query surface', async () => {
+    const response = await proxyIngestRequest(
+      jsonBodyRequest(
+        'http://localhost/ingest/flags/?v=2&only_evaluate_survey_feature_flags=true&compression=base64',
+        'data=abc',
+        { 'content-type': 'application/x-www-form-urlencoded' },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchCall().url).toBe(
+      `${US_INGEST}/flags/?v=2&only_evaluate_survey_feature_flags=true&compression=base64`,
+    );
+  });
+
+  it('forwards array config and static asset GETs to the assets origin', async () => {
+    const config = await proxyIngestRequest(
+      new Request('http://localhost/ingest/array/phc_testtoken/config'),
+    );
+    expect(config.status).toBe(200);
+    expect(fetchCall().url).toBe(`${US_ASSETS}/array/phc_testtoken/config`);
+    expect(fetchCall().init.method).toBe('GET');
+    expect(fetchCall().init.body).toBeUndefined();
+
+    vi.mocked(globalThis.fetch).mockClear();
+    const configJs = await proxyIngestRequest(
+      new Request('http://localhost/ingest/array/phc_testtoken/config.js'),
+    );
+    expect(configJs.status).toBe(200);
+    expect(fetchCall().url).toBe(`${US_ASSETS}/array/phc_testtoken/config.js`);
+
+    vi.mocked(globalThis.fetch).mockClear();
+    const script = await proxyIngestRequest(
+      new Request(
+        'http://localhost/ingest/static/recorder.js?v=1.415.1&t=1234567890',
+        { method: 'HEAD' },
+      ),
+    );
+    expect(script.status).toBe(200);
+    expect(fetchCall().url).toBe(
+      `${US_ASSETS}/static/recorder.js?v=1.415.1&t=1234567890`,
+    );
+    expect(fetchCall().init.method).toBe('HEAD');
+
+    vi.mocked(globalThis.fetch).mockClear();
+    const versioned = await proxyIngestRequest(
+      new Request(
+        'http://localhost/ingest/static/1.415.1/exception-autocapture.js',
+      ),
+    );
+    expect(versioned.status).toBe(200);
+    expect(fetchCall().url).toBe(
+      `${US_ASSETS}/static/1.415.1/exception-autocapture.js`,
+    );
+  });
+
+  it('preserves a self-hosted base path and ignores request-selected hosts', async () => {
+    vi.stubEnv(
+      'NEXT_PUBLIC_POSTHOG_HOST',
+      'https://posthog.example.com/analytics/',
+    );
+
+    const response = await proxyIngestRequest(
+      jsonBodyRequest('http://localhost/ingest/e/?compression=base64', '{}'),
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchCall().url).toBe(
+      'https://posthog.example.com/analytics/e/?compression=base64',
+    );
+  });
+
+  it.each([
+    'http://localhost/ingest',
+    'http://localhost/ingest/',
+    'http://localhost/ingest/unknown',
+    'http://localhost/ingest/e/extra',
+    'http://localhost/ingest/s/extra',
+    'http://localhost/ingest/s/replay',
+    'http://localhost/ingest/static/not-a-kind.js',
+    'http://localhost/ingest/static/../recorder.js',
+    'http://localhost/ingest/e%2Fextra',
+    'http://localhost/ingest/%2e%2e/e/',
+    'http://localhost/ingest/e%2f',
+    'http://localhost/ingest//e/',
+    'http://localhost/ingest/e/?host=https://evil.example',
+    'http://localhost/ingest/flags/?v=1',
+    'http://localhost/ingest/array/phc_test/config?callback=1',
+  ])('rejects %s before fetch', async (url) => {
+    const response = await proxyIngestRequest(
+      jsonBodyRequest(url, '{"event":"x"}'),
+    );
+    expect(response.status).toBe(404);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects backslash and dot-segment paths before fetch', async () => {
+    const slash = await proxyIngestRequest(
+      new Request('http://localhost/ingest/e\\foo'),
+    );
+    expect(slash.status).toBe(404);
+
+    const dots = await proxyIngestRequest(
+      new Request('http://localhost/ingest/foo/../../e/'),
+    );
+    expect(dots.status).toBe(404);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('returns 405 with Allow and does not fetch for unsupported methods', async () => {
+    const getCapture = await proxyIngestRequest(
+      new Request('http://localhost/ingest/e/'),
+    );
+    expect(getCapture.status).toBe(405);
+    expect(getCapture.headers.get('Allow')).toBe('POST');
+
+    const postAsset = await proxyIngestRequest(
+      jsonBodyRequest('http://localhost/ingest/static/recorder.js', '{}'),
+    );
+    expect(postAsset.status).toBe(405);
+    expect(postAsset.headers.get('Allow')).toBe('GET, HEAD');
+
+    const options = await proxyIngestRequest(
+      new Request('http://localhost/ingest/e/', { method: 'OPTIONS' }),
+    );
+    expect(options.status).toBe(405);
+    expect(options.headers.get('Allow')).toBe('POST');
+
+    const put = await proxyIngestRequest(
+      new Request('http://localhost/ingest/e/', { method: 'PUT' }),
+    );
+    expect(put.status).toBe(405);
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects a declared oversized capture body before reading it', async () => {
+    const pull = vi.fn(() => {
+      throw new Error('body should not be read');
+    });
+    const response = await proxyIngestRequest(
+      jsonBodyRequest(
+        'http://localhost/ingest/e/',
+        new ReadableStream<Uint8Array>({ pull, cancel: vi.fn() }),
+        { 'content-length': String(POSTHOG_INGEST_MAX_BODY_BYTES + 1) },
+      ),
+    );
+
+    expect(response.status).toBe(413);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(pull).not.toHaveBeenCalled();
+  });
+
+  it('rejects a streamed body that crosses the cap and cancels the reader', async () => {
+    const cancel = vi.fn();
+    const chunk = new Uint8Array(POSTHOG_INGEST_MAX_BODY_BYTES);
+    const overflow = new Uint8Array(1);
+    const response = await proxyIngestRequest(
+      jsonBodyRequest(
+        'http://localhost/ingest/e/',
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(chunk);
+            controller.enqueue(overflow);
+          },
+          cancel,
+        }),
+      ),
+    );
+
+    expect(response.status).toBe(413);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalled();
+  });
+
+  it('forwards a capture body that is exactly at the 1 MiB cap', async () => {
+    const body = 'x'.repeat(POSTHOG_INGEST_MAX_BODY_BYTES);
+    const response = await proxyIngestRequest(
+      jsonBodyRequest('http://localhost/ingest/e/', body, {
+        'content-type': 'text/plain',
+        'content-length': String(POSTHOG_INGEST_MAX_BODY_BYTES),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const sent = fetchCall().init.body;
+    expect(sent).toBeInstanceOf(Uint8Array);
+    expect((sent as Uint8Array).byteLength).toBe(POSTHOG_INGEST_MAX_BODY_BYTES);
+  });
+
+  it('rejects a body on an asset path before fetch', async () => {
+    const response = await proxyIngestRequest(
+      new Request('http://localhost/ingest/array/phc_test/config', {
+        method: 'GET',
+        headers: { 'content-length': '12' },
+      }),
+    );
+    expect(response.status).toBe(400);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects an upstream redirect without returning Location or Set-Cookie', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response(null, {
+        status: 302,
+        headers: {
+          Location: 'https://evil.example/phish',
+          'Set-Cookie': 'stolen=1',
+        },
+      }),
+    );
+
+    const response = await proxyIngestRequest(
+      jsonBodyRequest('http://localhost/ingest/e/', '{}'),
+    );
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(502);
+    expect(response.headers.get('location')).toBeNull();
+    expect(response.headers.get('set-cookie')).toBeNull();
+  });
+
+  it('returns 504 when the upstream timeout signal aborts', async () => {
+    vi.spyOn(AbortSignal, 'timeout').mockReturnValue(
+      AbortSignal.abort(new DOMException('Timed out', 'TimeoutError')),
+    );
+    vi.mocked(globalThis.fetch).mockImplementation((_url, init) => {
+      const signal = init?.signal;
+      if (signal?.aborted) {
+        return Promise.reject(signal.reason);
+      }
+      return Promise.reject(new Error('should have been aborted'));
+    });
+
+    const response = await proxyIngestRequest(
+      jsonBodyRequest('http://localhost/ingest/e/', '{}'),
+    );
+
+    expect(response.status).toBe(504);
+    expect(AbortSignal.timeout).toHaveBeenCalled();
+  });
+
+  it('rejects http non-loopback origins before fetch', async () => {
+    vi.stubEnv('NEXT_PUBLIC_POSTHOG_HOST', 'http://posthog.example.com');
+    const response = await proxyIngestRequest(
+      jsonBodyRequest('http://localhost/ingest/e/', '{}'),
+    );
+    expect(response.status).toBe(502);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('allows http loopback origins in test', async () => {
+    vi.stubEnv('NEXT_PUBLIC_POSTHOG_HOST', 'http://localhost:8000');
+    const response = await proxyIngestRequest(
+      jsonBodyRequest('http://localhost/ingest/e/', '{}'),
+    );
+    expect(response.status).toBe(200);
+    expect(fetchCall().url).toBe('http://localhost:8000/e/');
+  });
+});

--- a/tests/unit/lib/posthog/ingest-proxy.spec.ts
+++ b/tests/unit/lib/posthog/ingest-proxy.spec.ts
@@ -329,6 +329,34 @@ describe('proxyIngestRequest', () => {
     expect(pull).not.toHaveBeenCalled();
   });
 
+  it.each(['', '-1', 'Infinity', 'NaN'])(
+    'rejects malformed Content-Length %j before fetch',
+    async (contentLength) => {
+      const response = await proxyIngestRequest(
+        jsonBodyRequest('http://localhost/ingest/e/', '{}', {
+          'content-length': contentLength,
+        }),
+      );
+
+      expect(response.status).toBe(400);
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    { header: 'content-type', value: 'application/octet-stream' },
+    { header: 'content-encoding', value: 'br' },
+  ])('rejects unsupported $header before fetch', async ({ header, value }) => {
+    const response = await proxyIngestRequest(
+      jsonBodyRequest('http://localhost/ingest/e/', '{}', {
+        [header]: value,
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
   it('rejects a streamed body that crosses the cap and cancels the reader', async () => {
     const cancel = vi.fn();
     const chunk = new Uint8Array(POSTHOG_INGEST_MAX_BODY_BYTES);
@@ -416,6 +444,31 @@ describe('proxyIngestRequest', () => {
 
     expect(response.status).toBe(504);
     expect(AbortSignal.timeout).toHaveBeenCalled();
+  });
+
+  it('returns 502 for a generic upstream failure', async () => {
+    vi.mocked(globalThis.fetch).mockRejectedValue(new Error('network failed'));
+
+    const response = await proxyIngestRequest(
+      jsonBodyRequest('http://localhost/ingest/e/', '{}'),
+    );
+
+    expect(response.status).toBe(502);
+  });
+
+  it('returns 499 when the client aborts the upstream request', async () => {
+    const controller = new AbortController();
+    const request = jsonBodyRequest('http://localhost/ingest/e/', '{}');
+    const abortedRequest = new Request(request, { signal: controller.signal });
+    vi.mocked(globalThis.fetch).mockImplementation(async () => {
+      controller.abort();
+      throw controller.signal.reason;
+    });
+
+    const response = await proxyIngestRequest(abortedRequest);
+
+    expect(response.status).toBe(499);
+    expect(response.headers.get('connection')).toBe('close');
   });
 
   it('rejects http non-loopback origins before fetch', async () => {

--- a/tests/unit/shared/lesson-content.schemas.spec.ts
+++ b/tests/unit/shared/lesson-content.schemas.spec.ts
@@ -161,6 +161,18 @@ describe('lesson content Zod contracts', () => {
     expect(() =>
       ModuleLessonGenerationMetadataSchema.parse({ version: 1, x: 1 }),
     ).toThrow(z.ZodError);
+    expect(() =>
+      ModuleLessonGenerationMetadataSchema.parse({
+        version: 1,
+        providerStartedAt: '2026-08-20T18:00:00.000Z',
+      }),
+    ).not.toThrow();
+    expect(() =>
+      ModuleLessonGenerationMetadataSchema.parse({
+        version: 1,
+        providerStartedAt: 'not-iso',
+      }),
+    ).toThrow(z.ZodError);
   });
 
   it('accepts workflow metadata in ModuleLessonGenerationMetadataSchema', () => {


### PR DESCRIPTION
## Summary

- Replace the external PostHog `/ingest` rewrite with an application-owned constrained proxy that enforces fixed origins, exact paths and methods, body caps, header filtering, redirect rejection, response filtering, and timeouts.
- Serialize Clerk entitlement projection, active-plan admission, and parent/child plan lifecycle mutations with database-backed locks.
- Preserve provider-attempt accounting after provider start, reconcile abandoned provider-started module work through existing plan cleanup, and keep pre-provider compensation behavior.
- Verify the already-remediated JSON parser callers and add malformed `Content-Length` regression coverage.
- Add the current verification report: [docs/security/codex-scan-verification-2026-08-20.md](docs/security/codex-scan-verification-2026-08-20.md).

## Validation

- `pnpm test` — unit changed: 45 files / 410 tests; integration changed: 52 files / 298 tests; workflow: 1 file / 4 tests.
- `pnpm check:full` — lint and typecheck passed.
- Pre-commit Oxlint/Oxfmt and ggshield secret scan passed.
- `git diff --check` passed.

## Acceptance boundary

The report deliberately does not claim the entire historical scan is remediated. Hosted sentinel-cookie and Authorization capture, live Vercel rate-threshold proof, preview smoke tests, and Firewall overview inspection remain deferred because no deployment or hosted mutation was authorized. No production traffic, credentials, or provider billing requests were used.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches credential-forwarding on a public proxy, Clerk entitlement writes, and plan/lesson quota accounting. Concurrent lock and last-good failure policy changes can affect billing and generation correctness.
> 
> **Overview**
> Remediates the Codex scan by replacing Next.js `/ingest` rewrites with an application-owned PostHog proxy that allowlists paths/methods, strips session headers, caps bodies, rejects redirects, and times out upstream. Dashboard WAF/rate-limit docs are updated to match live `/ingest` rules.
> 
> **Concurrency and quota:** Clerk billing refresh now runs under a per-payer advisory lock with a bounded Clerk timeout so stale snapshots cannot overwrite newer entitlements. Plan insert and attempt reservation share a per-user admission lock; last-good plans stay `ready` and quota-eligible on failure, and retries cannot reactivate above `maxActivePlans`. Parent/child work is serialized with a plan lifecycle lock so lesson generation, regeneration, persist, and delete cannot race.
> 
> **Lesson usage:** A durable `providerStartedAt` marker consumes the lesson reservation after provider start; cleanup settles abandoned modules without refunding usage.
> 
> Adds a verification report plus unit/integration coverage for the proxy, locks, last-good cap, and JSON body caps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a039c419cd0de9eda13d146714f962677476a9ff. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->