### PR TITLE
fix: respect user preference write grants

### DIFF
--- a/src/lib/db/queries/user-preferences.ts
+++ b/src/lib/db/queries/user-preferences.ts
@@ -192,53 +192,49 @@ export async function saveEmailNotificationPreferences(
 export async function upsertUserPreferredAiModel(
   userId: string,
   preferredAiModel: PreferredAiModel | null,
-  dbClient: Pick<DbClient, 'insert'>,
+  dbClient: Pick<DbClient, 'execute'>,
 ): Promise<UserPreferenceValues | undefined> {
-  const [row] = await dbClient
-    .insert(userPreferences)
-    .values({
-      userId,
-      preferredAiModel,
-      updatedAt: sql<Date>`now()`,
-    })
-    .onConflictDoUpdate({
-      target: userPreferences.userId,
-      set: {
-        preferredAiModel: sql`excluded.preferred_ai_model`,
-        updatedAt: sql`excluded.updated_at`,
-      },
-    })
-    .returning({
-      preferredAiModel: userPreferences.preferredAiModel,
-      analyticsTimezone: userPreferences.analyticsTimezone,
-    });
+  const [row] = (await dbClient.execute(sql`
+    INSERT INTO ${userPreferences} ("user_id", "preferred_ai_model", "updated_at")
+    VALUES (${userId}, ${preferredAiModel}, now())
+    ON CONFLICT ("user_id") DO UPDATE SET
+      "preferred_ai_model" = EXCLUDED."preferred_ai_model",
+      "updated_at" = EXCLUDED."updated_at"
+    RETURNING "preferred_ai_model", "analytics_timezone"
+  `)) as Array<{
+    preferred_ai_model: PreferredAiModel | null;
+    analytics_timezone: string;
+  }>;
 
-  return row;
+  return row
+    ? {
+        preferredAiModel: row.preferred_ai_model,
+        analyticsTimezone: row.analytics_timezone,
+      }
+    : undefined;
 }
 
 export async function upsertUserAnalyticsTimezone(
   userId: string,
   analyticsTimezone: string,
-  dbClient: Pick<DbClient, 'insert'>,
+  dbClient: Pick<DbClient, 'execute'>,
 ): Promise<UserPreferenceValues | undefined> {
-  const [row] = await dbClient
-    .insert(userPreferences)
-    .values({
-      userId,
-      analyticsTimezone,
-      updatedAt: sql<Date>`now()`,
-    })
-    .onConflictDoUpdate({
-      target: userPreferences.userId,
-      set: {
-        analyticsTimezone: sql`excluded.analytics_timezone`,
-        updatedAt: sql`excluded.updated_at`,
-      },
-    })
-    .returning({
-      preferredAiModel: userPreferences.preferredAiModel,
-      analyticsTimezone: userPreferences.analyticsTimezone,
-    });
+  const [row] = (await dbClient.execute(sql`
+    INSERT INTO ${userPreferences} ("user_id", "analytics_timezone", "updated_at")
+    VALUES (${userId}, ${analyticsTimezone}, now())
+    ON CONFLICT ("user_id") DO UPDATE SET
+      "analytics_timezone" = EXCLUDED."analytics_timezone",
+      "updated_at" = EXCLUDED."updated_at"
+    RETURNING "preferred_ai_model", "analytics_timezone"
+  `)) as Array<{
+    preferred_ai_model: PreferredAiModel | null;
+    analytics_timezone: string;
+  }>;
 
-  return row;
+  return row
+    ? {
+        preferredAiModel: row.preferred_ai_model,
+        analyticsTimezone: row.analytics_timezone,
+      }
+    : undefined;
 }

--- a/tests/results/integration/08-21-2026-results.md
+++ b/tests/results/integration/08-21-2026-results.md
@@ -1,0 +1,5 @@
+# Integration test results — 08-21-2026
+
+- Command: `NODE_ENV=test pnpm vitest run --config vitest.config.ts --project integration tests/integration/api/user-preferences.spec.ts tests/integration/api/user-profile.spec.ts`
+- Result: passed — 2 test files, 27 tests.
+- Scope: user-preferences and profile API persistence paths used by the authenticated upserts.

--- a/tests/results/security/08-21-2026-results.md
+++ b/tests/results/security/08-21-2026-results.md
@@ -1,0 +1,5 @@
+# Security test results — 08-21-2026
+
+- Command: `NODE_ENV=test pnpm vitest run --config vitest.config.ts --project security tests/security/effective-privileges-attestation.spec.ts tests/security/user-preferences.rls.spec.ts`
+- Result: passed — 2 test files, 12 tests.
+- Scope: effective authenticated privilege contract and `user_preferences` RLS behavior.

--- a/tests/results/unit/08-21-2026-results.md
+++ b/tests/results/unit/08-21-2026-results.md
@@ -1,0 +1,5 @@
+# Unit test results — 08-21-2026
+
+- Command: `SKIP_DB_TEST_SETUP=true NODE_ENV=test pnpm vitest run --config vitest.config.ts --project unit tests/unit/db/user-preferences.queries.spec.ts`
+- Result: passed — 1 test file, 6 tests.
+- Scope: explicit user-preferences upsert column allowlists and omission of the disallowed `created_at` insert.

--- a/tests/unit/db/user-preferences.queries.spec.ts
+++ b/tests/unit/db/user-preferences.queries.spec.ts
@@ -155,18 +155,15 @@ describe('user preference queries', () => {
   });
 
   it('upserts preferred AI model on the user preference row', async () => {
-    const returning = vi.fn().mockResolvedValue([
+    const execute = vi.fn().mockResolvedValue([
       {
-        preferredAiModel: 'google/gemini-2.0-flash-exp:free',
-        analyticsTimezone: 'UTC',
+        preferred_ai_model: 'google/gemini-2.0-flash-exp:free',
+        analytics_timezone: 'UTC',
       },
     ]);
-    const onConflictDoUpdate = vi.fn().mockReturnValue({ returning });
-    const values = vi.fn().mockReturnValue({ onConflictDoUpdate });
-    const insert = vi.fn().mockReturnValue({ values });
 
     const dbClient = makeDbClient({
-      insert: insert as unknown as DbClient['insert'],
+      execute: execute as unknown as DbClient['execute'],
     });
 
     const result = await upsertUserPreferredAiModel(
@@ -176,28 +173,24 @@ describe('user preference queries', () => {
     );
 
     expect(result?.preferredAiModel).toBe('google/gemini-2.0-flash-exp:free');
-    expect(values).toHaveBeenCalledWith(
-      expect.objectContaining({
-        userId: 'user-1',
-        preferredAiModel: 'google/gemini-2.0-flash-exp:free',
-      }),
-    );
-    expect(onConflictDoUpdate).toHaveBeenCalledOnce();
+    expect(execute).toHaveBeenCalledOnce();
+
+    const query = new PgDialect().sqlToQuery(execute.mock.calls[0]?.[0] as SQL);
+    expect(query.sql).toContain('"preferred_ai_model"');
+    expect(query.sql).toContain('ON CONFLICT');
+    expect(query.sql).not.toContain('"created_at"');
   });
 
   it('upserts analytics timezone on the user preference row', async () => {
-    const returning = vi.fn().mockResolvedValue([
+    const execute = vi.fn().mockResolvedValue([
       {
-        preferredAiModel: null,
-        analyticsTimezone: 'America/Chicago',
+        preferred_ai_model: null,
+        analytics_timezone: 'America/Chicago',
       },
     ]);
-    const onConflictDoUpdate = vi.fn().mockReturnValue({ returning });
-    const values = vi.fn().mockReturnValue({ onConflictDoUpdate });
-    const insert = vi.fn().mockReturnValue({ values });
 
     const dbClient = makeDbClient({
-      insert: insert as unknown as DbClient['insert'],
+      execute: execute as unknown as DbClient['execute'],
     });
 
     const result = await upsertUserAnalyticsTimezone(
@@ -207,12 +200,11 @@ describe('user preference queries', () => {
     );
 
     expect(result?.analyticsTimezone).toBe('America/Chicago');
-    expect(values).toHaveBeenCalledWith(
-      expect.objectContaining({
-        userId: 'user-1',
-        analyticsTimezone: 'America/Chicago',
-      }),
-    );
-    expect(onConflictDoUpdate).toHaveBeenCalledOnce();
+    expect(execute).toHaveBeenCalledOnce();
+
+    const query = new PgDialect().sqlToQuery(execute.mock.calls[0]?.[0] as SQL);
+    expect(query.sql).toContain('"analytics_timezone"');
+    expect(query.sql).toContain('ON CONFLICT');
+    expect(query.sql).not.toContain('"created_at"');
   });
 });


### PR DESCRIPTION
## Summary

- Fixes the analytics timezone/user-preference upserts so they explicitly insert only the columns allowed by the authenticated database contract.
- Omits `created_at DEFAULT`, which previously caused Preview PostgreSQL `42501` failures.
- Preserves the existing `ON CONFLICT` behavior, return mapping, transaction context, and least-privilege ACLs.

## Verification

- Focused unit spec: 6/6 passed
- Profile/preferences integration: 27/27 passed
- RLS and privilege-attestation security specs: 12/12 passed
- Targeted oxlint, full TypeScript check, and `git diff --check`: passed
- Fresh Preview deployment `dpl_CWYQoPpX447RHyy4yaUzDZFVYxEX`: READY from this commit
- Authenticated analytics timezone action: HTTP 200 and persisted successfully
- Original UTC timezone restored and verified through API, Preview DB, and UI
- One no-cookie same-origin Server Action replay reached Atlaris/Clerk middleware, returned 404, and left state unchanged
- Independent GPT-5.6 Sol review: PASS, no findings

## Scope note

No database grants or migrations were changed. The separate Preview drift involving missing migration `20260811100700` and anonymous `learning_plans` INSERT privilege remains documented and outside this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches user-preference persistence used by profile/preferences APIs. Risk is moderate: SQL is parameterized and behavior is unchanged, but raw upserts sit on a least-privilege write path.
> 
> **Overview**
> Fixes authenticated upserts for preferred AI model and analytics timezone so they only write columns the DB role is allowed to touch.
> 
> `upsertUserPreferredAiModel` and `upsertUserAnalyticsTimezone` now use parameterized `INSERT ... ON CONFLICT` via `execute` instead of Drizzle `insert()`, omitting `created_at` (which triggered Preview PostgreSQL `42501`). Conflict handling and returned preference mapping stay the same. Unit tests assert the SQL omits `created_at`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c4a592a7d9c944a3e9a4ed5e3d3f1082d9b5371. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->